### PR TITLE
Improve how Binary Expressions are hung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Further improvements to the way binary expressions are hung on new lines
+
 ### Fixed
 - Fixed trailing comments at the end of multiline tables being lost
 - Fixed panic "stmt trailing comments not implemented" occuring due to incomplete function

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -38,6 +38,113 @@ impl CodeFormatter {
         }
     }
 
+    /// Pushes a BinOp onto a newline, and indent its depending on indent_level. Moves trailing comments to before the BinOp.
+    /// Does not hang if the BinOp is a relational operator.
+    fn hang_binop<'ast>(&self, binop: BinOp<'ast>, indent_level: usize) -> BinOp<'ast> {
+        match binop {
+            // Don't add the trivia if the binop is binding
+            BinOp::GreaterThan(_)
+            | BinOp::GreaterThanEqual(_)
+            | BinOp::LessThan(_)
+            | BinOp::LessThanEqual(_)
+            | BinOp::TildeEqual(_)
+            | BinOp::TwoEqual(_) => {
+                // Return original binop
+                binop
+            }
+            _ => {
+                // If there are any comments trailing the BinOp, we need to move them to before the BinOp
+                let mut trailing_comments = trivia_util::binop_trailing_comments(&binop);
+                // Create a newline just before the BinOp, and preserve the indentation
+                trailing_comments.push(self.create_newline_trivia());
+                trailing_comments.push(self.create_plain_indent_trivia(indent_level));
+
+                binop_add_trivia(
+                    binop,
+                    FormatTriviaType::Replace(trailing_comments),
+                    FormatTriviaType::Replace(vec![Token::new(TokenType::spaces(1))]),
+                )
+            }
+        }
+    }
+
+    fn hang_binop_expression<'ast>(
+        &self,
+        expression: Expression<'ast>,
+        top_binop: BinOp<'ast>,
+        indent_level: usize,
+    ) -> Expression<'ast> {
+        match expression {
+            Expression::BinaryOperator { lhs, binop, rhs } => {
+                // Keep grouping together all operators with the same precedence level as the main BinOp
+                // They should also have the same associativity
+                let same_op_level = binop.precedence() == top_binop.precedence()
+                    && binop.is_right_associative() == top_binop.is_right_associative();
+                let indent_level = if same_op_level {
+                    indent_level
+                } else {
+                    indent_level + 1
+                };
+
+                if top_binop.is_right_associative() {
+                    let over_column_width = indent_level * self.config.indent_width
+                        + lhs.to_string().len()
+                        > self.config.column_width;
+
+                    let (binop, rhs) = if same_op_level || over_column_width {
+                        let op = self.hang_binop(binop.to_owned(), indent_level);
+
+                        let rhs = self.hang_binop_expression(
+                            *rhs,
+                            if same_op_level { top_binop } else { binop },
+                            indent_level,
+                        );
+
+                        (op, rhs)
+                    } else {
+                        (binop, *rhs)
+                    };
+
+                    Expression::BinaryOperator {
+                        lhs,
+                        binop,
+                        rhs: Box::new(rhs),
+                    }
+                } else {
+                    panic!(
+                        "{} {}",
+                        lhs.to_string(),
+                        indent_level * self.config.indent_width + lhs.to_string().len()
+                    );
+                    let over_column_width = indent_level * self.config.indent_width
+                        + lhs.to_string().len()
+                        > self.config.column_width;
+                    let (binop, lhs) = if same_op_level || over_column_width {
+                        let op = self.hang_binop(binop.to_owned(), indent_level);
+
+                        let lhs = self.hang_binop_expression(
+                            *lhs,
+                            if same_op_level { top_binop } else { binop },
+                            indent_level,
+                        );
+
+                        (op, lhs)
+                    } else {
+                        (binop, *lhs)
+                    };
+
+                    Expression::BinaryOperator {
+                        lhs: Box::new(lhs),
+                        binop,
+                        rhs,
+                    }
+                }
+            }
+            // Base case: no more binary operators - just return to normal splitting
+            _ => self.expression_split_binop(expression, indent_level),
+        }
+    }
+
     fn expression_split_binop<'ast>(
         &self,
         expression: Expression<'ast>,
@@ -99,37 +206,53 @@ impl CodeFormatter {
                 expression: Box::new(self.expression_split_binop(*expression, indent_increase)),
             },
             Expression::BinaryOperator { lhs, binop, rhs } => {
-                let binop = match binop {
-                    // Don't add the trivia if the binop is binding
-                    BinOp::GreaterThan(_)
-                    | BinOp::GreaterThanEqual(_)
-                    | BinOp::LessThan(_)
-                    | BinOp::LessThanEqual(_)
-                    | BinOp::TildeEqual(_)
-                    | BinOp::TwoEqual(_) => {
-                        // Return original binop
-                        binop
-                    }
-                    _ => {
-                        // If there are any comments trailing the BinOp, we need to move them to before the BinOp
-                        let mut trailing_comments = trivia_util::binop_trailing_comments(&binop);
-                        // Create a newline just before the BinOp, and preserve the indentation
-                        trailing_comments.push(self.create_newline_trivia());
-                        trailing_comments.push(self.create_plain_indent_trivia(indent_increase));
+                let binop = self.hang_binop(binop, indent_increase);
+                let lhs =
+                    Box::new(self.hang_binop_expression(*lhs, binop.to_owned(), indent_increase));
+                let rhs =
+                    Box::new(self.hang_binop_expression(*rhs, binop.to_owned(), indent_increase));
 
-                        binop_add_trivia(
-                            binop,
-                            FormatTriviaType::Replace(trailing_comments),
-                            FormatTriviaType::Replace(vec![Token::new(TokenType::spaces(1))]),
-                        )
-                    }
-                };
+                Expression::BinaryOperator { lhs, binop, rhs }
 
-                Expression::BinaryOperator {
-                    lhs: Box::new(self.expression_split_binop(*lhs, indent_increase)),
-                    binop,
-                    rhs: Box::new(self.expression_split_binop(*rhs, indent_increase)),
-                }
+                // if binop.is_right_associative() {
+                //     let rhs = Box::new(self.hang_binop(*rhs, binop.to_owned(), indent_increase));
+                //     Expression::BinaryOperator { lhs, binop, rhs }
+                // } else {
+                //     let lhs = Box::new(self.hang_binop(*lhs, binop.to_owned(), indent_increase));
+                //     Expression::BinaryOperator { lhs, binop, rhs }
+                // }
+
+                // let binop = match binop {
+                //     // Don't add the trivia if the binop is binding
+                //     BinOp::GreaterThan(_)
+                //     | BinOp::GreaterThanEqual(_)
+                //     | BinOp::LessThan(_)
+                //     | BinOp::LessThanEqual(_)
+                //     | BinOp::TildeEqual(_)
+                //     | BinOp::TwoEqual(_) => {
+                //         // Return original binop
+                //         binop
+                //     }
+                //     _ => {
+                //         // If there are any comments trailing the BinOp, we need to move them to before the BinOp
+                //         let mut trailing_comments = trivia_util::binop_trailing_comments(&binop);
+                //         // Create a newline just before the BinOp, and preserve the indentation
+                //         trailing_comments.push(self.create_newline_trivia());
+                //         trailing_comments.push(self.create_plain_indent_trivia(indent_increase));
+
+                //         binop_add_trivia(
+                //             binop,
+                //             FormatTriviaType::Replace(trailing_comments),
+                //             FormatTriviaType::Replace(vec![Token::new(TokenType::spaces(1))]),
+                //         )
+                //     }
+                // };
+
+                // Expression::BinaryOperator {
+                //     lhs: Box::new(self.expression_split_binop(*lhs, indent_increase)),
+                //     binop,
+                //     rhs: Box::new(self.expression_split_binop(*rhs, indent_increase)),
+                // }
             }
 
             Expression::Value {

--- a/tests/inputs/multiline-expressions-3.lua
+++ b/tests/inputs/multiline-expressions-3.lua
@@ -1,0 +1,11 @@
+do
+	do
+		do
+			do
+				local text = "Players: " .. #Server_Container.ARandomVariableWhichIsVeryLongSoThatThisGetsOverTheColumnLimit.Players_F:GetChildren() - 1 .. "/20"
+				local ratio = (minAxis - minAxisSize) / delta * (self.props.maxScaleRatio - self.props.minScaleRatio) + self.props.minScaleRatio
+				local ratio2 = (minAxis - minAxisSize) / delta * (self.props.maxScaleRatio - self.props.minScaleRatio) * self.props.aRandomVariableWhichIsVeryLong + self.props.minScaleRatio
+			end
+		end
+	end
+end

--- a/tests/snapshots/tests__standard@multiline-expressions-3.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-expressions-3.lua.snap
@@ -1,0 +1,24 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+do
+	do
+		do
+			do
+				local text = "Players: "
+					.. #Server_Container.ARandomVariableWhichIsVeryLongSoThatThisGetsOverTheColumnLimit.Players_F:GetChildren() - 1
+					.. "/20"
+				local ratio = (minAxis - minAxisSize) / delta * (self.props.maxScaleRatio - self.props.minScaleRatio)
+					+ self.props.minScaleRatio
+				local ratio2 = (minAxis - minAxisSize)
+						/ delta
+						* (self.props.maxScaleRatio - self.props.minScaleRatio)
+						* self.props.aRandomVariableWhichIsVeryLong
+					+ self.props.minScaleRatio
+			end
+		end
+	end
+end
+


### PR DESCRIPTION
Improves the way Binary expressions are now hung, taking into account the operator precedence level and associativity.
For example:
Instead of
```lua
blablabla.Text = "Players: "
  .. #blablabla:GetChildren()
  - 1
  .. "/20"
```
we do
```lua
blablabla.Text = "Players: "
  .. #blablabla:GetChildren() - 1
  .. "/20"
```

Instead of 
```lua
local ratio = (minAxis - minAxisSize)
        / delta
        * (self.props.maxScaleRatio - self.props.minScaleRatio)
        + self.props.minScaleRatio
```
we do
```lua
local ratio = (minAxis - minAxisSize) / delta * (self.props.maxScaleRatio - self.props.minScaleRatio)
	+ self.props.minScaleRatio
```
since it falls under the column width.
If it was over the column width, such as
```lua
local ratio2 = (minAxis - minAxisSize) / delta * (self.props.maxScaleRatio - self.props.minScaleRatio) * self.props.aRandomVariableWhichIsVeryLong + self.props.minScaleRatio
```
we now format as
```lua
local ratio2 = (minAxis - minAxisSize)
		/ delta
		* (self.props.maxScaleRatio - self.props.minScaleRatio)
		* self.props.aRandomVariableWhichIsVeryLong
	+ self.props.minScaleRatio
```
This helps to indicate the precedence between the operators, since the ones with the same precedence will stay by itself.
A further improvement could be to put the `/ delta` on the first line, however this is not covered in this PR. This could be done at a later stage, but this PR already provides a better output compared to previous

Closes #58