### PR TITLE
extension: Use VSCode FileSystem rather than Node fs

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,10 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Changed
+
+- Improved internals to use VSCode file system
+
 ## [1.1.1] - 2021-02-25
 
 ### Fixed
@@ -26,6 +30,7 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 ## [1.0.3] - 2021-01-27
 
 ### Fixes
+
 - Extension now handles bigger files better, previously it could cut them off
 - StyLua binary can now be placed in a folder with spaces in it
 

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -8,7 +8,10 @@ import { formatCode, checkIgnored } from "./stylua";
  * @param document The document to retreive the byte offset in
  * @param position The possition to retreive the byte offset for
  */
-const byteOffset = (document: vscode.TextDocument, position: vscode.Position) => {
+const byteOffset = (
+  document: vscode.TextDocument,
+  position: vscode.Position
+) => {
   // Retreive all the text from the start of the document to the position provided
   const textRange = new vscode.Range(document.positionAt(0), position);
   const text = document.getText(textRange);
@@ -53,18 +56,25 @@ export async function activate(context: vscode.ExtensionContext) {
           return [];
         }
 
-        const fileName = document.fileName;
-        const cwd = vscode.workspace.getWorkspaceFolder(
-          vscode.Uri.file(document.uri.fsPath)
-        )?.uri?.fsPath;
-        if (await checkIgnored(fileName, cwd)) {
+        const currentWorkspace = vscode.workspace.getWorkspaceFolder(
+          document.uri
+        );
+        const cwd = currentWorkspace?.uri?.fsPath;
+
+        if (await checkIgnored(document.uri, currentWorkspace?.uri)) {
           return [];
         }
 
         const text = document.getText();
 
         try {
-          const formattedText = await formatCode(styluaBinaryPath, text, cwd, byteOffset(document, range.start), byteOffset(document, range.end));
+          const formattedText = await formatCode(
+            styluaBinaryPath,
+            text,
+            cwd,
+            byteOffset(document, range.start),
+            byteOffset(document, range.end)
+          );
           // Replace the whole document with our new formatted version
           const lastLineNumber = document.lineCount - 1;
           const fullDocumentRange = new vscode.Range(

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -3,7 +3,6 @@
 import * as vscode from "vscode";
 import * as os from "os";
 import * as fs from "fs";
-import * as path from "path";
 import * as unzip from "unzipper";
 import fetch from "node-fetch";
 import { executeStylua } from "./stylua";
@@ -53,14 +52,15 @@ const getAssetFilenamePattern = () => {
   }
 };
 
-export const fileExists = (path: string): Promise<boolean> => {
-  return fs.promises
-    .stat(path)
-    .then(() => true)
-    .catch((error) => error.code !== "ENOENT");
+export const fileExists = (path: vscode.Uri | string): Thenable<boolean> => {
+  const uri = path instanceof vscode.Uri ? path : vscode.Uri.file(path);
+  return vscode.workspace.fs.stat(uri).then(
+    () => true,
+    () => false
+  );
 };
 
-const downloadStylua = async (outputDirectory: string) => {
+const downloadStylua = async (outputDirectory: vscode.Uri) => {
   const latestRelease = await getLatestRelease();
   const assetFilename = getAssetFilenamePattern();
   const outputFilename = getDownloadOutputFilename();
@@ -68,7 +68,7 @@ const downloadStylua = async (outputDirectory: string) => {
   for (const asset of latestRelease.assets) {
     if (assetFilename.test(asset.name)) {
       const file = fs.createWriteStream(
-        path.join(outputDirectory, outputFilename),
+        vscode.Uri.joinPath(outputDirectory, outputFilename).fsPath,
         {
           mode: 0o755,
         }
@@ -103,7 +103,7 @@ export const downloadStyLuaVisual = (outputDirectory: vscode.Uri) => {
       location: vscode.ProgressLocation.Notification,
       title: "Downloading StyLua",
     },
-    () => downloadStylua(outputDirectory.fsPath)
+    () => downloadStylua(outputDirectory)
   );
 };
 
@@ -117,12 +117,12 @@ export const getStyluaPath = async (
     return settingPath;
   }
 
-  const downloadPath = path.join(
-    storageDirectory.fsPath,
+  const downloadPath = vscode.Uri.joinPath(
+    storageDirectory,
     getDownloadOutputFilename()
   );
   if (await fileExists(downloadPath)) {
-    return downloadPath;
+    return downloadPath.fsPath;
   }
 };
 
@@ -132,7 +132,7 @@ export const ensureStyluaExists = async (
   const path = await getStyluaPath(storageDirectory);
 
   if (path === undefined) {
-    await fs.promises.mkdir(storageDirectory.fsPath, { recursive: true });
+    await vscode.workspace.fs.createDirectory(storageDirectory);
     await downloadStyLuaVisual(storageDirectory);
     return await getStyluaPath(storageDirectory);
   } else {
@@ -141,8 +141,15 @@ export const ensureStyluaExists = async (
     }
 
     const version = (await executeStylua(path, ["--version"]))?.trim();
-    const release = await getLatestRelease(); 
-    if (version !== `stylua ${release.tag_name.startsWith('v') ? release.tag_name.substr(1) : release.tag_name}`) {
+    const release = await getLatestRelease();
+    if (
+      version !==
+      `stylua ${
+        release.tag_name.startsWith("v")
+          ? release.tag_name.substr(1)
+          : release.tag_name
+      }`
+    ) {
       openUpdatePrompt(storageDirectory, release);
     }
 


### PR DESCRIPTION
This PR converts all the `fs` calls in the extension to use `vscode.workspace.fs`. This allows the extension to work with remote files, and the system runs outside the editor process, improving performance.

The only remaining call is `fs.writeFileStream`, which is used when downloading StyLua. Currently unsure if `vscode.workspace.fs.writeFile()` is up to the task or not