### PR TITLE
Fix string escapes being incorrectly removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ force styles, we will always use the quote type specified.
 - Fixed LastStmt (return/break etc.) still being formatted when it wasn't defined inside the range
 - Fixed hanging expressions which are inside function calls being indented unnecessarily by one extra level
 - Fixed parentheses being incorrectly removed around a function definition, which may be called like `(function() ... end)()`
+- Fixed some string escapes being incorrectly deemed as unnecessary
 
 ## [0.5.0] - 2021-02-24
 ### Added

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -273,7 +273,7 @@ impl CodeFormatter {
                     // Based off https://github.com/prettier/prettier/blob/181a325c1c07f1a4f3738665b7b28288dfb960bc/src/common/util.js#L439
                     lazy_static::lazy_static! {
                         static ref RE: regex::Regex = regex::Regex::new(r#"\\?(["'])|\\([\S\s])"#).unwrap();
-                        static ref UNNECESSARY_ESCAPES: regex::Regex = regex::Regex::new(r#"^[^\n\r"'0-7\\bfnrt-vx\u2028\u2029]$"#).unwrap();
+                        static ref UNNECESSARY_ESCAPES: regex::Regex = regex::Regex::new(r#"^[^\n\r"'0-7\\abfnrtuvxz]$"#).unwrap();
                     }
                     let quote_to_use = self.get_quote_to_use(literal);
                     let literal = RE

--- a/tests/inputs/string-escapes-2.lua
+++ b/tests/inputs/string-escapes-2.lua
@@ -1,0 +1,17 @@
+-- standard escapes
+local a = "foo \a \b \f \n \r \t \v \\ \" \'"
+
+-- decimal escapes
+local b = "\000 \001 \189 \254 \255"
+
+-- lua 5.2: hex escapes
+local c = "hello \x77\x6f\x72\x6c\x64\x99"
+
+-- lua 5.2: \z
+local d = "hello \z  test"
+
+-- lua 5.3: utf8
+local e = "\u{123} \u{255}"
+
+-- wrong:
+local f = "\q \p \e"

--- a/tests/snapshots/tests__standard@string-escapes-2.lua.snap
+++ b/tests/snapshots/tests__standard@string-escapes-2.lua.snap
@@ -1,0 +1,23 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- standard escapes
+local a = "foo \a \b \f \n \r \t \v \\ \" '"
+
+-- decimal escapes
+local b = "\000 \001 \189 \254 \255"
+
+-- lua 5.2: hex escapes
+local c = "hello \x77\x6f\x72\x6c\x64\x99"
+
+-- lua 5.2: \z
+local d = "hello \z  test"
+
+-- lua 5.3: utf8
+local e = "\u{123} \u{255}"
+
+-- wrong:
+local f = "q p e"
+


### PR DESCRIPTION
Now covers all correct string escapes up to Lua 5.4
Part of #87 