### PR TITLE
Reduce amount of cloning within codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed heuristics for expanding function arguments. StyLua will now check through the arguments and look out for expanded tables
 or anonymous functions, and if found, will not expand the function call. However, if there are any other type of expression mixed between,
 then the function call will remain expanded.
+- Change internals of the formatter by reducing amount of cloning of AST nodes. Improves performance by 22%
 
 ## [0.1.0] - 2020-12-30
 ### Added

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -5,27 +5,22 @@ use std::borrow::Cow;
 use crate::formatters::CodeFormatter;
 
 impl CodeFormatter {
-    pub fn format_assignment<'ast>(&mut self, assignment: Assignment<'ast>) -> Assignment<'ast> {
-        let var_list =
-            self.format_punctuated(assignment.var_list().to_owned(), &CodeFormatter::format_var);
-        let expr_list = self.format_punctuated(
-            assignment.expr_list().to_owned(),
-            &CodeFormatter::format_expression,
-        );
+    pub fn format_assignment<'ast>(&mut self, assignment: &Assignment<'ast>) -> Assignment<'ast> {
+        let var_list = self.format_punctuated(assignment.var_list(), &CodeFormatter::format_var);
+        let expr_list =
+            self.format_punctuated(assignment.expr_list(), &CodeFormatter::format_expression);
 
-        assignment
-            .with_var_list(var_list)
+        Assignment::new(var_list, expr_list)
             .with_equal_token(Cow::Owned(TokenReference::symbol(" = ").unwrap()))
-            .with_expr_list(expr_list)
     }
 
     pub fn format_local_assignment<'ast>(
         &mut self,
-        assignment: LocalAssignment<'ast>,
+        assignment: &LocalAssignment<'ast>,
     ) -> LocalAssignment<'ast> {
-        let local_token = crate::fmt_symbol!(self, assignment.local_token().to_owned(), "local ");
+        let local_token = crate::fmt_symbol!(self, assignment.local_token(), "local ");
         let name_list = self.format_punctuated(
-            assignment.name_list().to_owned(),
+            assignment.name_list(),
             &CodeFormatter::format_token_reference_mut,
         );
 
@@ -33,33 +28,32 @@ impl CodeFormatter {
         let type_specifiers = assignment
             .type_specifiers()
             .map(|x| match x {
-                Some(type_specifier) => Some(self.format_type_specifier(type_specifier.to_owned())),
+                Some(type_specifier) => Some(self.format_type_specifier(type_specifier)),
                 None => None,
             })
             .collect();
 
-        #[cfg(feature = "luau")]
-        let assignment = assignment.with_type_specifiers(type_specifiers);
-
         if assignment.expr_list().is_empty() {
-            assignment
+            let local_assignment = LocalAssignment::new(name_list)
                 .with_local_token(local_token)
-                .with_name_list(name_list)
                 .with_equal_token(None)
-                .with_expr_list(Punctuated::new())
+                .with_expr_list(Punctuated::new());
+            #[cfg(feature = "luau")]
+            let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
+            local_assignment
         } else {
-            let equal_token =
-                crate::fmt_symbol!(self, assignment.equal_token().unwrap().to_owned(), " = ");
-            let expr_list = self.format_punctuated(
-                assignment.expr_list().to_owned(),
-                &CodeFormatter::format_expression,
-            );
+            let equal_token = crate::fmt_symbol!(self, assignment.equal_token().unwrap(), " = ");
+            let expr_list =
+                self.format_punctuated(assignment.expr_list(), &CodeFormatter::format_expression);
 
-            assignment
+            let local_assignment = LocalAssignment::new(name_list)
                 .with_local_token(local_token)
-                .with_name_list(name_list)
                 .with_equal_token(Some(equal_token))
-                .with_expr_list(expr_list)
+                .with_expr_list(expr_list);
+            #[cfg(feature = "luau")]
+            let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
+
+            local_assignment
         }
     }
 }

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -114,16 +114,14 @@ impl CodeFormatter {
     }
 
     pub fn format_return<'ast>(&mut self, return_node: &Return<'ast>) -> Return<'ast> {
-        let formatted_returns = self.format_punctuated(
-            return_node.returns().to_owned(),
-            &CodeFormatter::format_expression,
-        );
+        let formatted_returns =
+            self.format_punctuated(return_node.returns(), &CodeFormatter::format_expression);
         let wanted_token: TokenReference<'ast> = if formatted_returns.is_empty() {
             TokenReference::symbol("return").unwrap()
         } else {
             TokenReference::symbol("return ").unwrap()
         };
-        let formatted_token = self.format_symbol(return_node.token().to_owned(), wanted_token);
+        let formatted_token = self.format_symbol(return_node.token(), &wanted_token);
 
         Return::new()
             .with_token(formatted_token)
@@ -132,14 +130,12 @@ impl CodeFormatter {
 
     pub fn format_last_stmt<'ast>(&mut self, last_stmt: LastStmt<'ast>) -> LastStmt<'ast> {
         match last_stmt {
-            LastStmt::Break(token) => LastStmt::Break(
-                self.format_symbol(token.into_owned(), TokenReference::symbol("break").unwrap()),
-            ),
+            LastStmt::Break(token) => LastStmt::Break(crate::fmt_symbol!(self, &token, "break")),
             LastStmt::Return(return_node) => LastStmt::Return(self.format_return(&return_node)),
             #[cfg(feature = "luau")]
             LastStmt::Continue(token) => LastStmt::Continue(self.format_symbol(
-                token.into_owned(),
-                TokenReference::new(
+                &token,
+                &TokenReference::new(
                     vec![],
                     Token::new(TokenType::Identifier {
                         identifier: Cow::Owned(String::from("continue")),
@@ -239,7 +235,7 @@ impl CodeFormatter {
                 .map(|stmt| {
                     let range_in_stmt = CodeFormatter::get_range_in_stmt(stmt);
                     let additional_indent_level = self.get_range_indent_increase(range_in_stmt);
-                    let stmt = self.format_stmt(stmt.to_owned());
+                    let stmt = self.format_stmt(stmt);
                     (
                         self.stmt_add_trivia(stmt, additional_indent_level),
                         None, // The second parameter in the tuple is for semicolons - we do not want any semi-colons

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -67,7 +67,7 @@ impl CodeFormatter {
 
     /// Returns an arbitrary token inside of the stmt, to see if it falls inside of an indent range.
     /// The token returned does not matter, as we will be using the position of it, and if this token falls within the range, then the whole statement must do
-    fn get_range_in_stmt(stmt: Stmt) -> Range {
+    fn get_range_in_stmt(stmt: &Stmt) -> Range {
         match stmt {
             Stmt::Assignment(assignment) => {
                 CodeFormatter::get_token_range(assignment.equal_token().token())
@@ -113,7 +113,7 @@ impl CodeFormatter {
         }
     }
 
-    pub fn format_return<'ast>(&mut self, return_node: Return<'ast>) -> Return<'ast> {
+    pub fn format_return<'ast>(&mut self, return_node: &Return<'ast>) -> Return<'ast> {
         let formatted_returns = self.format_punctuated(
             return_node.returns().to_owned(),
             &CodeFormatter::format_expression,
@@ -124,7 +124,8 @@ impl CodeFormatter {
             TokenReference::symbol("return ").unwrap()
         };
         let formatted_token = self.format_symbol(return_node.token().to_owned(), wanted_token);
-        return_node
+
+        Return::new()
             .with_token(formatted_token)
             .with_returns(formatted_returns)
     }
@@ -134,7 +135,7 @@ impl CodeFormatter {
             LastStmt::Break(token) => LastStmt::Break(
                 self.format_symbol(token.into_owned(), TokenReference::symbol("break").unwrap()),
             ),
-            LastStmt::Return(return_node) => LastStmt::Return(self.format_return(return_node)),
+            LastStmt::Return(return_node) => LastStmt::Return(self.format_return(&return_node)),
             #[cfg(feature = "luau")]
             LastStmt::Continue(token) => LastStmt::Continue(self.format_symbol(
                 token.into_owned(),
@@ -236,7 +237,7 @@ impl CodeFormatter {
             block
                 .iter_stmts()
                 .map(|stmt| {
-                    let range_in_stmt = CodeFormatter::get_range_in_stmt(stmt.to_owned());
+                    let range_in_stmt = CodeFormatter::get_range_in_stmt(stmt);
                     let additional_indent_level = self.get_range_indent_increase(range_in_stmt);
                     let stmt = self.format_stmt(stmt.to_owned());
                     (

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -68,7 +68,7 @@ impl CodeFormatter {
                 contained,
                 expression,
             } => Expression::Parentheses {
-                contained: self.format_contained_span(contained),
+                contained: self.format_contained_span(&contained),
                 expression: Box::new(self.format_expression(*expression)),
             },
             Expression::UnaryOperator { unop, expression } => Expression::UnaryOperator {
@@ -85,7 +85,7 @@ impl CodeFormatter {
                 brackets,
                 expression,
             } => Index::Brackets {
-                brackets: self.format_contained_span(brackets),
+                brackets: self.format_contained_span(&brackets),
                 expression: self.format_expression(expression),
             },
 

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -6,18 +6,19 @@ use std::boxed::Box;
 
 use crate::formatters::CodeFormatter;
 
+#[macro_export]
 macro_rules! fmt_op {
     ($fmter:expr, $enum:ident, $value:ident, { $($operator:ident = $output:expr,)+ }) => {
         match $value {
             $(
-                $enum::$operator(token) => $enum::$operator(crate::fmt_symbol!($fmter, token.into_owned(), $output)),
+                $enum::$operator(token) => $enum::$operator(crate::fmt_symbol!($fmter, token, $output)),
             )+
         }
     };
 }
 
 impl CodeFormatter {
-    pub fn format_binop<'ast>(&self, binop: BinOp<'ast>) -> BinOp<'ast> {
+    pub fn format_binop<'ast>(&self, binop: &BinOp<'ast>) -> BinOp<'ast> {
         fmt_op!(self, BinOp, binop, {
             And = " and ",
             Caret = " ^ ",
@@ -37,15 +38,15 @@ impl CodeFormatter {
         })
     }
 
-    pub fn format_bin_op_rhs<'ast>(&mut self, bin_op_rhs: BinOpRhs<'ast>) -> BinOpRhs<'ast> {
+    pub fn format_bin_op_rhs<'ast>(&mut self, bin_op_rhs: &BinOpRhs<'ast>) -> BinOpRhs<'ast> {
         BinOpRhs::new(
-            self.format_binop(bin_op_rhs.bin_op().to_owned()),
-            Box::new(self.format_expression(bin_op_rhs.rhs().to_owned())),
+            self.format_binop(bin_op_rhs.bin_op()),
+            Box::new(self.format_expression(bin_op_rhs.rhs())),
         )
     }
 
     /// Formats an Expression node
-    pub fn format_expression<'ast>(&mut self, expression: Expression<'ast>) -> Expression<'ast> {
+    pub fn format_expression<'ast>(&mut self, expression: &Expression<'ast>) -> Expression<'ast> {
         match expression {
             Expression::Value {
                 value,
@@ -53,7 +54,7 @@ impl CodeFormatter {
                 #[cfg(feature = "luau")]
                 as_assertion,
             } => Expression::Value {
-                value: Box::new(self.format_value(*value)),
+                value: Box::new(self.format_value(value)),
                 binop: match binop {
                     Some(value) => Some(self.format_bin_op_rhs(value)),
                     None => None,
@@ -69,17 +70,17 @@ impl CodeFormatter {
                 expression,
             } => Expression::Parentheses {
                 contained: self.format_contained_span(&contained),
-                expression: Box::new(self.format_expression(*expression)),
+                expression: Box::new(self.format_expression(expression)),
             },
             Expression::UnaryOperator { unop, expression } => Expression::UnaryOperator {
                 unop: self.format_unop(unop),
-                expression: Box::new(self.format_expression(*expression)),
+                expression: Box::new(self.format_expression(expression)),
             },
         }
     }
 
     /// Formats an Index Node
-    pub fn format_index<'ast>(&mut self, index: Index<'ast>) -> Index<'ast> {
+    pub fn format_index<'ast>(&mut self, index: &Index<'ast>) -> Index<'ast> {
         match index {
             Index::Brackets {
                 brackets,
@@ -97,7 +98,7 @@ impl CodeFormatter {
     }
 
     /// Formats a Prefix Node
-    pub fn format_prefix<'ast>(&mut self, prefix: Prefix<'ast>) -> Prefix<'ast> {
+    pub fn format_prefix<'ast>(&mut self, prefix: &Prefix<'ast>) -> Prefix<'ast> {
         match prefix {
             Prefix::Expression(expression) => {
                 Prefix::Expression(self.format_expression(expression))
@@ -109,7 +110,7 @@ impl CodeFormatter {
     }
 
     /// Formats a Suffix Node
-    pub fn format_suffix<'ast>(&mut self, suffix: Suffix<'ast>) -> Suffix<'ast> {
+    pub fn format_suffix<'ast>(&mut self, suffix: &Suffix<'ast>) -> Suffix<'ast> {
         match suffix {
             Suffix::Call(call) => Suffix::Call(self.format_call(call)),
             Suffix::Index(index) => Suffix::Index(self.format_index(index)),
@@ -117,7 +118,7 @@ impl CodeFormatter {
     }
 
     /// Formats a Value Node
-    pub fn format_value<'ast>(&mut self, value: Value<'ast>) -> Value<'ast> {
+    pub fn format_value<'ast>(&mut self, value: &Value<'ast>) -> Value<'ast> {
         match value {
             Value::Function((token_reference, function_body)) => {
                 Value::Function(self.format_anonymous_function(token_reference, function_body))
@@ -145,7 +146,7 @@ impl CodeFormatter {
     }
 
     /// Formats a Var Node
-    pub fn format_var<'ast>(&mut self, var: Var<'ast>) -> Var<'ast> {
+    pub fn format_var<'ast>(&mut self, var: &Var<'ast>) -> Var<'ast> {
         match var {
             Var::Name(token_reference) => Var::Name(self.format_token_reference(token_reference)),
             Var::Expression(var_expression) => {
@@ -156,20 +157,19 @@ impl CodeFormatter {
 
     pub fn format_var_expression<'ast>(
         &mut self,
-        var_expression: VarExpression<'ast>,
+        var_expression: &VarExpression<'ast>,
     ) -> VarExpression<'ast> {
-        let formatted_prefix = self.format_prefix(var_expression.prefix().to_owned());
+        let formatted_prefix = self.format_prefix(var_expression.prefix());
         let formatted_suffixes = var_expression
             .iter_suffixes()
-            .map(|x| self.format_suffix(x.to_owned()))
+            .map(|x| self.format_suffix(x))
             .collect();
-        var_expression
-            .with_prefix(formatted_prefix)
-            .with_suffixes(formatted_suffixes)
+
+        VarExpression::new(formatted_prefix).with_suffixes(formatted_suffixes)
     }
 
     /// Formats an UnOp Node
-    pub fn format_unop<'ast>(&self, unop: UnOp<'ast>) -> UnOp<'ast> {
+    pub fn format_unop<'ast>(&self, unop: &UnOp<'ast>) -> UnOp<'ast> {
         fmt_op!(self, UnOp, unop, {
             Minus = "-",
             Not = "not ",

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -234,7 +234,7 @@ impl CodeFormatter {
                         self.format_punctuated(arguments, &CodeFormatter::format_expression);
 
                     FunctionArgs::Parentheses {
-                        parentheses: self.format_contained_span(parentheses),
+                        parentheses: self.format_contained_span(&parentheses),
                         arguments: formatted_arguments,
                     }
                 }
@@ -290,7 +290,7 @@ impl CodeFormatter {
         function_body: FunctionBody<'ast>,
     ) -> FunctionBody<'ast> {
         let parameters_parentheses =
-            self.format_contained_span(function_body.parameters_parentheses().to_owned());
+            self.format_contained_span(function_body.parameters_parentheses());
         let formatted_parameters = self.format_parameters(function_body.to_owned());
 
         #[cfg(feature = "luau")]
@@ -377,7 +377,7 @@ impl CodeFormatter {
             if let Some(token_reference) = function_name.method_name() {
                 formatted_method = Some((
                     crate::fmt_symbol!(self, method_colon.to_owned(), ":"),
-                    Cow::Owned(self.format_plain_token_reference(token_reference.to_owned())),
+                    Cow::Owned(self.format_plain_token_reference(token_reference)),
                 ));
             }
         };
@@ -420,8 +420,7 @@ impl CodeFormatter {
             local_function.function_token().to_owned(),
             "function "
         );
-        let formatted_name =
-            Cow::Owned(self.format_plain_token_reference(local_function.name().to_owned()));
+        let formatted_name = Cow::Owned(self.format_plain_token_reference(local_function.name()));
         let formatted_function_body =
             self.format_function_body(local_function.func_body().to_owned());
 
@@ -434,9 +433,8 @@ impl CodeFormatter {
 
     /// Formats a MethodCall node
     pub fn format_method_call<'ast>(&mut self, method_call: MethodCall<'ast>) -> MethodCall<'ast> {
-        let formatted_colon_token =
-            self.format_plain_token_reference(method_call.colon_token().to_owned());
-        let formatted_name = self.format_plain_token_reference(method_call.name().to_owned());
+        let formatted_colon_token = self.format_plain_token_reference(method_call.colon_token());
+        let formatted_name = self.format_plain_token_reference(method_call.name());
         let formatted_function_args = self.format_function_args(method_call.args().to_owned());
         method_call
             .with_colon_token(Cow::Owned(formatted_colon_token))

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -314,7 +314,7 @@ impl CodeFormatter {
 
     fn format_plain_token_reference<'a>(
         &self,
-        token_reference: TokenReference<'a>,
+        token_reference: &TokenReference<'a>,
     ) -> TokenReference<'a> {
         // Preserve comments in leading/trailing trivia
         let formatted_leading_trivia: Vec<Token<'a>> = self.load_token_trivia(
@@ -349,14 +349,14 @@ impl CodeFormatter {
         &self,
         token_reference: Cow<'a, TokenReference<'a>>,
     ) -> Cow<'a, TokenReference<'a>> {
-        Cow::Owned(self.format_plain_token_reference(token_reference.into_owned()))
+        Cow::Owned(self.format_plain_token_reference(&token_reference))
     }
 
     pub fn format_token_reference_mut<'ast>(
         &mut self,
         token_reference: Cow<'ast, TokenReference<'ast>>,
     ) -> Cow<'ast, TokenReference<'ast>> {
-        Cow::Owned(self.format_plain_token_reference(token_reference.into_owned()))
+        Cow::Owned(self.format_plain_token_reference(&token_reference))
     }
 
     pub fn format_punctuation<'ast>(
@@ -396,13 +396,13 @@ impl CodeFormatter {
 
     pub fn format_contained_span<'ast>(
         &self,
-        contained_span: ContainedSpan<'ast>,
+        contained_span: &ContainedSpan<'ast>,
     ) -> ContainedSpan<'ast> {
         let (start_token, end_token) = contained_span.tokens();
 
         ContainedSpan::new(
-            Cow::Owned(self.format_plain_token_reference(start_token.to_owned())),
-            Cow::Owned(self.format_plain_token_reference(end_token.to_owned())),
+            Cow::Owned(self.format_plain_token_reference(start_token)),
+            Cow::Owned(self.format_plain_token_reference(end_token)),
         )
     }
 

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -53,7 +53,7 @@ fn get_line_ending_character(line_endings: &LineEndings) -> String {
 #[macro_export]
 macro_rules! fmt_symbol {
     ($fmter:expr, $token:expr, $x:expr) => {
-        $fmter.format_symbol($token, TokenReference::symbol($x).unwrap())
+        $fmter.format_symbol($token, &TokenReference::symbol($x).unwrap())
     };
 }
 
@@ -347,21 +347,21 @@ impl CodeFormatter {
 
     pub fn format_token_reference<'a>(
         &self,
-        token_reference: Cow<'a, TokenReference<'a>>,
+        token_reference: &Cow<'a, TokenReference<'a>>,
     ) -> Cow<'a, TokenReference<'a>> {
         Cow::Owned(self.format_plain_token_reference(&token_reference))
     }
 
     pub fn format_token_reference_mut<'ast>(
         &mut self,
-        token_reference: Cow<'ast, TokenReference<'ast>>,
+        token_reference: &Cow<'ast, TokenReference<'ast>>,
     ) -> Cow<'ast, TokenReference<'ast>> {
         Cow::Owned(self.format_plain_token_reference(&token_reference))
     }
 
     pub fn format_punctuation<'ast>(
         &self,
-        punctuation: Cow<'ast, TokenReference<'ast>>,
+        punctuation: &Cow<'ast, TokenReference<'ast>>,
     ) -> Cow<'ast, TokenReference<'ast>> {
         Cow::Owned(TokenReference::new(
             Vec::new(),
@@ -372,11 +372,11 @@ impl CodeFormatter {
 
     pub fn format_punctuated<'a, T>(
         &mut self,
-        old: Punctuated<'a, T>,
-        value_formatter: &dyn Fn(&mut Self, T) -> T,
+        old: &Punctuated<'a, T>,
+        value_formatter: &dyn Fn(&mut Self, &T) -> T,
     ) -> Punctuated<'a, T> {
         let mut formatted: Punctuated<T> = Punctuated::new();
-        for pair in old.into_pairs() {
+        for pair in old.pairs() {
             // Format Punctuation
             match pair {
                 Pair::Punctuated(value, punctuation) => {
@@ -410,8 +410,8 @@ impl CodeFormatter {
     /// Used to preserve the comments around the symbol
     pub fn format_symbol<'ast>(
         &self,
-        current_symbol: TokenReference<'ast>,
-        wanted_symbol: TokenReference<'ast>,
+        current_symbol: &TokenReference<'ast>,
+        wanted_symbol: &TokenReference<'ast>,
     ) -> Cow<'ast, TokenReference<'ast>> {
         // Preserve comments in leading/trailing trivia
         let mut formatted_leading_trivia: Vec<Token<'ast>> = self.load_token_trivia(
@@ -451,7 +451,7 @@ impl CodeFormatter {
     /// This is required due to comments bound to an `end` token - they need to have one level higher indentation
     pub fn format_end_token<'ast>(
         &self,
-        current_token: TokenReference<'ast>,
+        current_token: &TokenReference<'ast>,
     ) -> Cow<'ast, TokenReference<'ast>> {
         // Indent any comments leading a token, as these comments are technically part of the function body block
         let formatted_leading_trivia: Vec<Token<'ast>> = self.load_token_trivia(

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -113,7 +113,7 @@ impl CodeFormatter {
     pub fn format_numeric_for<'ast>(&mut self, numeric_for: NumericFor<'ast>) -> NumericFor<'ast> {
         let for_token = crate::fmt_symbol!(self, numeric_for.for_token().to_owned(), "for ");
         let formatted_index_variable =
-            Cow::Owned(self.format_plain_token_reference(numeric_for.index_variable().to_owned()));
+            Cow::Owned(self.format_plain_token_reference(numeric_for.index_variable()));
 
         #[cfg(feature = "luau")]
         let type_specifier = match numeric_for.type_specifier() {
@@ -215,7 +215,7 @@ impl CodeFormatter {
         match stmt {
             Stmt::Assignment(assignment) => {
                 Stmt::Assignment(trivia_formatter::assignment_add_trivia(
-                    assignment,
+                    &assignment,
                     leading_trivia,
                     trailing_trivia,
                 ))

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -19,18 +19,21 @@ macro_rules! fmt_stmt {
 
 impl CodeFormatter {
     /// Format a Do node
-    pub fn format_do_block<'ast>(&self, do_block: Do<'ast>) -> Do<'ast> {
-        let do_token = crate::fmt_symbol!(self, do_block.do_token().to_owned(), "do");
-        let end_token = self.format_end_token(do_block.end_token().to_owned());
+    pub fn format_do_block<'ast>(&self, do_block: &Do<'ast>) -> Do<'ast> {
+        let do_token = crate::fmt_symbol!(self, do_block.do_token(), "do");
+        let end_token = self.format_end_token(do_block.end_token());
 
-        do_block.with_do_token(do_token).with_end_token(end_token)
+        do_block
+            .to_owned()
+            .with_do_token(do_token)
+            .with_end_token(end_token)
     }
 
     /// Format a GenericFor node
-    pub fn format_generic_for<'ast>(&mut self, generic_for: GenericFor<'ast>) -> GenericFor<'ast> {
-        let for_token = crate::fmt_symbol!(self, generic_for.for_token().to_owned(), "for ");
+    pub fn format_generic_for<'ast>(&mut self, generic_for: &GenericFor<'ast>) -> GenericFor<'ast> {
+        let for_token = crate::fmt_symbol!(self, generic_for.for_token(), "for ");
         let formatted_names = self.format_punctuated(
-            generic_for.names().to_owned(),
+            generic_for.names(),
             &CodeFormatter::format_token_reference_mut,
         );
 
@@ -38,69 +41,68 @@ impl CodeFormatter {
         let type_specifiers = generic_for
             .type_specifiers()
             .map(|x| match x {
-                Some(type_specifier) => Some(self.format_type_specifier(type_specifier.to_owned())),
+                Some(type_specifier) => Some(self.format_type_specifier(type_specifier)),
                 None => None,
             })
             .collect();
 
-        #[cfg(feature = "luau")]
-        let generic_for = generic_for.with_type_specifiers(type_specifiers);
+        let in_token = crate::fmt_symbol!(self, generic_for.in_token(), " in ");
+        let formatted_expr_list =
+            self.format_punctuated(generic_for.expr_list(), &CodeFormatter::format_expression);
+        let do_token = crate::fmt_symbol!(self, generic_for.do_token(), " do");
+        let end_token = self.format_end_token(generic_for.end_token());
 
-        let in_token = crate::fmt_symbol!(self, generic_for.in_token().to_owned(), " in ");
-        let formatted_expr_list = self.format_punctuated(
-            generic_for.expr_list().to_owned(),
-            &CodeFormatter::format_expression,
-        );
-        let do_token = crate::fmt_symbol!(self, generic_for.do_token().to_owned(), " do");
-        let end_token = self.format_end_token(generic_for.end_token().to_owned());
-
-        generic_for
+        let generic_for = generic_for
+            .to_owned()
             .with_for_token(for_token)
             .with_names(formatted_names)
             .with_in_token(in_token)
             .with_expr_list(formatted_expr_list)
             .with_do_token(do_token)
-            .with_end_token(end_token)
+            .with_end_token(end_token);
+        #[cfg(feature = "luau")]
+        let generic_for = generic_for.with_type_specifiers(type_specifiers);
+        generic_for
     }
 
     /// Formats an ElseIf node - This must always reside within format_if
-    fn format_else_if<'ast>(&mut self, else_if_node: ElseIf<'ast>) -> ElseIf<'ast> {
+    fn format_else_if<'ast>(&mut self, else_if_node: &ElseIf<'ast>) -> ElseIf<'ast> {
         let formatted_else_if_token =
-            crate::fmt_symbol!(self, else_if_node.else_if_token().to_owned(), "elseif ");
-        let formatted_condition = self.format_expression(else_if_node.condition().to_owned());
-        let formatted_then_token =
-            crate::fmt_symbol!(self, else_if_node.then_token().to_owned(), " then");
+            crate::fmt_symbol!(self, else_if_node.else_if_token(), "elseif ");
+        let formatted_condition = self.format_expression(else_if_node.condition());
+        let formatted_then_token = crate::fmt_symbol!(self, else_if_node.then_token(), " then");
 
         else_if_node
+            .to_owned()
             .with_else_if_token(formatted_else_if_token)
             .with_condition(formatted_condition)
             .with_then_token(formatted_then_token)
     }
 
     /// Format an If node
-    pub fn format_if<'ast>(&mut self, if_node: If<'ast>) -> If<'ast> {
-        let formatted_if_token = crate::fmt_symbol!(self, if_node.if_token().to_owned(), "if ");
-        let formatted_condition = self.format_expression(if_node.condition().to_owned());
-        let formatted_then_token =
-            crate::fmt_symbol!(self, if_node.then_token().to_owned(), " then");
-        let formatted_end_token = self.format_end_token(if_node.end_token().to_owned());
+    pub fn format_if<'ast>(&mut self, if_node: &If<'ast>) -> If<'ast> {
+        let formatted_if_token = crate::fmt_symbol!(self, if_node.if_token(), "if ");
+        let formatted_condition = self.format_expression(if_node.condition());
+        let formatted_then_token = crate::fmt_symbol!(self, if_node.then_token(), " then");
+        let formatted_end_token = self.format_end_token(if_node.end_token());
 
         let formatted_else_if = match if_node.else_if() {
             Some(else_if) => Some(
                 else_if
                     .iter()
-                    .map(|else_if| self.format_else_if(else_if.to_owned()))
+                    .map(|else_if| self.format_else_if(else_if))
                     .collect(),
             ),
             None => None,
         };
 
         let formatted_else_token = match if_node.else_token() {
-            Some(token) => Some(crate::fmt_symbol!(self, token.to_owned(), "else")),
+            Some(token) => Some(crate::fmt_symbol!(self, token, "else")),
             None => None,
         };
 
         if_node
+            .to_owned()
             .with_if_token(formatted_if_token)
             .with_condition(formatted_condition)
             .with_then_token(formatted_then_token)
@@ -110,41 +112,39 @@ impl CodeFormatter {
     }
 
     /// Format a NumericFor node
-    pub fn format_numeric_for<'ast>(&mut self, numeric_for: NumericFor<'ast>) -> NumericFor<'ast> {
-        let for_token = crate::fmt_symbol!(self, numeric_for.for_token().to_owned(), "for ");
+    pub fn format_numeric_for<'ast>(&mut self, numeric_for: &NumericFor<'ast>) -> NumericFor<'ast> {
+        let for_token = crate::fmt_symbol!(self, numeric_for.for_token(), "for ");
         let formatted_index_variable =
             Cow::Owned(self.format_plain_token_reference(numeric_for.index_variable()));
 
         #[cfg(feature = "luau")]
         let type_specifier = match numeric_for.type_specifier() {
-            Some(type_specifier) => Some(self.format_type_specifier(type_specifier.to_owned())),
+            Some(type_specifier) => Some(self.format_type_specifier(type_specifier)),
             None => None,
         };
-        #[cfg(feature = "luau")]
-        let numeric_for = numeric_for.with_type_specifier(type_specifier);
 
-        let equal_token = crate::fmt_symbol!(self, numeric_for.equal_token().to_owned(), " = ");
-        let formatted_start_expression = self.format_expression(numeric_for.start().to_owned());
-        let start_end_comma =
-            crate::fmt_symbol!(self, numeric_for.start_end_comma().to_owned(), ", ");
-        let formatted_end_expression = self.format_expression(numeric_for.end().to_owned());
+        let equal_token = crate::fmt_symbol!(self, numeric_for.equal_token(), " = ");
+        let formatted_start_expression = self.format_expression(numeric_for.start());
+        let start_end_comma = crate::fmt_symbol!(self, numeric_for.start_end_comma(), ", ");
+        let formatted_end_expression = self.format_expression(numeric_for.end());
 
         let (end_step_comma, formatted_step_expression) = match numeric_for.step() {
             Some(step) => (
                 Some(crate::fmt_symbol!(
                     self,
-                    numeric_for.end_step_comma().unwrap().to_owned(),
+                    numeric_for.end_step_comma().unwrap(),
                     ", "
                 )),
-                Some(self.format_expression(step.to_owned())),
+                Some(self.format_expression(step)),
             ),
             None => (None, None),
         };
 
-        let do_token = crate::fmt_symbol!(self, numeric_for.do_token().to_owned(), " do");
-        let end_token = self.format_end_token(numeric_for.end_token().to_owned());
+        let do_token = crate::fmt_symbol!(self, numeric_for.do_token(), " do");
+        let end_token = self.format_end_token(numeric_for.end_token());
 
-        numeric_for
+        let numeric_for = numeric_for
+            .to_owned()
             .with_for_token(for_token)
             .with_index_variable(formatted_index_variable)
             .with_equal_token(equal_token)
@@ -154,37 +154,42 @@ impl CodeFormatter {
             .with_end_step_comma(end_step_comma)
             .with_step(formatted_step_expression)
             .with_do_token(do_token)
-            .with_end_token(end_token)
+            .with_end_token(end_token);
+        #[cfg(feature = "luau")]
+        let numeric_for = numeric_for.with_type_specifier(type_specifier);
+
+        numeric_for
     }
 
     /// Format a Repeat node
-    pub fn format_repeat_block<'ast>(&mut self, repeat_block: Repeat<'ast>) -> Repeat<'ast> {
-        let repeat_token =
-            crate::fmt_symbol!(self, repeat_block.repeat_token().to_owned(), "repeat");
-        let until_token = crate::fmt_symbol!(self, repeat_block.until_token().to_owned(), "until ");
-        let formatted_until = self.format_expression(repeat_block.until().to_owned());
+    pub fn format_repeat_block<'ast>(&mut self, repeat_block: &Repeat<'ast>) -> Repeat<'ast> {
+        let repeat_token = crate::fmt_symbol!(self, repeat_block.repeat_token(), "repeat");
+        let until_token = crate::fmt_symbol!(self, repeat_block.until_token(), "until ");
+        let formatted_until = self.format_expression(repeat_block.until());
 
         repeat_block
+            .to_owned()
             .with_repeat_token(repeat_token)
             .with_until_token(until_token)
             .with_until(formatted_until)
     }
 
     /// Format a While node
-    pub fn format_while_block<'ast>(&mut self, while_block: While<'ast>) -> While<'ast> {
-        let while_token = crate::fmt_symbol!(self, while_block.while_token().to_owned(), "while ");
-        let formatted_condition = self.format_expression(while_block.condition().to_owned());
-        let do_token = crate::fmt_symbol!(self, while_block.do_token().to_owned(), " do");
-        let end_token = self.format_end_token(while_block.end_token().to_owned());
+    pub fn format_while_block<'ast>(&mut self, while_block: &While<'ast>) -> While<'ast> {
+        let while_token = crate::fmt_symbol!(self, while_block.while_token(), "while ");
+        let formatted_condition = self.format_expression(while_block.condition());
+        let do_token = crate::fmt_symbol!(self, while_block.do_token(), " do");
+        let end_token = self.format_end_token(while_block.end_token());
 
         while_block
+            .to_owned()
             .with_while_token(while_token)
             .with_condition(formatted_condition)
             .with_do_token(do_token)
             .with_end_token(end_token)
     }
 
-    pub fn format_stmt<'ast>(&mut self, stmt: Stmt<'ast>) -> Stmt<'ast> {
+    pub fn format_stmt<'ast>(&mut self, stmt: &Stmt<'ast>) -> Stmt<'ast> {
         fmt_stmt!(self, stmt, {
             Assignment = format_assignment,
             Do = format_do_block,

--- a/src/formatters/table_formatter.rs
+++ b/src/formatters/table_formatter.rs
@@ -272,7 +272,7 @@ impl CodeFormatter {
                 trailing_trivia = get_expression_trailing_trivia(value.to_owned());
                 Field::ExpressionKey {
                     brackets: trivia_formatter::contained_span_add_trivia(
-                        self.format_contained_span(brackets.to_owned()),
+                        self.format_contained_span(brackets),
                         leading_trivia,
                         FormatTriviaType::NoChange,
                     ),

--- a/src/formatters/table_formatter.rs
+++ b/src/formatters/table_formatter.rs
@@ -108,7 +108,7 @@ fn type_info_trailing_trivia<'ast>(type_info: &TypeInfo<'ast>) -> Vec<Token<'ast
     }
 }
 
-fn get_expression_trailing_trivia<'ast>(expression: Expression<'ast>) -> Vec<Token<'ast>> {
+fn get_expression_trailing_trivia<'ast>(expression: &Expression<'ast>) -> Vec<Token<'ast>> {
     match expression {
         Expression::Parentheses { contained, .. } => {
             let (_, end_parentheses) = contained.tokens();
@@ -117,7 +117,7 @@ fn get_expression_trailing_trivia<'ast>(expression: Expression<'ast>) -> Vec<Tok
                 .map(|x| x.to_owned())
                 .collect()
         }
-        Expression::UnaryOperator { expression, .. } => get_expression_trailing_trivia(*expression),
+        Expression::UnaryOperator { expression, .. } => get_expression_trailing_trivia(expression),
         Expression::Value {
             value,
             binop,
@@ -130,9 +130,9 @@ fn get_expression_trailing_trivia<'ast>(expression: Expression<'ast>) -> Vec<Tok
             }
 
             if let Some(binop) = binop {
-                get_expression_trailing_trivia(binop.rhs().to_owned())
+                get_expression_trailing_trivia(binop.rhs())
             } else {
-                match *value {
+                match &**value {
                     Value::Function((_, function_body)) => function_body
                         .end_token()
                         .trailing_trivia()
@@ -158,7 +158,7 @@ fn get_expression_trailing_trivia<'ast>(expression: Expression<'ast>) -> Vec<Tok
                         .trailing_trivia()
                         .map(|x| x.to_owned())
                         .collect(),
-                    Value::ParseExpression(expr) => get_expression_trailing_trivia(expr),
+                    Value::ParseExpression(expr) => get_expression_trailing_trivia(&expr),
                     Value::Symbol(token_reference) => token_reference
                         .trailing_trivia()
                         .map(|x| x.to_owned())
@@ -185,7 +185,7 @@ fn get_expression_trailing_trivia<'ast>(expression: Expression<'ast>) -> Vec<Tok
     }
 }
 
-fn get_expression_leading_trivia<'ast>(expression: Expression<'ast>) -> Vec<Token<'ast>> {
+fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec<Token<'ast>> {
     match expression {
         Expression::Parentheses { contained, .. } => contained
             .tokens()
@@ -198,7 +198,7 @@ fn get_expression_leading_trivia<'ast>(expression: Expression<'ast>) -> Vec<Toke
                 token_ref.leading_trivia().map(|x| x.to_owned()).collect()
             }
         },
-        Expression::Value { value, .. } => match *value {
+        Expression::Value { value, .. } => match &**value {
             Value::Function((token_ref, _)) => {
                 token_ref.leading_trivia().map(|x| x.to_owned()).collect()
             }
@@ -206,7 +206,7 @@ fn get_expression_leading_trivia<'ast>(expression: Expression<'ast>) -> Vec<Toke
                 Prefix::Name(token_ref) => {
                     token_ref.leading_trivia().map(|x| x.to_owned()).collect()
                 }
-                Prefix::Expression(expr) => get_expression_leading_trivia(expr.to_owned()),
+                Prefix::Expression(expr) => get_expression_leading_trivia(expr),
             },
             Value::TableConstructor(table) => table
                 .braces()
@@ -216,7 +216,7 @@ fn get_expression_leading_trivia<'ast>(expression: Expression<'ast>) -> Vec<Toke
                 .map(|x| x.to_owned())
                 .collect(),
             Value::Number(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
-            Value::ParseExpression(expr) => get_expression_leading_trivia(expr),
+            Value::ParseExpression(expr) => get_expression_leading_trivia(&expr),
             Value::String(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
             Value::Symbol(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
             Value::Var(var) => match var {
@@ -225,14 +225,14 @@ fn get_expression_leading_trivia<'ast>(expression: Expression<'ast>) -> Vec<Toke
                     Prefix::Name(token_ref) => {
                         token_ref.leading_trivia().map(|x| x.to_owned()).collect()
                     }
-                    Prefix::Expression(expr) => get_expression_leading_trivia(expr.to_owned()),
+                    Prefix::Expression(expr) => get_expression_leading_trivia(expr),
                 },
             },
         },
     }
 }
 
-fn get_field_leading_trivia<'ast>(field: Field<'ast>) -> Vec<Token<'ast>> {
+fn get_field_leading_trivia<'ast>(field: &Field<'ast>) -> Vec<Token<'ast>> {
     match field {
         Field::ExpressionKey { brackets, .. } => brackets
             .tokens()
@@ -269,40 +269,40 @@ impl CodeFormatter {
                 equal,
                 value,
             } => {
-                trailing_trivia = get_expression_trailing_trivia(value.to_owned());
+                trailing_trivia = get_expression_trailing_trivia(value);
                 Field::ExpressionKey {
                     brackets: trivia_formatter::contained_span_add_trivia(
                         self.format_contained_span(brackets),
                         leading_trivia,
                         FormatTriviaType::NoChange,
                     ),
-                    key: self.format_expression(key.to_owned()),
-                    equal: crate::fmt_symbol!(self, equal.to_owned().into_owned(), " = "),
+                    key: self.format_expression(key),
+                    equal: crate::fmt_symbol!(self, equal, " = "),
                     // We will remove all the trivia from this value, and place it after the comma
                     value: trivia_formatter::expression_add_trailing_trivia(
-                        self.format_expression(value.to_owned()),
+                        self.format_expression(value),
                         FormatTriviaType::Replace(vec![]),
                     ),
                 }
             }
             Field::NameKey { key, equal, value } => {
-                trailing_trivia = get_expression_trailing_trivia(value.to_owned());
+                trailing_trivia = get_expression_trailing_trivia(value);
                 Field::NameKey {
                     key: Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                        self.format_token_reference(key.to_owned()).into_owned(),
+                        self.format_token_reference(key).into_owned(),
                         leading_trivia,
                         FormatTriviaType::NoChange,
                     )),
-                    equal: crate::fmt_symbol!(self, equal.to_owned().into_owned(), " = "),
+                    equal: crate::fmt_symbol!(self, equal, " = "),
                     value: trivia_formatter::expression_add_trailing_trivia(
-                        self.format_expression(value.to_owned()),
+                        self.format_expression(value),
                         FormatTriviaType::Replace(vec![]),
                     ),
                 }
             }
             Field::NoKey(expression) => {
-                trailing_trivia = get_expression_trailing_trivia(expression.to_owned());
-                let formatted_expression = self.format_expression(expression.to_owned());
+                trailing_trivia = get_expression_trailing_trivia(expression);
+                let formatted_expression = self.format_expression(expression);
                 if let FormatTriviaType::NoChange = leading_trivia {
                     Field::NoKey(formatted_expression)
                 } else {
@@ -334,7 +334,7 @@ impl CodeFormatter {
                     vec![self.create_indent_trivia(additional_indent_level)];
 
                 // Add new_line trivia to start_brace
-                let start_brace_token = crate::fmt_symbol!(self, start_brace.to_owned(), "{");
+                let start_brace_token = crate::fmt_symbol!(self, start_brace, "{");
                 let start_brace_token = trivia_formatter::token_reference_add_trivia(
                     start_brace_token.into_owned(),
                     FormatTriviaType::NoChange,
@@ -350,25 +350,25 @@ impl CodeFormatter {
                 );
                 ContainedSpan::new(
                     Cow::Owned(start_brace_token),
-                    self.format_symbol(end_brace.to_owned(), end_brace_token),
+                    self.format_symbol(end_brace, &end_brace_token),
                 )
             }
 
             TableType::SingleLine => ContainedSpan::new(
-                crate::fmt_symbol!(self, start_brace.to_owned(), "{ "),
-                crate::fmt_symbol!(self, end_brace.to_owned(), " }"),
+                crate::fmt_symbol!(self, start_brace, "{ "),
+                crate::fmt_symbol!(self, end_brace, " }"),
             ),
 
             TableType::Empty => ContainedSpan::new(
-                crate::fmt_symbol!(self, start_brace.to_owned(), "{"),
-                crate::fmt_symbol!(self, end_brace.to_owned(), "}"),
+                crate::fmt_symbol!(self, start_brace, "{"),
+                crate::fmt_symbol!(self, end_brace, "}"),
             ),
         }
     }
 
     pub fn format_table_constructor<'ast>(
         &mut self,
-        table_constructor: TableConstructor<'ast>,
+        table_constructor: &TableConstructor<'ast>,
     ) -> TableConstructor<'ast> {
         let mut fields = Punctuated::new();
         let mut current_fields = table_constructor
@@ -388,7 +388,7 @@ impl CodeFormatter {
         // If so, then we should always be multiline
         // The newline is bound to the first field, so we need to check its leading trivia
         if let Some(first_field) = current_fields.peek() {
-            let leading_trivia = get_field_leading_trivia(first_field.value().to_owned());
+            let leading_trivia = get_field_leading_trivia(first_field.value());
             for trivia in leading_trivia.iter() {
                 if let TokenType::Whitespace { characters } = trivia.token_type() {
                     if characters.find('\n').is_some() {
@@ -443,9 +443,7 @@ impl CodeFormatter {
                     // Continue adding a comma and a new line for multiline tables
                     let mut symbol = TokenReference::symbol(",").unwrap();
                     if let Some(punctuation) = punctuation {
-                        symbol = self
-                            .format_symbol(punctuation.into_owned(), symbol)
-                            .into_owned();
+                        symbol = self.format_symbol(&punctuation, &symbol).into_owned();
                     }
                     // Add newline trivia to the end of the symbol, and preserve any comments
                     trailing_trivia.push(self.create_newline_trivia());
@@ -461,8 +459,8 @@ impl CodeFormatter {
                         // Have more elements still to go
                         formatted_punctuation = match punctuation {
                             Some(punctuation) => Some(self.format_symbol(
-                                punctuation.into_owned(),
-                                TokenReference::symbol(", ").unwrap(),
+                                &punctuation,
+                                &TokenReference::symbol(", ").unwrap(),
                             )),
                             None => Some(Cow::Owned(TokenReference::symbol(", ").unwrap())),
                         }

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -25,7 +25,7 @@ pub enum FormatTriviaType<'ast> {
 }
 
 pub fn assignment_add_trivia<'ast>(
-    assignment: Assignment<'ast>,
+    assignment: &Assignment<'ast>,
     leading_trivia: FormatTriviaType<'ast>,
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> Assignment<'ast> {
@@ -67,9 +67,8 @@ pub fn assignment_add_trivia<'ast>(
         }
     }
 
-    assignment
-        .with_var_list(formatted_var_list)
-        .with_expr_list(formatted_expression_list)
+    Assignment::new(formatted_var_list, formatted_expression_list)
+        .with_equal_token(Cow::Owned(assignment.equal_token().to_owned()))
 }
 
 pub fn function_call_add_trivia<'ast>(


### PR DESCRIPTION
This PR reduces the amount of cloning conducted whilst formatting, by passing nodes by references.

Through benchmarks, this has improved performance by 22%