### PR TITLE
Fix large files in vscode extension

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,10 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Fixes
+- Extension now handles bigger files better, previously it could cut them off
+- StyLua binary can now be placed in a folder with spaces in it
+
 ## [1.0.2] - 2020-12-31
 
 ### Fixes

--- a/stylua-vscode/src/stylua.ts
+++ b/stylua-vscode/src/stylua.ts
@@ -30,12 +30,12 @@ export function formatCode(
     const child = spawn(`${path}`, ["-"], {
       cwd,
     });
-    let output = ''
+    let output = '';
     child.stdout.on("data", (data) => {
-      output += data
+      output += data.toString();
     });
     child.stdout.on("close", () => {
-      resolve(output)
+      resolve(output);
     });
     child.stderr.on("data", (data) => reject(data.toString()));
     child.on("err", (err) => reject("Failed to start StyLua"));

--- a/stylua-vscode/src/stylua.ts
+++ b/stylua-vscode/src/stylua.ts
@@ -30,9 +30,12 @@ export function formatCode(
     const child = spawn(`${path}`, ["-"], {
       cwd,
     });
+    let output = ''
     child.stdout.on("data", (data) => {
-      child.kill(); // The process should close on its own, but we kill it here anyways
-      resolve(data.toString());
+      output += data
+    });
+    child.stdout.on("close", () => {
+      resolve(output)
     });
     child.stderr.on("data", (data) => reject(data.toString()));
     child.on("err", (err) => reject("Failed to start StyLua"));
@@ -50,7 +53,7 @@ export function executeStylua(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = exec(
-      `${path} ${args?.join(" ") ?? ""}`,
+      `"${path}" ${args?.join(" ") ?? ""}`,
       {
         cwd,
       },


### PR DESCRIPTION
Wait for child process to exit before resolving formatting promise so that large files are fully processed. Previously large files were being cut off as the data callback can be called multiple times and the current implementation was only allowing one callback.

Wrap path in quotes, so that paths with spaces still work when invoking exec. On Mac the default location of the StyLua binary will be under `Application Support` when installed via VSCode. This causes exec to fail due to the space. Wrapping in quotes solves the issue.