### PR TITLE
Fix hanging expr in function call being overly indented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ force styles, we will always use the quote type specified.
 - Fixed parentheses being incorrectly removed around a BinOp where first value was a UnOp
 - Fixed indentation of leading comments bound to the end brace of a multiline table
 - Fixed LastStmt (return/break etc.) still being formatted when it wasn't defined inside the range
+- Fixed hanging expressions which are inside function calls being indented unnecessarily by one extra level
 
 ## [0.5.0] - 2021-02-24
 ### Added

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -336,13 +336,6 @@ impl CodeFormatter {
                                         .len()
                                     > self.config.column_width;
 
-                        if require_multiline_expression {
-                            let expr_range = argument
-                                .range()
-                                .expect("no range for function call argument");
-                            self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes() + 1));
-                        }
-
                         // Unfortunately, we need to format again, taking into account in indent increase
                         // TODO: Can we fix this? We don't want to have to format twice
                         let mut formatted_argument = self.format_expression(argument.value());

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -4,7 +4,6 @@ use full_moon::ast::{
     Call, Expression, FunctionArgs, FunctionBody, FunctionCall, FunctionDeclaration, FunctionName,
     LocalFunction, MethodCall, Parameter, Value,
 };
-use full_moon::node::Node;
 use full_moon::tokenizer::{Symbol, Token, TokenKind, TokenReference, TokenType};
 use std::borrow::Cow;
 use std::boxed::Box;

--- a/tests/inputs/function-call-4.lua
+++ b/tests/inputs/function-call-4.lua
@@ -1,0 +1,9 @@
+Roact.createElement("ImageLabel", {
+	Size = UDim2.new(
+		0,
+		TextService:GetTextSize(self.props.PhysicalTool.Name, 16, Enum.Font.SourceSansBold, Vector2.new(100000, 100000)).X
+			+ 10,
+		0,
+		20
+	),
+})

--- a/tests/snapshots/tests__standard@function-call-4.lua.snap
+++ b/tests/snapshots/tests__standard@function-call-4.lua.snap
@@ -1,0 +1,15 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+Roact.createElement("ImageLabel", {
+	Size = UDim2.new(
+		0,
+		TextService:GetTextSize(self.props.PhysicalTool.Name, 16, Enum.Font.SourceSansBold, Vector2.new(100000, 100000)).X
+			+ 10,
+		0,
+		20
+	),
+})
+


### PR DESCRIPTION
Expression was overly indented as we added the expression range to the indent ranges.
This is unnecessary, as the whole function call range is already added - we do not need to indent any further.

Fixes #85 