### PR TITLE
Add initial support for Lua5.2 syntax (goto, label)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
 
     - name: Test (Luau)
       run: cargo test --features luau
+    
+    - name: Test (Lua 5.2)
+      run: cargo test --features lua52
 
     - name: Clippy
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/cli/main.rs"
 [features]
 default = []
 luau = ["full_moon/roblox"]
+lua52 = ["full_moon/lua52"]
 
 [dependencies]
 anyhow = "1.0.35"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StyLua
 
-An opinionated code formatter for Lua 5.1 and [Luau](https://roblox.github.io/luau/), built using [full-moon](https://github.com/Kampfkarren/full-moon).
+An opinionated code formatter for Lua 5.1, Lua 5.2 and [Luau](https://roblox.github.io/luau/), built using [full-moon](https://github.com/Kampfkarren/full-moon).
 StyLua is inspired by the likes of [prettier](https://github.com/prettier/prettier), it parses your Lua codebase, and prints it back out from scratch,
 enforcing a consistent code style.
 
@@ -9,7 +9,8 @@ There are multiple ways to install StyLua:
 
 ### With Github Releases
 Pre-built binaries are available on the [GitHub Releases Page](https://github.com/JohnnyMorganz/StyLua/releases).
-Please note, currently by default, StyLua is built with Luau features enabled. If you would just like to format Lua 5.1 code, please see installing from crates.io
+Please note, currently by default, **StyLua is built with Luau features enabled**. If you would just like to format Lua 5.1 code,
+or would like to format Lua 5.2 code, please see [installing from crates.io](#from-cratesio)
 
 ### With [Foreman](https://github.com/Roblox/foreman)
 StyLua can be installed using foreman. Add the following to your `foreman.toml` file:
@@ -39,6 +40,10 @@ This will compile StyLua (for Lua 5.1) and install it on your local machine.
 If you would like Luau features, pass the `--features luau` argument.
 ```
 cargo install stylua --features luau
+```
+Similarly, for Lua 5.2 syntax, pass the `--features lua52` argument.
+```
+cargo install stylua --features lua52
 ```
 
 ## Usage

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -375,6 +375,12 @@ impl CodeFormatter {
                 type_declaration.type_token(),
                 with_type_token
             ),
+            #[cfg(feature = "lua52")]
+            Stmt::Goto(goto) => update_first_token!(Goto, goto, goto.goto_token(), with_goto_token),
+            #[cfg(feature = "lua52")]
+            Stmt::Label(label) => {
+                update_first_token!(Label, label, label.left_colons(), with_left_colons)
+            }
             other => panic!("unknown node {:?}", other),
         }
     }

--- a/src/formatters/lua52_formatter.rs
+++ b/src/formatters/lua52_formatter.rs
@@ -40,7 +40,7 @@ impl CodeFormatter {
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::NoChange,
         );
-        let name = self.format_token_reference(label.body());
+        let name = self.format_token_reference(label.name());
 
         let right_colons = trivia_formatter::token_reference_add_trivia(
             crate::fmt_symbol!(self, label.right_colons(), "::"),

--- a/src/formatters/lua52_formatter.rs
+++ b/src/formatters/lua52_formatter.rs
@@ -1,0 +1,55 @@
+use crate::formatters::{
+    trivia_formatter::{self, FormatTriviaType},
+    CodeFormatter,
+};
+use full_moon::ast::lua52::{Goto, Label};
+use full_moon::tokenizer::TokenReference;
+
+impl CodeFormatter {
+    pub fn format_goto<'ast>(&self, goto: &Goto<'ast>) -> Goto<'ast> {
+        // Calculate trivia
+        let additional_indent_level =
+            self.get_range_indent_increase(CodeFormatter::get_token_range(goto.goto_token()));
+        let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
+        let trailing_trivia = vec![self.create_newline_trivia()];
+
+        let goto_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, goto.goto_token(), "goto "),
+            FormatTriviaType::Append(leading_trivia),
+            FormatTriviaType::NoChange,
+        );
+
+        let label_name = trivia_formatter::token_reference_add_trivia(
+            self.format_token_reference(goto.label_name()),
+            FormatTriviaType::NoChange,
+            FormatTriviaType::Append(trailing_trivia),
+        );
+
+        Goto::new(label_name).with_goto_token(goto_token)
+    }
+
+    pub fn format_label<'ast>(&self, label: &Label<'ast>) -> Label<'ast> {
+        // Calculate trivia
+        let additional_indent_level =
+            self.get_range_indent_increase(CodeFormatter::get_token_range(label.left_colons()));
+        let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
+        let trailing_trivia = vec![self.create_newline_trivia()];
+
+        let left_colons = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, label.left_colons(), "::"),
+            FormatTriviaType::Append(leading_trivia),
+            FormatTriviaType::NoChange,
+        );
+        let name = self.format_token_reference(label.body());
+
+        let right_colons = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, label.right_colons(), "::"),
+            FormatTriviaType::NoChange,
+            FormatTriviaType::Append(trailing_trivia),
+        );
+
+        Label::new(name)
+            .with_left_colons(left_colons)
+            .with_right_colons(right_colons)
+    }
+}

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -15,6 +15,8 @@ pub mod block_formatter;
 #[macro_use]
 pub mod expression_formatter;
 pub mod functions_formatter;
+#[cfg(feature = "lua52")]
+pub mod lua52_formatter;
 #[cfg(feature = "luau")]
 pub mod luau_formatter;
 pub mod stmt_formatter;

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -499,6 +499,8 @@ impl CodeFormatter {
             #[cfg(feature = "luau")] CompoundAssignment = format_compound_assignment,
             #[cfg(feature = "luau")] ExportedTypeDeclaration = format_exported_type_declaration,
             #[cfg(feature = "luau")] TypeDeclaration = format_type_declaration_stmt,
+            #[cfg(feature = "lua52")] Goto = format_goto,
+            #[cfg(feature = "lua52")] Label = format_label,
         })
     }
 }

--- a/tests/inputs-lua52/goto-1.lua
+++ b/tests/inputs-lua52/goto-1.lua
@@ -1,0 +1,2 @@
+for i=1,10 do if i == 1 then goto skip end end
+::skip::

--- a/tests/inputs-lua52/goto-2.lua
+++ b/tests/inputs-lua52/goto-2.lua
@@ -1,0 +1,7 @@
+-- http://lua-users.org/wiki/GotoStatement
+::redo:: for x=1,10 do for y=1,10 do
+	if not f(x,y) then goto continue end
+	if not g(x,y) then goto skip end
+	if not h(x,y) then goto redo end
+	::continue::
+  end end ::skip::

--- a/tests/snapshots/tests__lua52@goto-1.lua.snap
+++ b/tests/snapshots/tests__lua52@goto-1.lua.snap
@@ -1,0 +1,11 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+for i = 1, 10 do
+	if i == 1 then
+		goto skip
+	end
+end
+::skip::

--- a/tests/snapshots/tests__lua52@goto-2.lua.snap
+++ b/tests/snapshots/tests__lua52@goto-2.lua.snap
@@ -1,0 +1,23 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- http://lua-users.org/wiki/GotoStatement
+::redo::
+for x = 1, 10 do
+	for y = 1, 10 do
+		if not f(x, y) then
+			goto continue
+		end
+		if not g(x, y) then
+			goto skip
+		end
+		if not h(x, y) then
+			goto redo
+		end
+		::continue::
+	end
+end
+::skip::
+


### PR DESCRIPTION
Adds initial support for Lua5.2 syntax, including test structure and CI.

Adds support for formatting `goto` and `label`

Part of #87 

This PR is based off #77 as it is part of new full-moon syntax