### PR TITLE
Simplify assignment formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ force styles, we will always use the quote type specified.
 - Fixed indentation of leading comments bound to the end brace of a multiline table
 - Fixed LastStmt (return/break etc.) still being formatted when it wasn't defined inside the range
 - Fixed hanging expressions which are inside function calls being indented unnecessarily by one extra level
+- Fixed trailing comments after semicolons at the end of statements being lost when formatting
+- Fixed formatting issues in relation to newline and whitespace when using range formatting.
+- Fixed empty tables taking 2 formatting passes to format properly
 
 ## [0.5.0] - 2021-02-24
 ### Added

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -6,7 +6,6 @@ use full_moon::ast::{
 };
 use full_moon::node::Node;
 use full_moon::tokenizer::TokenReference;
-use std::borrow::Cow;
 
 use crate::formatters::{
     trivia_formatter::{self, FormatTriviaType},
@@ -43,8 +42,7 @@ impl CodeFormatter {
             }));
         }
 
-        Assignment::new(var_list, expr_list)
-            .with_equal_token(Cow::Owned(assignment.equal_token().to_owned()))
+        Assignment::new(var_list, expr_list).with_equal_token(assignment.equal_token().to_owned())
     }
 
     pub fn format_assignment<'ast>(&mut self, assignment: &Assignment<'ast>) -> Assignment<'ast> {
@@ -65,7 +63,7 @@ impl CodeFormatter {
 
         // Create preliminary assignment
         let formatted_assignment = Assignment::new(var_list.to_owned(), expr_list.to_owned())
-            .with_equal_token(Cow::Owned(TokenReference::symbol(" = ").unwrap()));
+            .with_equal_token(TokenReference::symbol(" = ").unwrap());
 
         // Test whether we need to hang the expression, using the updated assignment
         // We have to format normally before this, since we may be expanding the expression onto multiple lines
@@ -163,15 +161,15 @@ impl CodeFormatter {
             let mut name_list = local_assignment.names().to_owned();
             if let Some(last_pair) = name_list.pop() {
                 name_list.push(last_pair.map(|value| {
-                    Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                        value.into_owned(),
+                    trivia_formatter::token_reference_add_trivia(
+                        value,
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Replace(vec![]),
-                    ))
+                    )
                 }));
             }
 
-            LocalAssignment::new(name_list).with_local_token(Cow::Owned(local_token))
+            LocalAssignment::new(name_list).with_local_token(local_token)
         } else {
             let mut expr_list = local_assignment.expressions().to_owned();
             if let Some(last_pair) = expr_list.pop() {
@@ -183,12 +181,8 @@ impl CodeFormatter {
                 }));
             }
             LocalAssignment::new(local_assignment.names().to_owned())
-                .with_local_token(Cow::Owned(local_token))
-                .with_equal_token(
-                    local_assignment
-                        .equal_token()
-                        .map(|x| Cow::Owned(x.to_owned())),
-                )
+                .with_local_token(local_token)
+                .with_equal_token(local_assignment.equal_token().map(|x| x.to_owned()))
                 .with_expressions(expr_list)
         }
     }
@@ -206,11 +200,11 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let mut trailing_trivia = vec![self.create_newline_trivia()];
 
-        let local_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, assignment.local_token(), "local ").into_owned(),
+        let local_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, assignment.local_token(), "local "),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         let (mut name_list, mut name_list_comments_buf) = self.format_punctuated(
             assignment.names(),
@@ -250,11 +244,11 @@ impl CodeFormatter {
                 }
 
                 let pair = pair.map(|name| {
-                    Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                        name.to_owned().into_owned(),
+                    trivia_formatter::token_reference_add_trivia(
+                        name.to_owned(),
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append(name_list_comments_buf),
-                    ))
+                    )
                 });
                 name_list.push(pair);
             }

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -226,15 +226,13 @@ impl CodeFormatter {
             let mut new_line_added = false;
 
             #[cfg(feature = "luau")]
-            if let Some(type_specifier) = type_specifiers.pop() {
-                if let Some(specifier) = type_specifier {
-                    let specifier = trivia_formatter::type_specifier_add_trailing_trivia(
-                        specifier,
-                        FormatTriviaType::Append(trailing_trivia.to_owned()),
-                    );
-                    type_specifiers.push(Some(specifier));
-                    new_line_added = true;
-                }
+            if let Some(Some(specifier)) = type_specifiers.pop() {
+                let specifier = trivia_formatter::type_specifier_add_trailing_trivia(
+                    specifier,
+                    FormatTriviaType::Append(trailing_trivia.to_owned()),
+                );
+                type_specifiers.push(Some(specifier));
+                new_line_added = true;
             }
 
             if let Some(pair) = name_list.pop() {

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -2,37 +2,114 @@
 use full_moon::ast::types::TypeSpecifier;
 use full_moon::ast::{
     punctuated::{Pair, Punctuated},
-    Assignment, LocalAssignment,
+    Assignment, Expression, LocalAssignment,
 };
 use full_moon::node::Node;
-use full_moon::tokenizer::TokenReference;
+use full_moon::tokenizer::{Token, TokenReference};
 
 use crate::formatters::{
     trivia_formatter::{self, FormatTriviaType},
     trivia_util, CodeFormatter,
 };
 
-impl CodeFormatter {
-    /// Returns an Assignment with leading and trailing trivia removed
-    fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'ast> {
-        let mut var_list = Punctuated::new();
-        let mut added_first = false;
+/// Wrapper around [`token_reference_add_trivia`] to only add trailing trivia
+fn token_reference_add_trailing_trivia<'ast>(
+    token: TokenReference<'ast>,
+    trailing_trivia: FormatTriviaType<'ast>,
+) -> TokenReference<'ast> {
+    trivia_formatter::token_reference_add_trivia(token, FormatTriviaType::NoChange, trailing_trivia)
+}
 
-        for pair in assignment.variables().pairs() {
-            if added_first {
-                var_list.push(pair.to_owned());
-            } else {
-                var_list.push(pair.to_owned().map(|value| {
-                    trivia_formatter::var_add_leading_trivia(
-                        value,
-                        FormatTriviaType::Replace(vec![]),
-                    )
-                }));
-                added_first = true;
-            }
+/// Adds trailing trivia at the end of a [`Punctuated`] sequence, using the provider `adder` function
+fn add_punctuated_trailing_trivia<'ast, T, F>(
+    punctuated: &mut Punctuated<'ast, T>,
+    trivia: Vec<Token<'ast>>,
+    adder: F,
+) where
+    F: Fn(T, FormatTriviaType<'ast>) -> T,
+{
+    // Add any trailing trivia to the end of the punctuated list
+    if let Some(pair) = punctuated.pop() {
+        let pair = pair.map(|expr| adder(expr, FormatTriviaType::Append(trivia)));
+        punctuated.push(pair);
+    }
+}
+
+/// Adds trailing trivia at the end of a [`Punctuated`] sequence, using the provider `adder` function
+fn add_punctuated_leading_trivia<'ast, T, F>(
+    punctuated: Punctuated<'ast, T>,
+    trivia: Vec<Token<'ast>>,
+    adder: F,
+) -> Punctuated<'ast, T>
+where
+    F: Fn(T, FormatTriviaType<'ast>) -> T,
+{
+    let mut iterator = punctuated.into_pairs();
+
+    // Retrieve first item and add leading trivia
+    if let Some(first_pair) = iterator.next() {
+        let updated_pair = first_pair.map(|value| adder(value, FormatTriviaType::Append(trivia)));
+        let iterator = std::iter::once(updated_pair).chain(iterator);
+        iterator.collect()
+    } else {
+        iterator.collect()
+    }
+}
+
+/// Returns an Assignment with leading and trailing trivia removed
+fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'ast> {
+    let mut var_list = Punctuated::new();
+    let mut added_first = false;
+
+    for pair in assignment.variables().pairs() {
+        if added_first {
+            var_list.push(pair.to_owned());
+        } else {
+            var_list.push(pair.to_owned().map(|value| {
+                trivia_formatter::var_add_leading_trivia(value, FormatTriviaType::Replace(vec![]))
+            }));
+            added_first = true;
+        }
+    }
+
+    let mut expr_list = assignment.expressions().to_owned();
+    if let Some(last_pair) = expr_list.pop() {
+        expr_list.push(last_pair.map(|value| {
+            trivia_formatter::expression_add_trailing_trivia(
+                value,
+                FormatTriviaType::Replace(vec![]),
+            )
+        }));
+    }
+
+    Assignment::new(var_list, expr_list).with_equal_token(assignment.equal_token().to_owned())
+}
+
+/// Returns a LocalAssignment with leading and trailing trivia removed
+fn strip_local_assignment_trivia<'ast>(
+    local_assignment: &LocalAssignment<'ast>,
+) -> LocalAssignment<'ast> {
+    let local_token = trivia_formatter::token_reference_add_trivia(
+        local_assignment.local_token().to_owned(),
+        FormatTriviaType::Replace(vec![]),
+        FormatTriviaType::NoChange,
+    );
+
+    if local_assignment.expressions().is_empty() {
+        let mut name_list = local_assignment.names().to_owned();
+        if let Some(last_pair) = name_list.pop() {
+            name_list.push(last_pair.map(|value| {
+                trivia_formatter::token_reference_add_trivia(
+                    value,
+                    FormatTriviaType::NoChange,
+                    FormatTriviaType::Replace(vec![]),
+                )
+            }));
         }
 
-        let mut expr_list = assignment.expressions().to_owned();
+        LocalAssignment::new(name_list).with_local_token(local_token)
+    } else {
+        let mut expr_list = local_assignment.expressions().to_owned();
         if let Some(last_pair) = expr_list.pop() {
             expr_list.push(last_pair.map(|value| {
                 trivia_formatter::expression_add_trailing_trivia(
@@ -41,8 +118,40 @@ impl CodeFormatter {
                 )
             }));
         }
+        LocalAssignment::new(local_assignment.names().to_owned())
+            .with_local_token(local_token)
+            .with_equal_token(local_assignment.equal_token().map(|x| x.to_owned()))
+            .with_expressions(expr_list)
+    }
+}
 
-        Assignment::new(var_list, expr_list).with_equal_token(assignment.equal_token().to_owned())
+impl CodeFormatter {
+    fn hang_punctuated_list<'ast>(
+        &mut self,
+        punctuated: &Punctuated<'ast, Expression<'ast>>,
+        additional_indent_level: Option<usize>,
+    ) -> Punctuated<'ast, Expression<'ast>> {
+        // Add the expression list into the indent range, as it will be indented by one
+        let expr_range = punctuated
+            .range()
+            .expect("no range for assignment punctuated list");
+        self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
+        let mut output = Punctuated::new();
+
+        // Format each expression and hang them
+        // We need to format again because we will now take into account the indent increase
+        for pair in punctuated.pairs() {
+            let expr = self.format_expression(pair.value());
+            let value =
+                self.hang_expression_no_trailing_newline(expr, additional_indent_level, None);
+            output.push(Pair::new(
+                value,
+                pair.punctuation()
+                    .map(|x| crate::fmt_symbol!(self, x, ", ")),
+            ))
+        }
+
+        output
     }
 
     pub fn format_assignment<'ast>(&mut self, assignment: &Assignment<'ast>) -> Assignment<'ast> {
@@ -53,12 +162,12 @@ impl CodeFormatter {
             CodeFormatter::get_token_range(assignment.equal_token().token()),
         );
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
-        let mut trailing_trivia = vec![self.create_newline_trivia()];
+        let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let (var_list, mut var_comments_buf) =
+        let (var_list, var_comments_buf) =
             self.format_punctuated(assignment.variables(), &CodeFormatter::format_var);
 
-        let (mut expr_list, mut expr_comments_buf) =
+        let (mut expr_list, expr_comments_buf) =
             self.format_punctuated(assignment.expressions(), &CodeFormatter::format_expression);
 
         // Create preliminary assignment
@@ -71,7 +180,7 @@ impl CodeFormatter {
         let indent_spacing =
             (self.indent_level + additional_indent_level.unwrap_or(0)) * self.config.indent_width;
         let require_multiline_expression = indent_spacing
-            + CodeFormatter::strip_assignment_trivia(&formatted_assignment)
+            + strip_assignment_trivia(&formatted_assignment)
                 .to_string()
                 .lines()
                 .next()
@@ -85,106 +194,32 @@ impl CodeFormatter {
             });
 
         if require_multiline_expression {
-            // Add the expression list into the indent range, as it will be indented by one
-            let expr_range = assignment
-                .expressions()
-                .range()
-                .expect("no range for assignment expr");
-            self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-
-            expr_list = Punctuated::new();
-            // Format each expression and hang them
-            // We need to format again because we will now take into account the indent increase
-            for pair in assignment.expressions().pairs() {
-                let expr = self.format_expression(pair.value());
-                let value =
-                    self.hang_expression_no_trailing_newline(expr, additional_indent_level, None);
-                expr_list.push(Pair::new(
-                    value,
-                    pair.punctuation()
-                        .map(|x| crate::fmt_symbol!(self, x, ", ")),
-                ))
-            }
+            expr_list =
+                self.hang_punctuated_list(assignment.expressions(), additional_indent_level);
         }
 
-        // Add any trailing trivia to the lasts expression
-        match expr_list.pop() {
-            Some(pair) => {
-                var_comments_buf.append(&mut expr_comments_buf);
-                // Add on trailing trivia
-                var_comments_buf.append(&mut trailing_trivia);
-                let pair = pair.map(|expr| {
-                    trivia_formatter::expression_add_trailing_trivia(
-                        expr,
-                        FormatTriviaType::Append(var_comments_buf),
-                    )
-                });
-                expr_list.push(pair);
-            }
-            None => panic!("assignment with no expression"),
-        }
+        // Add any trailing trivia to the end of the expression list
+        add_punctuated_trailing_trivia(
+            &mut expr_list,
+            var_comments_buf
+                .iter()
+                .chain(expr_comments_buf.iter())
+                .chain(trailing_trivia.iter())
+                .map(|x| x.to_owned())
+                .collect(),
+            trivia_formatter::expression_add_trailing_trivia,
+        );
 
         // Add on leading trivia
-        let mut formatted_var_list = Punctuated::new();
-        let mut iterator = var_list.pairs();
-
-        // Retrieve first item and add indent to trailing trivia
-        if let Some(first_pair) = iterator.next() {
-            let updated_pair = first_pair.to_owned().map(|value| {
-                trivia_formatter::var_add_leading_trivia(
-                    value,
-                    FormatTriviaType::Append(leading_trivia),
-                )
-            });
-            formatted_var_list.push(updated_pair);
-        }
-        for pair in iterator {
-            formatted_var_list.push(pair.to_owned())
-        }
+        let formatted_var_list = add_punctuated_leading_trivia(
+            var_list,
+            leading_trivia,
+            trivia_formatter::var_add_leading_trivia,
+        );
 
         formatted_assignment
             .with_variables(formatted_var_list)
             .with_expressions(expr_list)
-    }
-
-    /// Returns a LocalAssignment with leading and trailing trivia removed
-    fn strip_local_assignment_trivia<'ast>(
-        local_assignment: &LocalAssignment<'ast>,
-    ) -> LocalAssignment<'ast> {
-        let local_token = trivia_formatter::token_reference_add_trivia(
-            local_assignment.local_token().to_owned(),
-            FormatTriviaType::Replace(vec![]),
-            FormatTriviaType::NoChange,
-        );
-
-        if local_assignment.expressions().is_empty() {
-            let mut name_list = local_assignment.names().to_owned();
-            if let Some(last_pair) = name_list.pop() {
-                name_list.push(last_pair.map(|value| {
-                    trivia_formatter::token_reference_add_trivia(
-                        value,
-                        FormatTriviaType::NoChange,
-                        FormatTriviaType::Replace(vec![]),
-                    )
-                }));
-            }
-
-            LocalAssignment::new(name_list).with_local_token(local_token)
-        } else {
-            let mut expr_list = local_assignment.expressions().to_owned();
-            if let Some(last_pair) = expr_list.pop() {
-                expr_list.push(last_pair.map(|value| {
-                    trivia_formatter::expression_add_trailing_trivia(
-                        value,
-                        FormatTriviaType::Replace(vec![]),
-                    )
-                }));
-            }
-            LocalAssignment::new(local_assignment.names().to_owned())
-                .with_local_token(local_token)
-                .with_equal_token(local_assignment.equal_token().map(|x| x.to_owned()))
-                .with_expressions(expr_list)
-        }
     }
 
     pub fn format_local_assignment<'ast>(
@@ -198,7 +233,7 @@ impl CodeFormatter {
             CodeFormatter::get_token_range(assignment.local_token().token()),
         );
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
-        let mut trailing_trivia = vec![self.create_newline_trivia()];
+        let trailing_trivia = vec![self.create_newline_trivia()];
 
         let local_token = trivia_formatter::token_reference_add_trivia(
             crate::fmt_symbol!(self, assignment.local_token(), "local "),
@@ -206,7 +241,7 @@ impl CodeFormatter {
             FormatTriviaType::NoChange,
         );
 
-        let (mut name_list, mut name_list_comments_buf) = self.format_punctuated(
+        let (mut name_list, name_list_comments_buf) = self.format_punctuated(
             assignment.names(),
             &CodeFormatter::format_token_reference_mut,
         );
@@ -235,21 +270,19 @@ impl CodeFormatter {
                 new_line_added = true;
             }
 
-            if let Some(pair) = name_list.pop() {
-                // Add the trailing trivia to the end of the name_list if not already added
-                if !new_line_added {
-                    name_list_comments_buf.append(&mut trailing_trivia);
-                }
-
-                let pair = pair.map(|name| {
-                    trivia_formatter::token_reference_add_trivia(
-                        name.to_owned(),
-                        FormatTriviaType::NoChange,
-                        FormatTriviaType::Append(name_list_comments_buf),
-                    )
-                });
-                name_list.push(pair);
-            }
+            // Add any trailing trivia to the end of the expression list
+            add_punctuated_trailing_trivia(
+                &mut name_list,
+                match new_line_added {
+                    true => name_list_comments_buf,
+                    false => name_list_comments_buf
+                        .iter()
+                        .chain(trailing_trivia.iter())
+                        .map(|x| x.to_owned())
+                        .collect(),
+                },
+                token_reference_add_trailing_trivia,
+            );
 
             let local_assignment = LocalAssignment::new(name_list)
                 .with_local_token(local_token)
@@ -262,7 +295,7 @@ impl CodeFormatter {
         } else {
             let equal_token = crate::fmt_symbol!(self, assignment.equal_token().unwrap(), " = ");
             // Format the expression normally
-            let (mut expr_list, mut expr_comments_buf) =
+            let (mut expr_list, expr_comments_buf) =
                 self.format_punctuated(assignment.expressions(), &CodeFormatter::format_expression);
             // Create our preliminary new assignment
             let local_assignment = LocalAssignment::new(name_list)
@@ -278,7 +311,7 @@ impl CodeFormatter {
             let indent_spacing = (self.indent_level + additional_indent_level.unwrap_or(0))
                 * self.config.indent_width;
             let require_multiline_expression = indent_spacing
-                + CodeFormatter::strip_local_assignment_trivia(&local_assignment)
+                + strip_local_assignment_trivia(&local_assignment)
                     .to_string()
                     .lines()
                     .next()
@@ -294,47 +327,21 @@ impl CodeFormatter {
 
             // Format the expression depending on whether we are multline or not
             if require_multiline_expression {
-                // Add the expression list into the indent range, as it will be indented by one
-                let expr_range = assignment
-                    .expressions()
-                    .range()
-                    .expect("no range for local assignment expr");
-                self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-
-                expr_list = Punctuated::new();
-
-                // Format each expression and hang them
-                // We need to format again because we will now take into account the indent increase
-                for pair in assignment.expressions().pairs() {
-                    let expr = self.format_expression(pair.value());
-                    let value = self.hang_expression_no_trailing_newline(
-                        expr,
-                        additional_indent_level,
-                        None,
-                    );
-                    expr_list.push(Pair::new(
-                        value,
-                        pair.punctuation()
-                            .map(|x| crate::fmt_symbol!(self, x, ", ")),
-                    ))
-                }
+                expr_list =
+                    self.hang_punctuated_list(assignment.expressions(), additional_indent_level);
             }
 
             // Add any trailing trivia to the end of the expression list
-            if let Some(pair) = expr_list.pop() {
-                // Append any comments to the end of the pair
-                name_list_comments_buf.append(&mut expr_comments_buf);
-                // Append any trailing trivia, if we aren't hanging the expression
-                name_list_comments_buf.append(&mut trailing_trivia);
-
-                let pair = pair.map(|expr| {
-                    trivia_formatter::expression_add_trailing_trivia(
-                        expr,
-                        FormatTriviaType::Append(name_list_comments_buf),
-                    )
-                });
-                expr_list.push(pair);
-            }
+            add_punctuated_trailing_trivia(
+                &mut expr_list,
+                name_list_comments_buf
+                    .iter()
+                    .chain(expr_comments_buf.iter())
+                    .chain(trailing_trivia.iter())
+                    .map(|x| x.to_owned())
+                    .collect(),
+                trivia_formatter::expression_add_trailing_trivia,
+            );
 
             // Update our local assignment
             local_assignment.with_expressions(expr_list)

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -19,7 +19,7 @@ impl CodeFormatter {
         let mut var_list = Punctuated::new();
         let mut added_first = false;
 
-        for pair in assignment.var_list().pairs() {
+        for pair in assignment.variables().pairs() {
             if added_first {
                 var_list.push(pair.to_owned());
             } else {
@@ -33,7 +33,7 @@ impl CodeFormatter {
             }
         }
 
-        let mut expr_list = assignment.expr_list().to_owned();
+        let mut expr_list = assignment.expressions().to_owned();
         if let Some(last_pair) = expr_list.pop() {
             expr_list.push(last_pair.map(|value| {
                 trivia_formatter::expression_add_trailing_trivia(
@@ -58,10 +58,10 @@ impl CodeFormatter {
         let mut trailing_trivia = vec![self.create_newline_trivia()];
 
         let (var_list, mut var_comments_buf) =
-            self.format_punctuated(assignment.var_list(), &CodeFormatter::format_var);
+            self.format_punctuated(assignment.variables(), &CodeFormatter::format_var);
 
         let (mut expr_list, mut expr_comments_buf) =
-            self.format_punctuated(assignment.expr_list(), &CodeFormatter::format_expression);
+            self.format_punctuated(assignment.expressions(), &CodeFormatter::format_expression);
 
         // Create preliminary assignment
         let formatted_assignment = Assignment::new(var_list.to_owned(), expr_list.to_owned())
@@ -80,7 +80,7 @@ impl CodeFormatter {
                 .expect("no lines")
                 .len()
             > self.config.column_width
-            || assignment.expr_list().pairs().any(|pair| {
+            || assignment.expressions().pairs().any(|pair| {
                 pair.punctuation()
                     .map_or(false, |punc| trivia_util::token_contains_comments(punc))
                     || trivia_util::expression_contains_inline_comments(pair.value())
@@ -89,7 +89,7 @@ impl CodeFormatter {
         if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
             let expr_range = assignment
-                .expr_list()
+                .expressions()
                 .range()
                 .expect("no range for assignment expr");
             self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
@@ -97,7 +97,7 @@ impl CodeFormatter {
             expr_list = Punctuated::new();
             // Format each expression and hang them
             // We need to format again because we will now take into account the indent increase
-            for pair in assignment.expr_list().pairs() {
+            for pair in assignment.expressions().pairs() {
                 let expr = self.format_expression(pair.value());
                 let value =
                     self.hang_expression_no_trailing_newline(expr, additional_indent_level, None);
@@ -145,8 +145,8 @@ impl CodeFormatter {
         }
 
         formatted_assignment
-            .with_var_list(formatted_var_list)
-            .with_expr_list(expr_list)
+            .with_variables(formatted_var_list)
+            .with_expressions(expr_list)
     }
 
     /// Returns a LocalAssignment with leading and trailing trivia removed
@@ -159,8 +159,8 @@ impl CodeFormatter {
             FormatTriviaType::NoChange,
         );
 
-        if local_assignment.expr_list().is_empty() {
-            let mut name_list = local_assignment.name_list().to_owned();
+        if local_assignment.expressions().is_empty() {
+            let mut name_list = local_assignment.names().to_owned();
             if let Some(last_pair) = name_list.pop() {
                 name_list.push(last_pair.map(|value| {
                     Cow::Owned(trivia_formatter::token_reference_add_trivia(
@@ -173,7 +173,7 @@ impl CodeFormatter {
 
             LocalAssignment::new(name_list).with_local_token(Cow::Owned(local_token))
         } else {
-            let mut expr_list = local_assignment.expr_list().to_owned();
+            let mut expr_list = local_assignment.expressions().to_owned();
             if let Some(last_pair) = expr_list.pop() {
                 expr_list.push(last_pair.map(|value| {
                     trivia_formatter::expression_add_trailing_trivia(
@@ -182,14 +182,14 @@ impl CodeFormatter {
                     )
                 }));
             }
-            LocalAssignment::new(local_assignment.name_list().to_owned())
+            LocalAssignment::new(local_assignment.names().to_owned())
                 .with_local_token(Cow::Owned(local_token))
                 .with_equal_token(
                     local_assignment
                         .equal_token()
                         .map(|x| Cow::Owned(x.to_owned())),
                 )
-                .with_expr_list(expr_list)
+                .with_expressions(expr_list)
         }
     }
 
@@ -213,7 +213,7 @@ impl CodeFormatter {
         ));
 
         let (mut name_list, mut name_list_comments_buf) = self.format_punctuated(
-            assignment.name_list(),
+            assignment.names(),
             &CodeFormatter::format_token_reference_mut,
         );
 
@@ -226,7 +226,7 @@ impl CodeFormatter {
             })
             .collect();
 
-        if assignment.expr_list().is_empty() {
+        if assignment.expressions().is_empty() {
             // See if the last variable assigned has a type specifier, and add a new line to that
             #[allow(unused_mut)]
             let mut new_line_added = false;
@@ -262,7 +262,7 @@ impl CodeFormatter {
             let local_assignment = LocalAssignment::new(name_list)
                 .with_local_token(local_token)
                 .with_equal_token(None)
-                .with_expr_list(Punctuated::new());
+                .with_expressions(Punctuated::new());
 
             #[cfg(feature = "luau")]
             let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
@@ -271,12 +271,12 @@ impl CodeFormatter {
             let equal_token = crate::fmt_symbol!(self, assignment.equal_token().unwrap(), " = ");
             // Format the expression normally
             let (mut expr_list, mut expr_comments_buf) =
-                self.format_punctuated(assignment.expr_list(), &CodeFormatter::format_expression);
+                self.format_punctuated(assignment.expressions(), &CodeFormatter::format_expression);
             // Create our preliminary new assignment
             let local_assignment = LocalAssignment::new(name_list)
                 .with_local_token(local_token)
                 .with_equal_token(Some(equal_token))
-                .with_expr_list(expr_list.to_owned());
+                .with_expressions(expr_list.to_owned());
             #[cfg(feature = "luau")]
             let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
 
@@ -293,7 +293,7 @@ impl CodeFormatter {
                     .expect("no lines")
                     .len()
                 > self.config.column_width
-                || assignment.expr_list().pairs().any(|pair| {
+                || assignment.expressions().pairs().any(|pair| {
                     pair.punctuation()
                         .map_or(false, |punc| trivia_util::token_contains_comments(punc))
                         || trivia_util::expression_contains_inline_comments(pair.value())
@@ -304,7 +304,7 @@ impl CodeFormatter {
             if require_multiline_expression {
                 // Add the expression list into the indent range, as it will be indented by one
                 let expr_range = assignment
-                    .expr_list()
+                    .expressions()
                     .range()
                     .expect("no range for local assignment expr");
                 self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
@@ -313,7 +313,7 @@ impl CodeFormatter {
 
                 // Format each expression and hang them
                 // We need to format again because we will now take into account the indent increase
-                for pair in assignment.expr_list().pairs() {
+                for pair in assignment.expressions().pairs() {
                     let expr = self.format_expression(pair.value());
                     let value = self.hang_expression_no_trailing_newline(
                         expr,
@@ -345,7 +345,7 @@ impl CodeFormatter {
             }
 
             // Update our local assignment
-            local_assignment.with_expr_list(expr_list)
+            local_assignment.with_expressions(expr_list)
         }
     }
 }

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -20,7 +20,7 @@ macro_rules! update_first_token {
             FormatTriviaType::Replace(leading_trivia),
             FormatTriviaType::NoChange,
         );
-        Stmt::$enum($var.$update_method(Cow::Owned(new_token)))
+        Stmt::$enum($var.$update_method(new_token))
     }};
 }
 impl CodeFormatter {
@@ -98,7 +98,7 @@ impl CodeFormatter {
 
         let formatted_token = if formatted_returns.is_empty() {
             trivia_formatter::token_reference_add_trivia(
-                crate::fmt_symbol!(self, return_node.token(), "return").into_owned(),
+                crate::fmt_symbol!(self, return_node.token(), "return"),
                 FormatTriviaType::Append(leading_trivia),
                 FormatTriviaType::Append(trailing_trivia),
             )
@@ -153,14 +153,14 @@ impl CodeFormatter {
             }
 
             trivia_formatter::token_reference_add_trivia(
-                crate::fmt_symbol!(self, return_node.token(), "return ").into_owned(),
+                crate::fmt_symbol!(self, return_node.token(), "return "),
                 FormatTriviaType::Append(leading_trivia),
                 FormatTriviaType::NoChange,
             )
         };
 
         Return::new()
-            .with_token(Cow::Owned(formatted_token))
+            .with_token(formatted_token)
             .with_returns(formatted_returns)
     }
 
@@ -169,19 +169,19 @@ impl CodeFormatter {
 
         match last_stmt {
             LastStmt::Break(token) => {
-                LastStmt::Break(Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                    crate::fmt_symbol!(self, token, "break").into_owned(),
+                LastStmt::Break(trivia_formatter::token_reference_add_trivia(
+                    crate::fmt_symbol!(self, token, "break"),
                     FormatTriviaType::Append(vec![self.create_indent_trivia(
                         self.get_range_indent_increase(CodeFormatter::get_token_range(token)),
                     )]),
                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
-                )))
+                ))
             }
 
             LastStmt::Return(return_node) => LastStmt::Return(self.format_return(return_node)),
             #[cfg(feature = "luau")]
             LastStmt::Continue(token) => {
-                LastStmt::Continue(Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                LastStmt::Continue(trivia_formatter::token_reference_add_trivia(
                     self.format_symbol(
                         token,
                         &TokenReference::new(
@@ -191,13 +191,12 @@ impl CodeFormatter {
                             }),
                             vec![],
                         ),
-                    )
-                    .into_owned(),
+                    ),
                     FormatTriviaType::Append(vec![self.create_indent_trivia(
                         self.get_range_indent_increase(CodeFormatter::get_token_range(token)),
                     )]),
                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
-                )))
+                ))
             }
 
             other => panic!("unknown node {:?}", other),
@@ -221,11 +220,11 @@ impl CodeFormatter {
                 let leading_trivia =
                     CodeFormatter::trivia_remove_leading_newlines(token.leading_trivia().collect());
                 let new_token = trivia_formatter::token_reference_add_trivia(
-                    token.to_owned().into_owned(),
+                    token.to_owned(),
                     FormatTriviaType::Replace(leading_trivia),
                     FormatTriviaType::NoChange,
                 );
-                Prefix::Name(Cow::Owned(new_token))
+                Prefix::Name(new_token)
             }
             Prefix::Expression(expr) => Prefix::Expression(match expr {
                 Expression::Parentheses {
@@ -243,8 +242,8 @@ impl CodeFormatter {
                     );
                     Expression::Parentheses {
                         contained: full_moon::ast::span::ContainedSpan::new(
-                            Cow::Owned(new_token),
-                            Cow::Owned(end_parens.to_owned()),
+                            new_token,
+                            end_parens.to_owned(),
                         ),
                         expression: Box::new(*expression.to_owned()),
                     }
@@ -264,11 +263,11 @@ impl CodeFormatter {
                 let leading_trivia =
                     CodeFormatter::trivia_remove_leading_newlines(token.leading_trivia().collect());
                 let new_token = trivia_formatter::token_reference_add_trivia(
-                    token.into_owned(),
+                    token,
                     FormatTriviaType::Replace(leading_trivia),
                     FormatTriviaType::NoChange,
                 );
-                Var::Name(Cow::Owned(new_token))
+                Var::Name(new_token)
             }
             Var::Expression(var_expr) => {
                 let prefix = CodeFormatter::prefix_remove_leading_newlines(var_expr.prefix());
@@ -385,21 +384,21 @@ impl CodeFormatter {
                 let leading_trivia =
                     CodeFormatter::trivia_remove_leading_newlines(token.leading_trivia().collect());
                 let new_token = trivia_formatter::token_reference_add_trivia(
-                    token.into_owned(),
+                    token,
                     FormatTriviaType::Replace(leading_trivia),
                     FormatTriviaType::NoChange,
                 );
-                LastStmt::Break(Cow::Owned(new_token))
+                LastStmt::Break(new_token)
             }
             LastStmt::Return(return_node) => {
                 let old_token = return_node.token();
-                let token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                let token = trivia_formatter::token_reference_add_trivia(
                     old_token.to_owned(),
                     FormatTriviaType::Replace(CodeFormatter::trivia_remove_leading_newlines(
                         old_token.leading_trivia().collect(),
                     )),
                     FormatTriviaType::NoChange,
-                ));
+                );
 
                 LastStmt::Return(return_node.with_token(token))
             }
@@ -408,19 +407,18 @@ impl CodeFormatter {
                 let leading_trivia =
                     CodeFormatter::trivia_remove_leading_newlines(token.leading_trivia().collect());
                 let new_token = trivia_formatter::token_reference_add_trivia(
-                    token.into_owned(),
+                    token,
                     FormatTriviaType::Replace(leading_trivia),
                     FormatTriviaType::NoChange,
                 );
-                LastStmt::Continue(Cow::Owned(new_token))
+                LastStmt::Continue(new_token)
             }
             other => panic!("unknown node {:?}", other),
         }
     }
 
     pub fn format_block<'ast>(&mut self, block: Block<'ast>) -> Block<'ast> {
-        let mut formatted_statements: Vec<(Stmt<'ast>, Option<Cow<'ast, TokenReference<'ast>>>)> =
-            Vec::new();
+        let mut formatted_statements: Vec<(Stmt<'ast>, Option<TokenReference<'ast>>)> = Vec::new();
         let mut found_first_stmt = false;
         let mut stmt_iterator = block.stmts_with_semicolon().peekable();
         while let Some((stmt, semi)) = stmt_iterator.next() {
@@ -460,14 +458,14 @@ impl CodeFormatter {
                 true => {
                     let (updated_stmt, trivia) = trivia_util::get_stmt_trailing_trivia(stmt);
                     stmt = updated_stmt;
-                    Some(Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                    Some(trivia_formatter::token_reference_add_trivia(
                         match semi {
-                            Some(semi) => crate::fmt_symbol!(self, semi, ";").into_owned(),
+                            Some(semi) => crate::fmt_symbol!(self, semi, ";"),
                             None => TokenReference::symbol(";").expect("could not make semicolon"),
                         },
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append(trivia),
-                    )))
+                    ))
                 }
                 false => match semi {
                     Some(semi) => {
@@ -476,7 +474,7 @@ impl CodeFormatter {
                         let (updated_stmt, trivia) = trivia_util::get_stmt_trailing_trivia(stmt);
                         stmt = updated_stmt;
                         // We will do a hack here, where we insert an empty token, and add all the remaining trivia onto it
-                        Some(Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                        Some(trivia_formatter::token_reference_add_trivia(
                             self.format_symbol(
                                 semi,
                                 &TokenReference::new(
@@ -484,11 +482,10 @@ impl CodeFormatter {
                                     Token::new(TokenType::spaces(0)),
                                     vec![],
                                 ),
-                            )
-                            .into_owned(),
+                            ),
                             FormatTriviaType::NoChange,
                             FormatTriviaType::Append(trivia),
-                        )))
+                        ))
                     }
                     None => None,
                 },

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -57,7 +57,9 @@ impl CodeFormatter {
                         table_constructor.braces().tokens().0.token(),
                     ),
                     Value::Number(token_ref) => CodeFormatter::get_token_range(token_ref.token()),
-                    Value::ParseExpression(expr) => CodeFormatter::get_range_in_expression(&expr),
+                    Value::ParenthesesExpression(expr) => {
+                        CodeFormatter::get_range_in_expression(&expr)
+                    }
                     Value::String(token_ref) => CodeFormatter::get_token_range(token_ref.token()),
                     Value::Symbol(token_ref) => CodeFormatter::get_token_range(token_ref.token()),
                     Value::Var(var) => match var {

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -43,6 +43,7 @@ impl CodeFormatter {
                 UnOp::Hash(token_reference) => {
                     CodeFormatter::get_token_range(token_reference.token())
                 }
+                other => panic!("unknown node {:?}", other),
             },
             Expression::BinaryOperator { lhs, .. } => CodeFormatter::get_range_in_expression(lhs),
             Expression::Value { value, .. } => {
@@ -68,9 +69,12 @@ impl CodeFormatter {
                         Var::Expression(var_expr) => {
                             CodeFormatter::get_range_in_prefix(var_expr.prefix())
                         }
+                        other => panic!("unknown node {:?}", other),
                     },
+                    other => panic!("unknown node {:?}", other),
                 }
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -78,6 +82,7 @@ impl CodeFormatter {
         match prefix {
             Prefix::Name(token) => CodeFormatter::get_token_range(token.token()),
             Prefix::Expression(expression) => CodeFormatter::get_range_in_expression(expression),
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -194,6 +199,8 @@ impl CodeFormatter {
                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                 )))
             }
+
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -246,6 +253,8 @@ impl CodeFormatter {
                     unreachable!("got non-parentheses expression as prefix {:?}", other)
                 }
             }),
+
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -265,6 +274,7 @@ impl CodeFormatter {
                 let prefix = CodeFormatter::prefix_remove_leading_newlines(var_expr.prefix());
                 Var::Expression(var_expr.with_prefix(prefix))
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -365,6 +375,7 @@ impl CodeFormatter {
                 type_declaration.type_token(),
                 with_type_token
             ),
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -403,6 +414,7 @@ impl CodeFormatter {
                 );
                 LastStmt::Continue(Cow::Owned(new_token))
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -273,7 +273,7 @@ impl CodeFormatter {
             Stmt::Assignment(assignment) => {
                 let mut var_list = Punctuated::new();
 
-                for (idx, pair) in assignment.var_list().pairs().enumerate() {
+                for (idx, pair) in assignment.variables().pairs().enumerate() {
                     if idx == 0 {
                         let pair = pair
                             .to_owned()
@@ -284,7 +284,7 @@ impl CodeFormatter {
                     }
                 }
 
-                Stmt::Assignment(assignment.with_var_list(var_list))
+                Stmt::Assignment(assignment.with_variables(var_list))
             }
             Stmt::Do(do_block) => {
                 update_first_token!(Do, do_block, do_block.do_token(), with_do_token)
@@ -410,7 +410,7 @@ impl CodeFormatter {
         let mut formatted_statements: Vec<(Stmt<'ast>, Option<Cow<'ast, TokenReference<'ast>>>)> =
             Vec::new();
         let mut found_first_stmt = false;
-        let mut stmt_iterator = block.iter_stmts_with_semicolon().peekable();
+        let mut stmt_iterator = block.stmts_with_semicolon().peekable();
         while let Some((stmt, semi)) = stmt_iterator.next() {
             let mut stmt = self.format_stmt(stmt);
 

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -9,6 +9,7 @@ use full_moon::ast::{
 use full_moon::node::Node;
 use full_moon::tokenizer::TokenType;
 use full_moon::tokenizer::{Token, TokenReference};
+#[cfg(feature = "luau")]
 use std::borrow::Cow;
 
 macro_rules! update_first_token {

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -201,7 +201,7 @@ impl CodeFormatter {
     ) -> VarExpression<'ast> {
         let formatted_prefix = self.format_prefix(var_expression.prefix());
         let formatted_suffixes = var_expression
-            .iter_suffixes()
+            .suffixes()
             .map(|x| self.format_suffix(x))
             .collect();
 

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -11,6 +11,7 @@ macro_rules! fmt_op {
             $(
                 $enum::$operator(token) => $enum::$operator(crate::fmt_symbol!($fmter, token, $output)),
             )+
+            other => panic!("unknown node {:?}", other),
         }
     };
 }
@@ -70,6 +71,7 @@ impl CodeFormatter {
                     _ => true,
                 }
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -116,6 +118,7 @@ impl CodeFormatter {
                 binop: self.format_binop(binop),
                 rhs: Box::new(self.format_expression(rhs)),
             },
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -134,6 +137,7 @@ impl CodeFormatter {
                 dot: self.format_token_reference(dot),
                 name: self.format_token_reference(name),
             },
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -146,6 +150,7 @@ impl CodeFormatter {
             Prefix::Name(token_reference) => {
                 Prefix::Name(self.format_token_reference(token_reference))
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -154,6 +159,7 @@ impl CodeFormatter {
         match suffix {
             Suffix::Call(call) => Suffix::Call(self.format_call(call)),
             Suffix::Index(index) => Suffix::Index(self.format_index(index)),
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -182,6 +188,7 @@ impl CodeFormatter {
                 Value::TableConstructor(self.format_table_constructor(table_constructor))
             }
             Value::Var(var) => Value::Var(self.format_var(var)),
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -192,6 +199,7 @@ impl CodeFormatter {
             Var::Expression(var_expression) => {
                 Var::Expression(self.format_var_expression(var_expression))
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -79,12 +79,12 @@ impl CodeFormatter {
             Expression::Value {
                 value,
                 #[cfg(feature = "luau")]
-                as_assertion,
+                type_assertion,
             } => Expression::Value {
                 value: Box::new(self.format_value(value)),
                 #[cfg(feature = "luau")]
-                as_assertion: match as_assertion {
-                    Some(assertion) => Some(self.format_as_assertion(assertion)),
+                type_assertion: match type_assertion {
+                    Some(assertion) => Some(self.format_type_assertion(assertion)),
                     None => None,
                 },
             },

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -181,8 +181,8 @@ impl CodeFormatter {
             Value::Number(token_reference) => {
                 Value::Number(self.format_token_reference(token_reference))
             }
-            Value::ParseExpression(expression) => {
-                Value::ParseExpression(self.format_expression(expression))
+            Value::ParenthesesExpression(expression) => {
+                Value::ParenthesesExpression(self.format_expression(expression))
             }
             Value::String(token_reference) => {
                 Value::String(self.format_token_reference(token_reference))

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -631,7 +631,7 @@ impl CodeFormatter {
     ) -> FunctionCall<'ast> {
         let formatted_prefix = self.format_prefix(function_call.prefix());
         let formatted_suffixes = function_call
-            .iter_suffixes()
+            .suffixes()
             .map(|x| self.format_suffix(x))
             .collect();
 
@@ -721,7 +721,7 @@ impl CodeFormatter {
 
         let function_token = crate::fmt_symbol!(self, local_function.function_token(), "function ");
         let formatted_name = Cow::Owned(self.format_plain_token_reference(local_function.name()));
-        let formatted_function_body = self.format_function_body(local_function.func_body(), true);
+        let formatted_function_body = self.format_function_body(local_function.body(), true);
 
         LocalFunction::new(formatted_name)
             .with_local_token(local_token)

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -6,11 +6,9 @@ use full_moon::ast::{
 };
 use full_moon::node::Node;
 use full_moon::tokenizer::{Symbol, Token, TokenKind, TokenReference, TokenType};
-use std::borrow::Cow;
 use std::boxed::Box;
 
 use crate::formatters::{
-    get_line_ending_character,
     trivia_formatter::{self, FormatTriviaType},
     trivia_util, CodeFormatter,
 };
@@ -22,7 +20,7 @@ impl CodeFormatter {
         &mut self,
         function_token: &TokenReference<'ast>,
         function_body: &FunctionBody<'ast>,
-    ) -> (Cow<'ast, TokenReference<'ast>>, FunctionBody<'ast>) {
+    ) -> (TokenReference<'ast>, FunctionBody<'ast>) {
         let function_token_range = CodeFormatter::get_token_range(function_token.token());
         let additional_indent_level = self.get_range_indent_increase(function_token_range); //code_formatter.get_token_indent_increase(function_token.token());
 
@@ -66,11 +64,11 @@ impl CodeFormatter {
             function_body = function_body.with_parameters_parentheses(parameters_parentheses);
         };
 
-        let end_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
+        let end_token = trivia_formatter::token_reference_add_trivia(
             function_body.end_token().to_owned(),
             FormatTriviaType::Append(vec![self.create_indent_trivia(additional_indent_level)]),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         (function_token, function_body.with_end_token(end_token))
     }
@@ -288,7 +286,7 @@ impl CodeFormatter {
                     // Add new_line trivia to start_parens
                     let start_parens_token = crate::fmt_symbol!(self, start_parens, "(");
                     let start_parens_token = trivia_formatter::token_reference_add_trivia(
-                        start_parens_token.into_owned(),
+                        start_parens_token,
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                     );
@@ -302,7 +300,7 @@ impl CodeFormatter {
                     );
 
                     let parentheses = ContainedSpan::new(
-                        Cow::Owned(start_parens_token),
+                        start_parens_token,
                         self.format_symbol(end_parens, &end_parens_token),
                     );
 
@@ -370,22 +368,18 @@ impl CodeFormatter {
                                 // Continue adding a comma and a new line for multiline function args
                                 let symbol = crate::fmt_symbol!(self, punctuation, ",");
                                 let symbol = trivia_formatter::token_reference_add_trivia(
-                                    symbol.into_owned(),
+                                    symbol,
                                     FormatTriviaType::NoChange,
                                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                                 );
 
-                                Some(Cow::Owned(symbol))
+                                Some(symbol)
                             }
-                            None => Some(Cow::Owned(TokenReference::new(
+                            None => Some(TokenReference::new(
                                 vec![],
-                                Token::new(TokenType::Whitespace {
-                                    characters: Cow::Owned(get_line_ending_character(
-                                        &self.config.line_endings,
-                                    )),
-                                }),
+                                self.create_newline_trivia(),
                                 vec![],
-                            ))),
+                            )),
                         };
 
                         formatted_arguments.push(Pair::new(formatted_argument, punctuation))
@@ -422,16 +416,16 @@ impl CodeFormatter {
                     // Recreate parentheses with the comments removed from the opening parens
                     // and all the comments placed at the end of the closing parens
                     let parentheses = ContainedSpan::new(
-                        Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                        trivia_formatter::token_reference_add_trivia(
                             start_parens.to_owned(),
                             FormatTriviaType::NoChange,
                             FormatTriviaType::Replace(vec![]),
-                        )),
-                        Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                        ),
+                        trivia_formatter::token_reference_add_trivia(
                             end_parens.to_owned(),
                             FormatTriviaType::NoChange,
                             FormatTriviaType::Append(parens_comments),
-                        )),
+                        ),
                     );
 
                     FunctionArgs::Parentheses {
@@ -456,8 +450,8 @@ impl CodeFormatter {
                 // Create parentheses, and add the trailing comments to the end of the parentheses
                 let parentheses = trivia_formatter::contained_span_add_trivia(
                     ContainedSpan::new(
-                        Cow::Owned(TokenReference::symbol("(").unwrap()),
-                        Cow::Owned(TokenReference::symbol(")").unwrap()),
+                        TokenReference::symbol("(").unwrap(),
+                        TokenReference::symbol(")").unwrap(),
                     ),
                     FormatTriviaType::NoChange,
                     FormatTriviaType::Append(comments_buffer),
@@ -486,8 +480,8 @@ impl CodeFormatter {
                 // Create parentheses, and add the trailing comments to the end of the parentheses
                 let parentheses = trivia_formatter::contained_span_add_trivia(
                     ContainedSpan::new(
-                        Cow::Owned(TokenReference::symbol("(").unwrap()),
-                        Cow::Owned(TokenReference::symbol(")").unwrap()),
+                        TokenReference::symbol("(").unwrap(),
+                        TokenReference::symbol(")").unwrap(),
                     ),
                     FormatTriviaType::NoChange,
                     FormatTriviaType::Append(comments_buffer),
@@ -537,7 +531,7 @@ impl CodeFormatter {
                 // Add new_line trivia to start_parens
                 let start_parens_token = crate::fmt_symbol!(self, start_parens, "(");
                 let start_parens_token = trivia_formatter::token_reference_add_trivia(
-                    start_parens_token.into_owned(),
+                    start_parens_token,
                     FormatTriviaType::NoChange,
                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                 );
@@ -551,7 +545,7 @@ impl CodeFormatter {
                 );
 
                 ContainedSpan::new(
-                    Cow::Owned(start_parens_token),
+                    start_parens_token,
                     self.format_symbol(end_parens, &end_parens_token),
                 )
             }
@@ -602,12 +596,11 @@ impl CodeFormatter {
         }
 
         let end_token = if add_trivia {
-            Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                self.format_end_token(function_body.end_token())
-                    .into_owned(),
+            trivia_formatter::token_reference_add_trivia(
+                self.format_end_token(function_body.end_token()),
                 FormatTriviaType::Append(leading_trivia),
                 FormatTriviaType::Append(trailing_trivia),
-            ))
+            )
         } else {
             self.format_end_token(function_body.end_token())
         };
@@ -662,16 +655,13 @@ impl CodeFormatter {
             }
         }
 
-        let mut formatted_method: Option<(
-            Cow<'ast, TokenReference<'ast>>,
-            Cow<'ast, TokenReference<'ast>>,
-        )> = None;
+        let mut formatted_method: Option<(TokenReference<'ast>, TokenReference<'ast>)> = None;
 
         if let Some(method_colon) = function_name.method_colon() {
             if let Some(token_reference) = function_name.method_name() {
                 formatted_method = Some((
                     crate::fmt_symbol!(self, method_colon, ":"),
-                    Cow::Owned(self.format_plain_token_reference(token_reference)),
+                    self.format_token_reference(token_reference),
                 ));
             }
         };
@@ -690,12 +680,11 @@ impl CodeFormatter {
         );
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
 
-        let function_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, function_declaration.function_token(), "function ")
-                .into_owned(),
+        let function_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, function_declaration.function_token(), "function "),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::NoChange,
-        ));
+        );
         let formatted_function_name = self.format_function_name(function_declaration.name());
         let formatted_function_body = self.format_function_body(function_declaration.body(), true);
 
@@ -715,14 +704,14 @@ impl CodeFormatter {
         );
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
 
-        let local_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, local_function.local_token(), "local ").into_owned(),
+        let local_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, local_function.local_token(), "local "),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         let function_token = crate::fmt_symbol!(self, local_function.function_token(), "function ");
-        let formatted_name = Cow::Owned(self.format_plain_token_reference(local_function.name()));
+        let formatted_name = self.format_token_reference(local_function.name());
         let formatted_function_body = self.format_function_body(local_function.body(), true);
 
         LocalFunction::new(formatted_name)
@@ -733,12 +722,12 @@ impl CodeFormatter {
 
     /// Formats a MethodCall node
     pub fn format_method_call<'ast>(&mut self, method_call: &MethodCall<'ast>) -> MethodCall<'ast> {
-        let formatted_colon_token = self.format_plain_token_reference(method_call.colon_token());
-        let formatted_name = self.format_plain_token_reference(method_call.name());
+        let formatted_colon_token = self.format_token_reference(method_call.colon_token());
+        let formatted_name = self.format_token_reference(method_call.name());
         let formatted_function_args = self.format_function_args(method_call.args());
 
-        MethodCall::new(Cow::Owned(formatted_name), formatted_function_args)
-            .with_colon_token(Cow::Owned(formatted_colon_token))
+        MethodCall::new(formatted_name, formatted_function_args)
+            .with_colon_token(formatted_colon_token)
     }
 
     /// Formats a single Parameter node
@@ -755,10 +744,9 @@ impl CodeFormatter {
     // Checks whether the input Parameter contains comments
     fn parameter_contains_comments(parameter: &Parameter<'_>) -> bool {
         match parameter {
-            Parameter::Ellipse(token) | Parameter::Name(token) => match token {
-                Cow::Owned(t) => trivia_util::token_contains_comments(&t),
-                Cow::Borrowed(t) => trivia_util::token_contains_comments(t),
-            },
+            Parameter::Ellipse(token) | Parameter::Name(token) => {
+                trivia_util::token_contains_comments(token)
+            }
             other => panic!("unknown node {:?}", other),
         }
     }
@@ -792,12 +780,12 @@ impl CodeFormatter {
 
             let formatted_punctuation = match pair.punctuation() {
                 Some(punctuation) => Some(match force_multiline {
-                    true => Cow::Owned(trivia_formatter::token_reference_add_trivia(
+                    true => trivia_formatter::token_reference_add_trivia(
                         // Create a comma with no trailing space, and instead we will add a newline character
-                        crate::fmt_symbol!(self, punctuation, ",").into_owned(),
+                        crate::fmt_symbol!(self, punctuation, ","),
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append(vec![self.create_newline_trivia()]),
-                    )),
+                    ),
                     // Create a comma, with a trailing space at the end
                     false => crate::fmt_symbol!(self, punctuation, ", "),
                 }),

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -444,7 +444,6 @@ impl CodeFormatter {
                 let mut arguments = Punctuated::new();
                 let new_expression = self.format_expression(&Expression::Value {
                     value: Box::new(Value::String(token_reference.to_owned())),
-                    binop: None,
                     #[cfg(feature = "luau")]
                     as_assertion: None,
                 });
@@ -475,7 +474,6 @@ impl CodeFormatter {
                 let mut arguments = Punctuated::new();
                 let new_expression = self.format_expression(&Expression::Value {
                     value: Box::new(Value::TableConstructor(table_constructor.to_owned())),
-                    binop: None,
                     #[cfg(feature = "luau")]
                     as_assertion: None,
                 });

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -445,7 +445,7 @@ impl CodeFormatter {
                 let new_expression = self.format_expression(&Expression::Value {
                     value: Box::new(Value::String(token_reference.to_owned())),
                     #[cfg(feature = "luau")]
-                    as_assertion: None,
+                    type_assertion: None,
                 });
 
                 // Remove any trailing comments from the expression, and move them into a buffer
@@ -475,7 +475,7 @@ impl CodeFormatter {
                 let new_expression = self.format_expression(&Expression::Value {
                     value: Box::new(Value::TableConstructor(table_constructor.to_owned())),
                     #[cfg(feature = "luau")]
-                    as_assertion: None,
+                    type_assertion: None,
                 });
 
                 // Remove any trailing comments from the expression, and move them into a buffer

--- a/src/formatters/functions_formatter.rs
+++ b/src/formatters/functions_formatter.rs
@@ -82,6 +82,7 @@ impl CodeFormatter {
                 Call::AnonymousCall(self.format_function_args(function_args))
             }
             Call::MethodCall(method_call) => Call::MethodCall(self.format_method_call(method_call)),
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -499,6 +500,7 @@ impl CodeFormatter {
                     arguments,
                 }
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -746,6 +748,7 @@ impl CodeFormatter {
             Parameter::Name(token_reference) => {
                 Parameter::Name(self.format_token_reference(token_reference))
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -756,6 +759,7 @@ impl CodeFormatter {
                 Cow::Owned(t) => trivia_util::token_contains_comments(&t),
                 Cow::Borrowed(t) => trivia_util::token_contains_comments(t),
             },
+            other => panic!("unknown node {:?}", other),
         }
     }
     /// Utilises the FunctionBody iterator to format a list of Parameter nodes

--- a/src/formatters/luau_formatter.rs
+++ b/src/formatters/luau_formatter.rs
@@ -277,6 +277,8 @@ impl CodeFormatter {
 
                 TypeInfo::Union { left, pipe, right }
             }
+
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -306,6 +308,8 @@ impl CodeFormatter {
                     generics,
                 }
             }
+
+            other => panic!("unknown node {:?}", other),
         }
     }
 
@@ -348,6 +352,7 @@ impl CodeFormatter {
 
                 TypeFieldKey::IndexSignature { brackets, inner }
             }
+            other => panic!("unknown node {:?}", other),
         }
     }
 

--- a/src/formatters/luau_formatter.rs
+++ b/src/formatters/luau_formatter.rs
@@ -205,7 +205,7 @@ impl CodeFormatter {
                             // Continue adding a comma and a new line for multiline tables
                             let mut symbol = TokenReference::symbol(",").unwrap();
                             if let Some(punctuation) = punctuation {
-                                symbol = self.format_symbol(&punctuation, &symbol).into_owned();
+                                symbol = self.format_symbol(&punctuation, &symbol);
                             }
                             // Add newline trivia to the end of the symbol
                             let symbol = trivia_formatter::token_reference_add_trivia(
@@ -213,18 +213,17 @@ impl CodeFormatter {
                                 FormatTriviaType::NoChange,
                                 FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                             );
-                            formatted_punctuation = Some(Cow::Owned(symbol))
+                            formatted_punctuation = Some(symbol)
                         }
 
                         false => {
                             if current_fields.peek().is_some() {
                                 // Have more elements still to go
                                 formatted_punctuation = match punctuation {
-                                    Some(punctuation) => Some(self.format_symbol(
-                                        &punctuation,
-                                        &TokenReference::symbol(", ").unwrap(),
-                                    )),
-                                    None => Some(Cow::Owned(TokenReference::symbol(", ").unwrap())),
+                                    Some(punctuation) => {
+                                        Some(crate::fmt_symbol!(self, &punctuation, ", "))
+                                    }
+                                    None => Some(TokenReference::symbol(", ").unwrap()),
                                 }
                             };
                         }
@@ -336,11 +335,11 @@ impl CodeFormatter {
     ) -> TypeFieldKey<'ast> {
         match type_field_key {
             TypeFieldKey::Name(token) => {
-                TypeFieldKey::Name(Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                    self.format_token_reference(token).into_owned(),
+                TypeFieldKey::Name(trivia_formatter::token_reference_add_trivia(
+                    self.format_token_reference(token),
                     leading_trivia,
                     FormatTriviaType::NoChange,
-                )))
+                ))
             }
             TypeFieldKey::IndexSignature { brackets, inner } => {
                 let brackets = trivia_formatter::contained_span_add_trivia(
@@ -390,14 +389,14 @@ impl CodeFormatter {
 
         if add_leading_trivia {
             let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
-            type_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                type_token.into_owned(),
+            type_token = trivia_formatter::token_reference_add_trivia(
+                type_token,
                 FormatTriviaType::Append(leading_trivia),
                 FormatTriviaType::NoChange,
-            ))
+            )
         }
 
-        let type_name = Cow::Owned(self.format_plain_token_reference(type_declaration.type_name()));
+        let type_name = self.format_token_reference(type_declaration.type_name());
         let generics = match type_declaration.generics() {
             Some(generics) => Some(self.format_generic_declaration(generics)),
             None => None,
@@ -467,7 +466,7 @@ impl CodeFormatter {
         );
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
 
-        let export_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
+        let export_token = trivia_formatter::token_reference_add_trivia(
             self.format_symbol(
                 exported_type_declaration.export_token(),
                 &TokenReference::new(
@@ -477,11 +476,10 @@ impl CodeFormatter {
                     }),
                     vec![Token::new(TokenType::spaces(1))],
                 ),
-            )
-            .into_owned(),
+            ),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::NoChange,
-        ));
+        );
         let type_declaration =
             self.format_type_declaration(exported_type_declaration.type_declaration(), false);
 

--- a/src/formatters/luau_formatter.rs
+++ b/src/formatters/luau_formatter.rs
@@ -4,8 +4,8 @@ use crate::formatters::{
     CodeFormatter,
 };
 use full_moon::ast::types::{
-    AsAssertion, CompoundAssignment, CompoundOp, ExportedTypeDeclaration, GenericDeclaration,
-    IndexedTypeInfo, TypeDeclaration, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier,
+    CompoundAssignment, CompoundOp, ExportedTypeDeclaration, GenericDeclaration, IndexedTypeInfo,
+    TypeAssertion, TypeDeclaration, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier,
 };
 use full_moon::ast::{
     punctuated::{Pair, Punctuated},
@@ -351,26 +351,14 @@ impl CodeFormatter {
         }
     }
 
-    pub fn format_as_assertion<'ast>(
+    pub fn format_type_assertion<'ast>(
         &mut self,
-        as_assertion: &AsAssertion<'ast>,
-    ) -> AsAssertion<'ast> {
-        let as_token = self.format_symbol(
-            as_assertion.as_token(),
-            &TokenReference::new(
-                vec![],
-                Token::new(TokenType::Identifier {
-                    identifier: Cow::Owned(String::from("as")),
-                }),
-                vec![Token::new(TokenType::spaces(1))],
-            ),
-        );
-        let cast_to = self.format_type_info(as_assertion.cast_to());
+        type_assertion: &TypeAssertion<'ast>,
+    ) -> TypeAssertion<'ast> {
+        let assertion_op = crate::fmt_symbol!(self, type_assertion.assertion_op(), " :: ");
+        let cast_to = self.format_type_info(type_assertion.cast_to());
 
-        as_assertion
-            .to_owned()
-            .with_as_token(as_token)
-            .with_cast_to(cast_to)
+        TypeAssertion::new(cast_to).with_assertion_op(assertion_op)
     }
 
     fn format_type_declaration<'ast>(

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -14,6 +14,7 @@ macro_rules! fmt_stmt {
                 $(#[$inner])*
                 Stmt::$operator(stmt) => Stmt::$operator($fmter.$output(stmt)),
             )+
+            other => panic!("unknown node {:?}", other),
         }
     };
 }

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -5,7 +5,6 @@ use crate::formatters::{
 use full_moon::ast::{Do, ElseIf, FunctionCall, GenericFor, If, NumericFor, Repeat, Stmt, While};
 use full_moon::node::Node;
 use full_moon::tokenizer::TokenReference;
-use std::borrow::Cow;
 
 macro_rules! fmt_stmt {
     ($fmter:expr, $value:ident, { $($(#[$inner:meta])* $operator:ident = $output:ident,)+ }) => {
@@ -30,20 +29,20 @@ impl CodeFormatter {
         let trailing_trivia = FormatTriviaType::Append(vec![self.create_newline_trivia()]);
 
         let do_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, do_block.do_token(), "do").into_owned(),
+            crate::fmt_symbol!(self, do_block.do_token(), "do"),
             leading_trivia.to_owned(),
             trailing_trivia.to_owned(),
         );
         let end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(do_block.end_token()).into_owned(),
+            self.format_end_token(do_block.end_token()),
             leading_trivia,
             trailing_trivia,
         );
 
         do_block
             .to_owned()
-            .with_do_token(Cow::Owned(do_token))
-            .with_end_token(Cow::Owned(end_token))
+            .with_do_token(do_token)
+            .with_end_token(end_token)
     }
 
     /// Format a GenericFor node
@@ -54,11 +53,11 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let mut trailing_trivia = vec![self.create_newline_trivia()];
 
-        let for_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, generic_for.for_token(), "for ").into_owned(),
+        let for_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, generic_for.for_token(), "for "),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
+        );
         let (formatted_names, mut names_comments_buf) = self.format_punctuated(
             generic_for.names(),
             &CodeFormatter::format_token_reference_mut,
@@ -82,17 +81,17 @@ impl CodeFormatter {
         // Append trailing trivia to the end
         names_comments_buf.append(&mut trailing_trivia);
 
-        let do_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, generic_for.do_token(), " do").into_owned(),
+        let do_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, generic_for.do_token(), " do"),
             FormatTriviaType::NoChange,
             FormatTriviaType::Append(names_comments_buf),
-        ));
+        );
 
-        let end_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(generic_for.end_token()).into_owned(),
+        let end_token = trivia_formatter::token_reference_add_trivia(
+            self.format_end_token(generic_for.end_token()),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::Append(vec![self.create_newline_trivia()]), // trailing_trivia was emptied when it was appended to names_comment_buf
-        ));
+        );
 
         let generic_for = generic_for
             .to_owned()
@@ -132,11 +131,11 @@ impl CodeFormatter {
             ("elseif ", " then")
         };
 
-        let formatted_else_if_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, else_if_node.else_if_token(), else_if_text).into_owned(),
+        let formatted_else_if_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, else_if_node.else_if_token(), else_if_text),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -157,15 +156,15 @@ impl CodeFormatter {
             self.format_expression(else_if_node.condition())
         };
 
-        let formatted_then_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, else_if_node.then_token(), then_text).into_owned(),
+        let formatted_then_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, else_if_node.then_token(), then_text),
             if require_multiline_expression {
                 FormatTriviaType::Append(leading_trivia)
             } else {
                 FormatTriviaType::NoChange
             },
             FormatTriviaType::Append(trailing_trivia),
-        ));
+        );
 
         else_if_node
             .to_owned()
@@ -198,11 +197,11 @@ impl CodeFormatter {
             ("if ", " then")
         };
 
-        let formatted_if_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, if_node.if_token(), if_text).into_owned(),
+        let formatted_if_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, if_node.if_token(), if_text),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -223,20 +222,20 @@ impl CodeFormatter {
             self.format_expression(if_node.condition())
         };
 
-        let formatted_then_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, if_node.then_token(), then_text).into_owned(),
+        let formatted_then_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, if_node.then_token(), then_text),
             if require_multiline_expression {
                 FormatTriviaType::Append(leading_trivia.to_owned())
             } else {
                 FormatTriviaType::NoChange
             },
             FormatTriviaType::Append(trailing_trivia.to_owned()),
-        ));
-        let formatted_end_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(if_node.end_token()).into_owned(),
+        );
+        let formatted_end_token = trivia_formatter::token_reference_add_trivia(
+            self.format_end_token(if_node.end_token()),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::Append(trailing_trivia.to_owned()),
-        ));
+        );
 
         let formatted_else_if = match if_node.else_if() {
             Some(else_if) => Some(
@@ -250,11 +249,11 @@ impl CodeFormatter {
 
         let formatted_else_token = match if_node.else_token() {
             Some(token) => {
-                let formatted = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                    crate::fmt_symbol!(self, token, "else").into_owned(),
+                let formatted = trivia_formatter::token_reference_add_trivia(
+                    crate::fmt_symbol!(self, token, "else"),
                     FormatTriviaType::Append(leading_trivia),
                     FormatTriviaType::Append(trailing_trivia),
-                ));
+                );
                 Some(formatted)
             }
             None => None,
@@ -278,13 +277,12 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let for_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, numeric_for.for_token(), "for ").into_owned(),
+        let for_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, numeric_for.for_token(), "for "),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
-        let formatted_index_variable =
-            Cow::Owned(self.format_plain_token_reference(numeric_for.index_variable()));
+        );
+        let formatted_index_variable = self.format_token_reference(numeric_for.index_variable());
 
         #[cfg(feature = "luau")]
         let type_specifier = match numeric_for.type_specifier() {
@@ -309,16 +307,16 @@ impl CodeFormatter {
             None => (None, None),
         };
 
-        let do_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, numeric_for.do_token(), " do").into_owned(),
+        let do_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, numeric_for.do_token(), " do"),
             FormatTriviaType::NoChange,
             FormatTriviaType::Append(trailing_trivia.to_owned()),
-        ));
-        let end_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(numeric_for.end_token()).into_owned(),
+        );
+        let end_token = trivia_formatter::token_reference_add_trivia(
+            self.format_end_token(numeric_for.end_token()),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::Append(trailing_trivia),
-        ));
+        );
 
         let numeric_for = numeric_for
             .to_owned()
@@ -346,16 +344,16 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let repeat_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, repeat_block.repeat_token(), "repeat").into_owned(),
+        let repeat_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, repeat_block.repeat_token(), "repeat"),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::Append(trailing_trivia.to_owned()),
-        ));
-        let until_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, repeat_block.until_token(), "until ").into_owned(),
+        );
+        let until_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, repeat_block.until_token(), "until "),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         // Determine if we need to hang the until expression
         let last_line_str = trivia_formatter::no_comments(repeat_block.until_token())
@@ -414,11 +412,11 @@ impl CodeFormatter {
             ("while ", " do")
         };
 
-        let while_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, while_block.while_token(), while_text).into_owned(),
+        let while_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, while_block.while_token(), while_text),
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::NoChange,
-        ));
+        );
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -439,17 +437,17 @@ impl CodeFormatter {
             self.format_expression(while_block.condition())
         };
 
-        let do_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, while_block.do_token(), do_text).into_owned(),
+        let do_token = trivia_formatter::token_reference_add_trivia(
+            crate::fmt_symbol!(self, while_block.do_token(), do_text),
             FormatTriviaType::NoChange,
             FormatTriviaType::Append(trailing_trivia.to_owned()),
-        ));
+        );
 
-        let end_token = Cow::Owned(trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(while_block.end_token()).into_owned(),
+        let end_token = trivia_formatter::token_reference_add_trivia(
+            self.format_end_token(while_block.end_token()),
             FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::Append(trailing_trivia),
-        ));
+        );
 
         while_block
             .to_owned()

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -74,7 +74,7 @@ impl CodeFormatter {
 
         let in_token = crate::fmt_symbol!(self, generic_for.in_token(), " in ");
         let (formatted_expr_list, mut expr_comments_buf) =
-            self.format_punctuated(generic_for.expr_list(), &CodeFormatter::format_expression);
+            self.format_punctuated(generic_for.expressions(), &CodeFormatter::format_expression);
 
         // Create comments buffer and append to end of do token
         names_comments_buf.append(&mut expr_comments_buf);
@@ -98,7 +98,7 @@ impl CodeFormatter {
             .with_for_token(for_token)
             .with_names(formatted_names)
             .with_in_token(in_token)
-            .with_expr_list(formatted_expr_list)
+            .with_expressions(formatted_expr_list)
             .with_do_token(do_token)
             .with_end_token(end_token);
         #[cfg(feature = "luau")]

--- a/src/formatters/table_formatter.rs
+++ b/src/formatters/table_formatter.rs
@@ -80,6 +80,8 @@ impl CodeFormatter {
                     ))
                 }
             }
+
+            other => panic!("unknown node {:?}", other),
         };
 
         (field, trailing_trivia)
@@ -203,6 +205,7 @@ impl CodeFormatter {
                         }
                         Field::NameKey { key, .. } => CodeFormatter::get_token_range(key.token()),
                         Field::NoKey(expr) => CodeFormatter::get_range_in_expression(&expr),
+                        other => panic!("unknown node {:?}", other),
                     };
                     let additional_indent_level = self.get_range_indent_increase(range);
                     FormatTriviaType::Append(vec![

--- a/src/formatters/table_formatter.rs
+++ b/src/formatters/table_formatter.rs
@@ -8,7 +8,6 @@ use full_moon::ast::{
     Field, TableConstructor,
 };
 use full_moon::tokenizer::{Token, TokenKind, TokenReference, TokenType};
-use std::borrow::Cow;
 
 /// Used to provide information about the table
 pub enum TableType {
@@ -53,11 +52,11 @@ impl CodeFormatter {
             Field::NameKey { key, equal, value } => {
                 trailing_trivia = trivia_util::get_expression_trailing_trivia(value);
                 Field::NameKey {
-                    key: Cow::Owned(trivia_formatter::token_reference_add_trivia(
-                        self.format_token_reference(key).into_owned(),
+                    key: trivia_formatter::token_reference_add_trivia(
+                        self.format_token_reference(key),
                         leading_trivia,
                         FormatTriviaType::NoChange,
-                    )),
+                    ),
                     equal: crate::fmt_symbol!(self, equal, " = "),
                     value: trivia_formatter::expression_add_trailing_trivia(
                         self.format_expression(value),
@@ -102,18 +101,18 @@ impl CodeFormatter {
 
                 // Add new_line trivia to start_brace
                 let start_brace_token = trivia_formatter::token_reference_add_trivia(
-                    crate::fmt_symbol!(self, start_brace, "{").into_owned(),
+                    crate::fmt_symbol!(self, start_brace, "{"),
                     FormatTriviaType::NoChange,
                     FormatTriviaType::Append(vec![self.create_newline_trivia()]),
                 );
 
                 let end_brace_token = trivia_formatter::token_reference_add_trivia(
-                    self.format_end_token(end_brace).into_owned(),
+                    self.format_end_token(end_brace),
                     FormatTriviaType::Append(end_brace_leading_trivia),
                     FormatTriviaType::Replace(vec![]),
                 );
 
-                ContainedSpan::new(Cow::Owned(start_brace_token), Cow::Owned(end_brace_token))
+                ContainedSpan::new(start_brace_token, end_brace_token)
             }
 
             TableType::SingleLine => ContainedSpan::new(
@@ -230,7 +229,7 @@ impl CodeFormatter {
                     // Continue adding a comma and a new line for multiline tables
                     let mut symbol = TokenReference::symbol(",").unwrap();
                     if let Some(punctuation) = punctuation {
-                        symbol = self.format_symbol(&punctuation, &symbol).into_owned();
+                        symbol = self.format_symbol(&punctuation, &symbol);
                     }
                     // Add newline trivia to the end of the symbol, and preserve any comments
                     trailing_trivia.push(self.create_newline_trivia());
@@ -239,7 +238,7 @@ impl CodeFormatter {
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append(trailing_trivia),
                     );
-                    formatted_punctuation = Some(Cow::Owned(symbol))
+                    formatted_punctuation = Some(symbol)
                 }
                 false => {
                     if current_fields.peek().is_some() {
@@ -249,7 +248,7 @@ impl CodeFormatter {
                                 &punctuation,
                                 &TokenReference::symbol(", ").unwrap(),
                             )),
-                            None => Some(Cow::Owned(TokenReference::symbol(", ").unwrap())),
+                            None => Some(TokenReference::symbol(", ").unwrap()),
                         }
                     };
                 }

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -296,6 +296,7 @@ macro_rules! binop_leading_trivia {
             $(
                 $enum::$operator(token) => $enum::$operator(Cow::Owned(token_reference_add_trivia(token.into_owned(), $leading_trivia, FormatTriviaType::NoChange))),
             )+
+            other => panic!("unknown node {:?}", other),
         }
     };
 }
@@ -380,6 +381,7 @@ pub fn call_add_trailing_trivia<'ast>(
             method_call,
             trailing_trivia,
         )),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -415,6 +417,7 @@ pub fn expression_add_leading_trivia<'ast>(
             #[cfg(feature = "luau")]
             type_assertion,
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -474,6 +477,7 @@ pub fn expression_add_trailing_trivia<'ast>(
             unop,
             expression: Box::new(expression_add_trailing_trivia(*expression, trailing_trivia)),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -510,6 +514,7 @@ pub fn function_args_add_trailing_trivia<'ast>(
                 trailing_trivia,
             ))
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -577,6 +582,7 @@ pub fn index_add_trailing_trivia<'ast>(
                 trailing_trivia,
             )),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -609,6 +615,7 @@ pub fn parameter_add_trivia<'ast>(
             leading_trivia,
             trailing_trivia,
         ))),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -626,6 +633,7 @@ pub fn prefix_add_leading_trivia<'ast>(
         Prefix::Expression(expression) => {
             Prefix::Expression(expression_add_leading_trivia(expression, leading_trivia))
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -637,6 +645,7 @@ pub fn suffix_add_trailing_trivia<'ast>(
     match suffix {
         Suffix::Call(call) => Suffix::Call(call_add_trailing_trivia(call, trailing_trivia)),
         Suffix::Index(index) => Suffix::Index(index_add_trailing_trivia(index, trailing_trivia)),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -720,6 +729,7 @@ pub fn unop_add_leading_trivia<'ast>(
             leading_trivia,
             FormatTriviaType::NoChange,
         ))),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -765,6 +775,7 @@ pub fn value_add_leading_trivia<'ast>(
             ))
         }
         Value::Var(var) => Value::Var(var_add_leading_trivia(var, leading_trivia)),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -807,6 +818,7 @@ pub fn value_add_trailing_trivia<'ast>(
             ))
         }
         Value::Var(var) => Value::Var(var_add_trailing_trivia(var, trailing_trivia)),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -825,6 +837,7 @@ pub fn var_add_leading_trivia<'ast>(
             var_expresion,
             leading_trivia,
         )),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -843,6 +856,7 @@ pub fn var_add_trailing_trivia<'ast>(
             var_expression,
             trailing_trivia,
         )),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -999,6 +1013,8 @@ pub fn type_info_add_trailing_trivia<'ast>(
             let right = Box::new(type_info_add_trailing_trivia(*right, trailing_trivia));
             TypeInfo::Union { left, pipe, right }
         }
+
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -1029,6 +1045,8 @@ pub fn indexed_type_info_add_trailing_trivia<'ast>(
                 generics,
             }
         }
+
+        other => panic!("unknown node {:?}", other),
     }
 }
 

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -543,10 +543,8 @@ pub fn function_call_add_trailing_trivia<'ast>(
     function_call: FunctionCall<'ast>,
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> FunctionCall<'ast> {
-    let mut new_suffixes: Vec<Suffix<'ast>> = function_call
-        .iter_suffixes()
-        .map(|x| x.to_owned())
-        .collect();
+    let mut new_suffixes: Vec<Suffix<'ast>> =
+        function_call.suffixes().map(|x| x.to_owned()).collect();
     if let Some(last_suffix) = new_suffixes.pop() {
         new_suffixes.push(suffix_add_trailing_trivia(
             last_suffix.to_owned(),
@@ -866,10 +864,8 @@ pub fn var_expression_add_trailing_trivia<'ast>(
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> VarExpression<'ast> {
     // TODO: This is copied from FunctionCall, can we combine them?
-    let mut new_suffixes: Vec<Suffix<'ast>> = var_expression
-        .iter_suffixes()
-        .map(|x| x.to_owned())
-        .collect();
+    let mut new_suffixes: Vec<Suffix<'ast>> =
+        var_expression.suffixes().map(|x| x.to_owned()).collect();
     if let Some(last_suffix) = new_suffixes.pop() {
         new_suffixes.push(suffix_add_trailing_trivia(
             last_suffix.to_owned(),

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -224,8 +224,8 @@ impl CodeFormatter {
                         match *value {
                             // Handle any values which may have expressions inside of them
                             // which we may need to split onto multiple lines
-                            Value::ParseExpression(expression) => {
-                                Value::ParseExpression(self.expression_split_binop(
+                            Value::ParenthesesExpression(expression) => {
+                                Value::ParenthesesExpression(self.expression_split_binop(
                                     expression.to_owned(),
                                     binop_leading_trivia.to_owned(),
                                     indent_increase,
@@ -749,8 +749,8 @@ pub fn value_add_leading_trivia<'ast>(
             leading_trivia,
             FormatTriviaType::NoChange,
         ))),
-        Value::ParseExpression(expression) => {
-            Value::ParseExpression(expression_add_leading_trivia(expression, leading_trivia))
+        Value::ParenthesesExpression(expression) => {
+            Value::ParenthesesExpression(expression_add_leading_trivia(expression, leading_trivia))
         }
         Value::String(token_reference) => Value::String(Cow::Owned(token_reference_add_trivia(
             token_reference.into_owned(),
@@ -791,9 +791,9 @@ pub fn value_add_trailing_trivia<'ast>(
             FormatTriviaType::NoChange,
             trailing_trivia,
         ))),
-        Value::ParseExpression(expression) => {
-            Value::ParseExpression(expression_add_trailing_trivia(expression, trailing_trivia))
-        }
+        Value::ParenthesesExpression(expression) => Value::ParenthesesExpression(
+            expression_add_trailing_trivia(expression, trailing_trivia),
+        ),
         Value::String(token_reference) => Value::String(Cow::Owned(token_reference_add_trivia(
             token_reference.into_owned(),
             FormatTriviaType::NoChange,

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -3,7 +3,7 @@ use crate::{
     IndentType,
 };
 #[cfg(feature = "luau")]
-use full_moon::ast::types::{AsAssertion, IndexedTypeInfo, TypeInfo, TypeSpecifier};
+use full_moon::ast::types::{IndexedTypeInfo, TypeAssertion, TypeInfo, TypeSpecifier};
 use full_moon::ast::{
     span::ContainedSpan, BinOp, BinOpRhs, Call, Expression, FunctionArgs, FunctionBody,
     FunctionCall, Index, MethodCall, Parameter, Prefix, Suffix, TableConstructor, UnOp, Value, Var,
@@ -408,12 +408,12 @@ pub fn expression_add_leading_trivia<'ast>(
             value,
             binop,
             #[cfg(feature = "luau")]
-            as_assertion,
+            type_assertion,
         } => Expression::Value {
             value: Box::new(value_add_leading_trivia(*value, leading_trivia)),
             binop,
             #[cfg(feature = "luau")]
-            as_assertion,
+            type_assertion,
         },
     }
 }
@@ -428,14 +428,13 @@ pub fn expression_add_trailing_trivia<'ast>(
             value,
             binop,
             #[cfg(feature = "luau")]
-            as_assertion,
+            type_assertion,
         } => {
             #[cfg(feature = "luau")]
-            if let Some(as_assertion) = as_assertion {
+            if let Some(as_assertion) = type_assertion {
                 return Expression::Value {
                     value,
-                    binop,
-                    as_assertion: Some(as_assertion_add_trailing_trivia(
+                    type_assertion: Some(type_assertion_add_trailing_trivia(
                         as_assertion,
                         trailing_trivia,
                     )),
@@ -452,10 +451,8 @@ pub fn expression_add_trailing_trivia<'ast>(
             } else {
                 Expression::Value {
                     value: Box::new(value_add_trailing_trivia(*value, trailing_trivia)),
-                    binop,
-                    #[cfg(feature = "luau")]
-                    as_assertion,
-                }
+                #[cfg(feature = "luau")]
+                type_assertion,
             }
         }
 
@@ -1036,12 +1033,13 @@ pub fn indexed_type_info_add_trailing_trivia<'ast>(
 }
 
 #[cfg(feature = "luau")]
-pub fn as_assertion_add_trailing_trivia<'ast>(
-    as_assertion: AsAssertion<'ast>,
+pub fn type_assertion_add_trailing_trivia<'ast>(
+    type_assertion: TypeAssertion<'ast>,
     trailing_trivia: FormatTriviaType<'ast>,
-) -> AsAssertion<'ast> {
-    let cast_to = type_info_add_trailing_trivia(as_assertion.cast_to().to_owned(), trailing_trivia);
-    as_assertion.with_cast_to(cast_to)
+) -> TypeAssertion<'ast> {
+    let cast_to =
+        type_info_add_trailing_trivia(type_assertion.cast_to().to_owned(), trailing_trivia);
+    type_assertion.with_cast_to(cast_to)
 }
 
 #[cfg(feature = "luau")]

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -10,7 +10,6 @@ use full_moon::ast::{
     VarExpression,
 };
 use full_moon::tokenizer::{Token, TokenKind, TokenReference, TokenType};
-use std::borrow::Cow;
 
 /// Enum to determine how trivia should be added when using trivia formatter functions
 #[derive(Clone, Debug)]
@@ -115,7 +114,7 @@ impl CodeFormatter {
                 let (start_token, end_token) = contained.tokens();
 
                 let contained = ContainedSpan::new(
-                    Cow::Owned(token_reference_add_trivia(
+                    token_reference_add_trivia(
                         start_token.to_owned(),
                         FormatTriviaType::NoChange,
                         FormatTriviaType::Append({
@@ -125,12 +124,12 @@ impl CodeFormatter {
                             new_vec.push(self.create_plain_indent_trivia(1));
                             new_vec
                         }),
-                    )),
-                    Cow::Owned(token_reference_add_trivia(
+                    ),
+                    token_reference_add_trivia(
                         end_token.to_owned(),
                         FormatTriviaType::Append(current_indent_vec.to_vec()),
                         FormatTriviaType::NoChange,
-                    )),
+                    ),
                 );
 
                 // Modify the binop leading trivia to increment by one
@@ -355,16 +354,16 @@ pub fn contained_span_add_trivia<'ast>(
 ) -> ContainedSpan<'ast> {
     let (start_token, end_token) = contained_span.tokens();
     ContainedSpan::new(
-        Cow::Owned(token_reference_add_trivia(
+        token_reference_add_trivia(
             start_token.to_owned(),
             leading_trivia,
             FormatTriviaType::NoChange,
-        )),
-        Cow::Owned(token_reference_add_trivia(
+        ),
+        token_reference_add_trivia(
             end_token.to_owned(),
             FormatTriviaType::NoChange,
             trailing_trivia,
-        )),
+        ),
     )
 }
 
@@ -500,13 +499,11 @@ pub fn function_args_add_trailing_trivia<'ast>(
         },
 
         // Add for completeness
-        FunctionArgs::String(token_reference) => {
-            FunctionArgs::String(Cow::Owned(token_reference_add_trivia(
-                token_reference.into_owned(),
-                FormatTriviaType::NoChange,
-                trailing_trivia,
-            )))
-        }
+        FunctionArgs::String(token_reference) => FunctionArgs::String(token_reference_add_trivia(
+            token_reference,
+            FormatTriviaType::NoChange,
+            trailing_trivia,
+        )),
         FunctionArgs::TableConstructor(table_constructor) => {
             FunctionArgs::TableConstructor(table_constructor_add_trivia(
                 table_constructor,
@@ -524,11 +521,11 @@ pub fn function_body_add_trailing_trivia<'ast>(
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> FunctionBody<'ast> {
     let function_body_token = function_body.end_token().to_owned();
-    function_body.with_end_token(Cow::Owned(token_reference_add_trivia(
+    function_body.with_end_token(token_reference_add_trivia(
         function_body_token,
         FormatTriviaType::NoChange,
         trailing_trivia,
-    )))
+    ))
 }
 
 /// Adds leading trivia to the start of a FunctionCall node
@@ -576,11 +573,7 @@ pub fn index_add_trailing_trivia<'ast>(
         },
         Index::Dot { dot, name } => Index::Dot {
             dot,
-            name: Cow::Owned(token_reference_add_trivia(
-                name.into_owned(),
-                FormatTriviaType::NoChange,
-                trailing_trivia,
-            )),
+            name: token_reference_add_trivia(name, FormatTriviaType::NoChange, trailing_trivia),
         },
         other => panic!("unknown node {:?}", other),
     }
@@ -605,16 +598,16 @@ pub fn parameter_add_trivia<'ast>(
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> Parameter<'ast> {
     match parameter {
-        Parameter::Ellipse(token) => Parameter::Ellipse(Cow::Owned(token_reference_add_trivia(
-            token.into_owned(),
+        Parameter::Ellipse(token) => Parameter::Ellipse(token_reference_add_trivia(
+            token,
             leading_trivia,
             trailing_trivia,
-        ))),
-        Parameter::Name(token) => Parameter::Name(Cow::Owned(token_reference_add_trivia(
-            token.into_owned(),
+        )),
+        Parameter::Name(token) => Parameter::Name(token_reference_add_trivia(
+            token,
             leading_trivia,
             trailing_trivia,
-        ))),
+        )),
         other => panic!("unknown node {:?}", other),
     }
 }
@@ -625,11 +618,11 @@ pub fn prefix_add_leading_trivia<'ast>(
     leading_trivia: FormatTriviaType<'ast>,
 ) -> Prefix<'ast> {
     match prefix {
-        Prefix::Name(token_reference) => Prefix::Name(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Prefix::Name(token_reference) => Prefix::Name(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
+        )),
         Prefix::Expression(expression) => {
             Prefix::Expression(expression_add_leading_trivia(expression, leading_trivia))
         }
@@ -714,21 +707,21 @@ pub fn unop_add_leading_trivia<'ast>(
     leading_trivia: FormatTriviaType<'ast>,
 ) -> UnOp<'ast> {
     match unop {
-        UnOp::Hash(token_reference) => UnOp::Hash(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        UnOp::Hash(token_reference) => UnOp::Hash(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
-        UnOp::Minus(token_reference) => UnOp::Minus(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        )),
+        UnOp::Minus(token_reference) => UnOp::Minus(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
-        UnOp::Not(token_reference) => UnOp::Not(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        )),
+        UnOp::Not(token_reference) => UnOp::Not(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
+        )),
         other => panic!("unknown node {:?}", other),
     }
 }
@@ -739,34 +732,30 @@ pub fn value_add_leading_trivia<'ast>(
 ) -> Value<'ast> {
     match value {
         Value::Function((token, function_body)) => Value::Function((
-            Cow::Owned(token_reference_add_trivia(
-                token.into_owned(),
-                leading_trivia,
-                FormatTriviaType::NoChange,
-            )),
+            token_reference_add_trivia(token, leading_trivia, FormatTriviaType::NoChange),
             function_body,
         )),
         Value::FunctionCall(function_call) => Value::FunctionCall(
             function_call_add_leading_trivia(function_call, leading_trivia),
         ),
-        Value::Number(token_reference) => Value::Number(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Value::Number(token_reference) => Value::Number(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
+        )),
         Value::ParenthesesExpression(expression) => {
             Value::ParenthesesExpression(expression_add_leading_trivia(expression, leading_trivia))
         }
-        Value::String(token_reference) => Value::String(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Value::String(token_reference) => Value::String(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
-        Value::Symbol(token_reference) => Value::Symbol(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        )),
+        Value::Symbol(token_reference) => Value::Symbol(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
+        )),
         Value::TableConstructor(table_constructor) => {
             Value::TableConstructor(table_constructor_add_trivia(
                 table_constructor,
@@ -792,24 +781,24 @@ pub fn value_add_trailing_trivia<'ast>(
         Value::FunctionCall(function_call) => Value::FunctionCall(
             function_call_add_trailing_trivia(function_call, trailing_trivia),
         ),
-        Value::Number(token_reference) => Value::Number(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Value::Number(token_reference) => Value::Number(token_reference_add_trivia(
+            token_reference,
             FormatTriviaType::NoChange,
             trailing_trivia,
-        ))),
+        )),
         Value::ParenthesesExpression(expression) => Value::ParenthesesExpression(
             expression_add_trailing_trivia(expression, trailing_trivia),
         ),
-        Value::String(token_reference) => Value::String(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Value::String(token_reference) => Value::String(token_reference_add_trivia(
+            token_reference,
             FormatTriviaType::NoChange,
             trailing_trivia,
-        ))),
-        Value::Symbol(token_reference) => Value::Symbol(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        )),
+        Value::Symbol(token_reference) => Value::Symbol(token_reference_add_trivia(
+            token_reference,
             FormatTriviaType::NoChange,
             trailing_trivia,
-        ))),
+        )),
         Value::TableConstructor(table_constructor) => {
             Value::TableConstructor(table_constructor_add_trivia(
                 table_constructor,
@@ -828,11 +817,11 @@ pub fn var_add_leading_trivia<'ast>(
     leading_trivia: FormatTriviaType<'ast>,
 ) -> Var<'ast> {
     match var {
-        Var::Name(token_reference) => Var::Name(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Var::Name(token_reference) => Var::Name(token_reference_add_trivia(
+            token_reference,
             leading_trivia,
             FormatTriviaType::NoChange,
-        ))),
+        )),
         Var::Expression(var_expresion) => Var::Expression(var_expression_add_leading_trivia(
             var_expresion,
             leading_trivia,
@@ -847,11 +836,11 @@ pub fn var_add_trailing_trivia<'ast>(
     trailing_trivia: FormatTriviaType<'ast>,
 ) -> Var<'ast> {
     match var {
-        Var::Name(token_reference) => Var::Name(Cow::Owned(token_reference_add_trivia(
-            token_reference.into_owned(),
+        Var::Name(token_reference) => Var::Name(token_reference_add_trivia(
+            token_reference,
             FormatTriviaType::NoChange,
             trailing_trivia,
-        ))),
+        )),
         Var::Expression(var_expression) => Var::Expression(var_expression_add_trailing_trivia(
             var_expression,
             trailing_trivia,
@@ -901,13 +890,11 @@ pub fn type_info_add_trailing_trivia<'ast>(
             );
             TypeInfo::Array { braces, type_info }
         }
-        TypeInfo::Basic(token_reference) => {
-            TypeInfo::Basic(Cow::Owned(token_reference_add_trivia(
-                token_reference.to_owned().into_owned(),
-                FormatTriviaType::NoChange,
-                trailing_trivia,
-            )))
-        }
+        TypeInfo::Basic(token_reference) => TypeInfo::Basic(token_reference_add_trivia(
+            token_reference.to_owned(),
+            FormatTriviaType::NoChange,
+            trailing_trivia,
+        )),
         TypeInfo::Callback {
             parentheses,
             arguments,
@@ -972,11 +959,11 @@ pub fn type_info_add_trailing_trivia<'ast>(
             base,
             question_mark,
         } => {
-            let question_mark = Cow::Owned(token_reference_add_trivia(
-                question_mark.to_owned().into_owned(),
+            let question_mark = token_reference_add_trivia(
+                question_mark.to_owned(),
                 FormatTriviaType::NoChange,
                 trailing_trivia,
-            ));
+            );
             TypeInfo::Optional {
                 base,
                 question_mark,
@@ -1025,11 +1012,11 @@ pub fn indexed_type_info_add_trailing_trivia<'ast>(
 ) -> IndexedTypeInfo<'ast> {
     match indexed_type_info {
         IndexedTypeInfo::Basic(token_reference) => {
-            IndexedTypeInfo::Basic(Cow::Owned(token_reference_add_trivia(
-                token_reference.to_owned().into_owned(),
+            IndexedTypeInfo::Basic(token_reference_add_trivia(
+                token_reference.to_owned(),
                 FormatTriviaType::NoChange,
                 trailing_trivia,
-            )))
+            ))
         }
         IndexedTypeInfo::Generic {
             base,

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -10,12 +10,19 @@ use full_moon::{
 };
 use std::borrow::Cow;
 
+pub fn trivia_is_newline(trivia: &Token) -> bool {
+    if let TokenType::Whitespace { characters } = trivia.token_type() {
+        if characters.find('\n').is_some() {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn trivia_contains_newline<'ast>(trivia_vec: impl Iterator<Item = &'ast Token<'ast>>) -> bool {
     for trivia in trivia_vec {
-        if let TokenType::Whitespace { characters } = trivia.token_type() {
-            if characters.find('\n').is_some() {
-                return true;
-            }
+        if trivia_is_newline(trivia) {
+            return true;
         }
     }
     false

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -1,6 +1,6 @@
 use crate::formatters::trivia_formatter::{self, FormatTriviaType};
 #[cfg(feature = "luau")]
-use full_moon::ast::types::{AsAssertion, IndexedTypeInfo, TypeField, TypeFieldKey, TypeInfo};
+use full_moon::ast::types::{TypeAssertion, IndexedTypeInfo, TypeField, TypeFieldKey, TypeInfo};
 use full_moon::{
     ast::{
         punctuated::Pair, span::ContainedSpan, BinOp, Call, Expression, Field, FunctionArgs, Index,
@@ -199,11 +199,11 @@ pub fn get_expression_trailing_trivia<'ast>(expression: &Expression<'ast>) -> Ve
         Expression::Value {
             value,
             #[cfg(feature = "luau")]
-            as_assertion,
+            type_assertion,
         } => {
             #[cfg(feature = "luau")]
-            if let Some(as_assertion) = as_assertion {
-                return type_info_trailing_trivia(as_assertion.cast_to());
+            if let Some(type_assertion) = type_assertion {
+                return type_info_trailing_trivia(type_assertion.cast_to());
             }
 
             get_value_trailing_trivia(value)
@@ -670,9 +670,9 @@ fn type_field_key_contains_comments<'ast>(type_field_key: &TypeFieldKey<'ast>) -
 }
 
 #[cfg(feature = "luau")]
-fn as_assertion_contains_comments<'ast>(as_assertion: &AsAssertion<'ast>) -> bool {
-    token_contains_comments(as_assertion.as_token())
-        || type_info_contains_comments(as_assertion.cast_to())
+fn type_assertion_contains_comments<'ast>(type_assertion: &TypeAssertion<'ast>) -> bool {
+    token_contains_comments(type_assertion.assertion_op())
+        || type_info_contains_comments(type_assertion.cast_to())
 }
 
 fn value_contains_comments(value: &Value) -> bool {
@@ -783,14 +783,14 @@ pub fn expression_contains_comments(expression: &Expression) -> bool {
         Expression::Value {
             value,
             #[cfg(feature = "luau")]
-            as_assertion,
+            type_assertion,
         } => {
             #[cfg(feature = "luau")]
             {
                 return value_contains_comments(value)
-                    || as_assertion
+                    || type_assertion
                         .as_ref()
-                        .map_or(false, |x| as_assertion_contains_comments(x));
+                        .map_or(false, |x| type_assertion_contains_comments(x));
             }
 
             #[cfg(not(feature = "luau"))]

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -34,6 +34,7 @@ pub fn can_hang_expression(expression: &Expression) -> bool {
         Expression::UnaryOperator { expression, .. } => can_hang_expression(expression),
         Expression::BinaryOperator { .. } => true, // If a binop is present, then we can hang the expression
         Expression::Value { .. } => false,
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -52,6 +53,7 @@ fn function_args_trailing_trivia<'ast>(function_args: &FunctionArgs<'ast>) -> Ve
             let (_, end_brace) = table_constructor.braces().tokens();
             end_brace.trailing_trivia().map(|x| x.to_owned()).collect()
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -63,11 +65,14 @@ fn suffix_trailing_trivia<'ast>(suffix: &Suffix<'ast>) -> Vec<Token<'ast>> {
                 end_brace.trailing_trivia().map(|x| x.to_owned()).collect()
             }
             Index::Dot { name, .. } => name.trailing_trivia().map(|x| x.to_owned()).collect(),
+            other => panic!("unknown node {:?}", other),
         },
         Suffix::Call(call) => match call {
             Call::AnonymousCall(function_args) => function_args_trailing_trivia(function_args),
             Call::MethodCall(method_call) => function_args_trailing_trivia(method_call.args()),
+            other => panic!("unknown node {:?}", other),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -84,6 +89,7 @@ fn indexed_type_info_trailing_trivia<'ast>(
             let (_, end_brace) = arrows.tokens();
             end_brace.trailing_trivia().map(|x| x.to_owned()).collect()
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -129,6 +135,8 @@ fn type_info_trailing_trivia<'ast>(type_info: &TypeInfo<'ast>) -> Vec<Token<'ast
         }
 
         TypeInfo::Union { right, .. } => type_info_trailing_trivia(right),
+
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -146,6 +154,7 @@ fn var_trailing_trivia<'ast>(var: &Var<'ast>) -> Vec<Token<'ast>> {
                 vec![]
             }
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -182,6 +191,7 @@ pub fn get_value_trailing_trivia<'ast>(value: &Value<'ast>) -> Vec<Token<'ast>> 
             .map(|x| x.to_owned())
             .collect(),
         Value::Var(var) => var_trailing_trivia(var),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -208,6 +218,7 @@ pub fn get_expression_trailing_trivia<'ast>(expression: &Expression<'ast>) -> Ve
 
             get_value_trailing_trivia(value)
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -223,6 +234,7 @@ pub fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec
             UnOp::Minus(token_ref) | UnOp::Not(token_ref) | UnOp::Hash(token_ref) => {
                 token_ref.leading_trivia().map(|x| x.to_owned()).collect()
             }
+            other => panic!("unknown node {:?}", other),
         },
         Expression::BinaryOperator { lhs, .. } => get_expression_leading_trivia(lhs),
         Expression::Value { value, .. } => match &**value {
@@ -234,6 +246,7 @@ pub fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec
                     token_ref.leading_trivia().map(|x| x.to_owned()).collect()
                 }
                 Prefix::Expression(expr) => get_expression_leading_trivia(expr),
+                other => panic!("unknown node {:?}", other),
             },
             Value::TableConstructor(table) => table
                 .braces()
@@ -253,9 +266,13 @@ pub fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec
                         token_ref.leading_trivia().map(|x| x.to_owned()).collect()
                     }
                     Prefix::Expression(expr) => get_expression_leading_trivia(expr),
+                    other => panic!("unknown node {:?}", other),
                 },
+                other => panic!("unknown node {:?}", other),
             },
+            other => panic!("unknown node {:?}", other),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -269,6 +286,7 @@ pub fn get_field_leading_trivia<'ast>(field: &Field<'ast>) -> Vec<Token<'ast>> {
             .collect(),
         Field::NameKey { key, .. } => key.leading_trivia().map(|x| x.to_owned()).collect(),
         Field::NoKey(expression) => get_expression_leading_trivia(expression),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -454,6 +472,7 @@ pub fn table_fields_contains_comments(table_constructor: &TableConstructor) -> b
                     || expression_contains_comments(value)
             }
             Field::NoKey(expression) => expression_contains_comments(expression),
+            other => panic!("unknown node {:?}", other),
         };
 
         if let Some(punctuation) = field.punctuation() {
@@ -502,6 +521,7 @@ fn function_args_contains_comments(function_args: &FunctionArgs) -> bool {
         FunctionArgs::TableConstructor(table_constructor) => {
             table_constructor_contains_comments(table_constructor)
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -514,6 +534,7 @@ fn suffix_contains_comments(suffix: &Suffix) -> bool {
                     || token_contains_comments(method_call.colon_token())
                     || function_args_contains_comments(method_call.args())
             }
+            other => panic!("unknown node {:?}", other),
         },
         Suffix::Index(index) => match index {
             Index::Brackets {
@@ -528,7 +549,9 @@ fn suffix_contains_comments(suffix: &Suffix) -> bool {
             Index::Dot { dot, name } => {
                 token_contains_comments(dot) || token_contains_comments(name)
             }
+            other => panic!("unknown node {:?}", other),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -628,6 +651,7 @@ fn type_info_contains_comments<'ast>(type_info: &TypeInfo<'ast>) -> bool {
                 || token_contains_comments(pipe)
                 || type_info_contains_comments(right)
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -649,6 +673,7 @@ fn indexed_type_info_contains_comments<'ast>(type_info: &IndexedTypeInfo<'ast>) 
                             .map_or(false, |punc| token_contains_comments(punc))
                 })
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -666,6 +691,7 @@ fn type_field_key_contains_comments<'ast>(type_field_key: &TypeFieldKey<'ast>) -
         TypeFieldKey::IndexSignature { brackets, inner } => {
             contained_span_contains_comments(brackets) || type_info_contains_comments(inner)
         }
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -689,6 +715,7 @@ fn value_contains_comments(value: &Value) -> bool {
             let contained = match function_call.prefix() {
                 Prefix::Name(token) => token_contains_comments(token),
                 Prefix::Expression(expression) => expression_contains_comments(expression),
+                other => panic!("unknown node {:?}", other),
             };
 
             if contained {
@@ -717,6 +744,7 @@ fn value_contains_comments(value: &Value) -> bool {
                 let contained = match var_expr.prefix() {
                     Prefix::Name(token) => token_contains_comments(token),
                     Prefix::Expression(expression) => expression_contains_comments(expression),
+                    other => panic!("unknown node {:?}", other),
                 };
 
                 if contained {
@@ -732,7 +760,9 @@ fn value_contains_comments(value: &Value) -> bool {
                     contained_comments
                 }
             }
+            other => panic!("unknown node {:?}", other),
         },
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -753,6 +783,7 @@ fn binop_contains_comments(binop: &BinOp) -> bool {
         | BinOp::TildeEqual(t)
         | BinOp::TwoDots(t)
         | BinOp::TwoEqual(t) => token_contains_comments(t),
+        other => panic!("unknown node {:?}", other),
     }
 }
 
@@ -772,6 +803,7 @@ pub fn expression_contains_comments(expression: &Expression) -> bool {
                         return true;
                     }
                 }
+                other => panic!("unknown node {:?}", other),
             }
 
             expression_contains_comments(expression)
@@ -818,7 +850,7 @@ pub fn expression_contains_inline_comments(expression: &Expression) -> bool {
                     op_contains_comments || expression_contains_inline_comments(expression)
                 }
                 Expression::Value{ .. } => false,
-                Expression::Parentheses { .. } => expression_contains_comments(rhs)
+                other => panic!("unknown node {:?}", other),
             }
         }
         _ => false,

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -168,7 +168,7 @@ pub fn get_value_trailing_trivia<'ast>(value: &Value<'ast>) -> Vec<Token<'ast>> 
             .trailing_trivia()
             .map(|x| x.to_owned())
             .collect(),
-        Value::ParseExpression(expr) => get_expression_trailing_trivia(&expr),
+        Value::ParenthesesExpressions(expr) => get_expression_trailing_trivia(&expr),
         Value::Symbol(token_reference) => token_reference
             .trailing_trivia()
             .map(|x| x.to_owned())
@@ -238,7 +238,7 @@ pub fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec
                 .map(|x| x.to_owned())
                 .collect(),
             Value::Number(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
-            Value::ParseExpression(expr) => get_expression_leading_trivia(&expr),
+            Value::ParenthesesExpression(expr) => get_expression_leading_trivia(&expr),
             Value::String(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
             Value::Symbol(token_ref) => token_ref.leading_trivia().map(|x| x.to_owned()).collect(),
             Value::Var(var) => match var {
@@ -703,7 +703,7 @@ fn value_contains_comments(value: &Value) -> bool {
             table_constructor_contains_comments(table_constructor)
         }
         Value::Number(token) => token_contains_comments(token),
-        Value::ParseExpression(expression) => expression_contains_comments(expression),
+        Value::ParenthesesExpression(expression) => expression_contains_comments(expression),
         Value::String(token) => token_contains_comments(token),
         Value::Symbol(token) => token_contains_comments(token),
         Value::Var(var) => match var {

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -132,7 +132,7 @@ fn var_trailing_trivia<'ast>(var: &Var<'ast>) -> Vec<Token<'ast>> {
             .map(|x| x.to_owned())
             .collect(),
         Var::Expression(var_expr) => {
-            if let Some(last_suffix) = var_expr.iter_suffixes().last() {
+            if let Some(last_suffix) = var_expr.suffixes().last() {
                 suffix_trailing_trivia(last_suffix)
             } else {
                 // TODO: is it possible for this to happen?
@@ -150,7 +150,7 @@ pub fn get_value_trailing_trivia<'ast>(value: &Value<'ast>) -> Vec<Token<'ast>> 
             .map(|x| x.to_owned())
             .collect(),
         Value::FunctionCall(function_call) => {
-            if let Some(last_suffix) = function_call.iter_suffixes().last() {
+            if let Some(last_suffix) = function_call.suffixes().last() {
                 suffix_trailing_trivia(last_suffix)
             } else {
                 // TODO: is it possible for this to happen?
@@ -308,7 +308,7 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
     let mut trailing_trivia = Vec::new();
     let updated_stmt = match stmt {
         Stmt::Assignment(assignment) => {
-            let mut formatted_expression_list = assignment.expr_list().to_owned();
+            let mut formatted_expression_list = assignment.expressions().to_owned();
             if let Some(last_pair) = formatted_expression_list.pop() {
                 match last_pair {
                     Pair::End(value) => {
@@ -325,13 +325,13 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                 }
             }
 
-            Stmt::Assignment(assignment.with_expr_list(formatted_expression_list))
+            Stmt::Assignment(assignment.with_expressions(formatted_expression_list))
         }
 
         Stmt::LocalAssignment(local_assignment) => {
-            let new_assignment = if local_assignment.expr_list().is_empty() {
+            let new_assignment = if local_assignment.expressions().is_empty() {
                 // Unassigned local variable
-                let mut formatted_name_list = local_assignment.name_list().to_owned();
+                let mut formatted_name_list = local_assignment.names().to_owned();
 
                 // Retrieve last item and take its trailing comments
                 if let Some(last_pair) = formatted_name_list.pop() {
@@ -351,11 +351,11 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                         }
                     }
                 }
-                local_assignment.with_name_list(formatted_name_list)
+                local_assignment.with_names(formatted_name_list)
             } else {
                 // Add newline at the end of LocalAssignment expression list
                 // Expression list should already be formatted
-                let mut formatted_expression_list = local_assignment.expr_list().to_owned();
+                let mut formatted_expression_list = local_assignment.expressions().to_owned();
 
                 // Retrieve last item and remove trailing trivia
                 if let Some(last_pair) = formatted_expression_list.pop() {
@@ -374,14 +374,14 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                     }
                 }
 
-                local_assignment.with_expr_list(formatted_expression_list)
+                local_assignment.with_expressions(formatted_expression_list)
             };
 
             Stmt::LocalAssignment(new_assignment)
         }
 
         Stmt::FunctionCall(function_call) => {
-            let last_suffix = function_call.iter_suffixes().last();
+            let last_suffix = function_call.suffixes().last();
             trailing_trivia = match last_suffix {
                 Some(suffix) => suffix_trailing_trivia(suffix),
                 None => Vec::new(),
@@ -688,7 +688,7 @@ fn value_contains_comments(value: &Value) -> bool {
                 true
             } else {
                 let mut contained_comments = false;
-                for suffix in function_call.iter_suffixes() {
+                for suffix in function_call.suffixes() {
                     contained_comments = suffix_contains_comments(suffix);
                     if contained_comments {
                         break;
@@ -716,7 +716,7 @@ fn value_contains_comments(value: &Value) -> bool {
                     true
                 } else {
                     let mut contained_comments = false;
-                    for suffix in var_expr.iter_suffixes() {
+                    for suffix in var_expr.suffixes() {
                         contained_comments = suffix_contains_comments(suffix);
                         if contained_comments {
                             break;

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -217,6 +217,7 @@ pub fn get_expression_leading_trivia<'ast>(expression: &Expression<'ast>) -> Vec
                 token_ref.leading_trivia().map(|x| x.to_owned()).collect()
             }
         },
+        Expression::BinaryOperator { lhs, .. } => get_expression_leading_trivia(lhs),
         Expression::Value { value, .. } => match &**value {
             Value::Function((token_ref, _)) => {
                 token_ref.leading_trivia().map(|x| x.to_owned()).collect()

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -560,7 +560,7 @@ fn contained_span_contains_comments(contained_span: &ContainedSpan) -> bool {
 }
 
 #[cfg(feature = "luau")]
-fn type_info_contains_comments<'ast>(type_info: &TypeInfo<'ast>) -> bool {
+fn type_info_contains_comments(type_info: &TypeInfo) -> bool {
     match type_info {
         TypeInfo::Array { braces, type_info } => {
             contained_span_contains_comments(braces) || type_info_contains_comments(type_info)
@@ -655,7 +655,7 @@ fn type_info_contains_comments<'ast>(type_info: &TypeInfo<'ast>) -> bool {
 }
 
 #[cfg(feature = "luau")]
-fn indexed_type_info_contains_comments<'ast>(type_info: &IndexedTypeInfo<'ast>) -> bool {
+fn indexed_type_info_contains_comments(type_info: &IndexedTypeInfo) -> bool {
     match type_info {
         IndexedTypeInfo::Basic(token) => token_contains_comments(token),
         IndexedTypeInfo::Generic {
@@ -677,14 +677,14 @@ fn indexed_type_info_contains_comments<'ast>(type_info: &IndexedTypeInfo<'ast>) 
 }
 
 #[cfg(feature = "luau")]
-fn type_field_contains_comments<'ast>(type_field: &TypeField<'ast>) -> bool {
+fn type_field_contains_comments(type_field: &TypeField) -> bool {
     type_field_key_contains_comments(type_field.key())
         || token_contains_comments(type_field.colon_token())
         || type_info_contains_comments(type_field.value())
 }
 
 #[cfg(feature = "luau")]
-fn type_field_key_contains_comments<'ast>(type_field_key: &TypeFieldKey<'ast>) -> bool {
+fn type_field_key_contains_comments(type_field_key: &TypeFieldKey) -> bool {
     match type_field_key {
         TypeFieldKey::Name(token) => token_contains_comments(token),
         TypeFieldKey::IndexSignature { brackets, inner } => {
@@ -695,7 +695,7 @@ fn type_field_key_contains_comments<'ast>(type_field_key: &TypeFieldKey<'ast>) -
 }
 
 #[cfg(feature = "luau")]
-fn type_assertion_contains_comments<'ast>(type_assertion: &TypeAssertion<'ast>) -> bool {
+fn type_assertion_contains_comments(type_assertion: &TypeAssertion) -> bool {
     token_contains_comments(type_assertion.assertion_op())
         || type_info_contains_comments(type_assertion.cast_to())
 }

--- a/tests/inputs/semicolon-1.lua
+++ b/tests/inputs/semicolon-1.lua
@@ -1,0 +1,1 @@
+local x = 1; -- comment

--- a/tests/inputs/table-1.lua
+++ b/tests/inputs/table-1.lua
@@ -3,3 +3,7 @@ local foo = {"bar", "baz", "foo", "bar", "baz", "foo", "bar", "baz", "foo", "bar
 local foo = {"bar", "baz", "foo", "bar", "baz", "foo",
 	"bar", "baz", "foo", "bar", "baz", "foo", "bar",
 	"baz", "foo", "bar", "baz", "foo", "bar", "baz"}
+
+local foo = {
+
+}

--- a/tests/snapshots/tests__standard@semicolon-1.lua.snap
+++ b/tests/snapshots/tests__standard@semicolon-1.lua.snap
@@ -1,0 +1,7 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+local x = 1 -- comment
+

--- a/tests/snapshots/tests__standard@table-1.lua.snap
+++ b/tests/snapshots/tests__standard@table-1.lua.snap
@@ -46,3 +46,5 @@ local foo = {
 	"baz",
 }
 
+local foo = {}
+

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -152,7 +152,6 @@ end end end end end
     	end
     end
 
-
     if string.sub(msg, 1, 5) == "trip/" then local player = findplayer(string.sub(msg, 6), speaker)
     if player ~= 0 then for i = 1, #player do
     if player[i].Character ~= nil then

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -17,7 +17,6 @@ local bar   =     baz
         ),
         @r###"
     local foo = bar
-
     local bar   =     baz    
                 
     "###
@@ -58,7 +57,6 @@ local bar   =     baz
         ),
     @r###"
     local foo = bar
-
     local bar   =     baz    
 
 


### PR DESCRIPTION
Reduces repeated code, and abstracts out parts into specific functions

Based off #77 