### PR TITLE
Improve internal code for trivia formatting

### DIFF
--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -67,7 +67,7 @@ fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'a
     let mut expr_list = assignment.expressions().to_owned();
     if let Some(last_pair) = expr_list.pop() {
         expr_list.push(
-            last_pair.map(|value| value.update_leading_trivia(FormatTriviaType::Replace(vec![]))),
+            last_pair.map(|value| value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))),
         );
     }
 

--- a/src/formatters/assignment_formatter.rs
+++ b/src/formatters/assignment_formatter.rs
@@ -8,47 +8,38 @@ use full_moon::node::Node;
 use full_moon::tokenizer::{Token, TokenKind, TokenReference};
 
 use crate::formatters::{
-    trivia_formatter::{self, FormatTriviaType},
+    trivia_formatter::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
     trivia_util, CodeFormatter,
 };
 
-/// Wrapper around [`token_reference_add_trivia`] to only add trailing trivia
-fn token_reference_add_trailing_trivia<'ast>(
-    token: TokenReference<'ast>,
-    trailing_trivia: FormatTriviaType<'ast>,
-) -> TokenReference<'ast> {
-    trivia_formatter::token_reference_add_trivia(token, FormatTriviaType::NoChange, trailing_trivia)
-}
-
-/// Adds trailing trivia at the end of a [`Punctuated`] sequence, using the provider `adder` function
-fn add_punctuated_trailing_trivia<'ast, T, F>(
+/// Adds trailing trivia at the end of a [`Punctuated`] sequence
+fn add_punctuated_trailing_trivia<'ast, T>(
     punctuated: &mut Punctuated<'ast, T>,
     trivia: Vec<Token<'ast>>,
-    adder: F,
 ) where
-    F: Fn(T, FormatTriviaType<'ast>) -> T,
+    T: UpdateTrailingTrivia<'ast>,
 {
     // Add any trailing trivia to the end of the punctuated list
     if let Some(pair) = punctuated.pop() {
-        let pair = pair.map(|expr| adder(expr, FormatTriviaType::Append(trivia)));
+        let pair = pair.map(|expr| expr.update_trailing_trivia(FormatTriviaType::Append(trivia)));
         punctuated.push(pair);
     }
 }
 
-/// Adds trailing trivia at the end of a [`Punctuated`] sequence, using the provider `adder` function
-fn add_punctuated_leading_trivia<'ast, T, F>(
+/// Adds trailing trivia at the end of a [`Punctuated`] sequence
+fn add_punctuated_leading_trivia<'ast, T>(
     punctuated: Punctuated<'ast, T>,
     trivia: Vec<Token<'ast>>,
-    adder: F,
 ) -> Punctuated<'ast, T>
 where
-    F: Fn(T, FormatTriviaType<'ast>) -> T,
+    T: UpdateLeadingTrivia<'ast>,
 {
     let mut iterator = punctuated.into_pairs();
 
     // Retrieve first item and add leading trivia
     if let Some(first_pair) = iterator.next() {
-        let updated_pair = first_pair.map(|value| adder(value, FormatTriviaType::Append(trivia)));
+        let updated_pair =
+            first_pair.map(|value| value.update_leading_trivia(FormatTriviaType::Append(trivia)));
         let iterator = std::iter::once(updated_pair).chain(iterator);
         iterator.collect()
     } else {
@@ -65,21 +56,19 @@ fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'a
         if added_first {
             var_list.push(pair.to_owned());
         } else {
-            var_list.push(pair.to_owned().map(|value| {
-                trivia_formatter::var_add_leading_trivia(value, FormatTriviaType::Replace(vec![]))
-            }));
+            var_list.push(
+                pair.to_owned()
+                    .map(|value| value.update_leading_trivia(FormatTriviaType::Replace(vec![]))),
+            );
             added_first = true;
         }
     }
 
     let mut expr_list = assignment.expressions().to_owned();
     if let Some(last_pair) = expr_list.pop() {
-        expr_list.push(last_pair.map(|value| {
-            trivia_formatter::expression_add_trailing_trivia(
-                value,
-                FormatTriviaType::Replace(vec![]),
-            )
-        }));
+        expr_list.push(
+            last_pair.map(|value| value.update_leading_trivia(FormatTriviaType::Replace(vec![]))),
+        );
     }
 
     Assignment::new(var_list, expr_list).with_equal_token(assignment.equal_token().to_owned())
@@ -89,34 +78,27 @@ fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'a
 fn strip_local_assignment_trivia<'ast>(
     local_assignment: &LocalAssignment<'ast>,
 ) -> LocalAssignment<'ast> {
-    let local_token = trivia_formatter::token_reference_add_trivia(
-        local_assignment.local_token().to_owned(),
-        FormatTriviaType::Replace(vec![]),
-        FormatTriviaType::NoChange,
-    );
+    let local_token = local_assignment
+        .local_token()
+        .update_leading_trivia(FormatTriviaType::Replace(vec![]));
 
     if local_assignment.expressions().is_empty() {
         let mut name_list = local_assignment.names().to_owned();
         if let Some(last_pair) = name_list.pop() {
-            name_list.push(last_pair.map(|value| {
-                trivia_formatter::token_reference_add_trivia(
-                    value,
-                    FormatTriviaType::NoChange,
-                    FormatTriviaType::Replace(vec![]),
-                )
-            }));
+            name_list.push(
+                last_pair
+                    .map(|value| value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))),
+            );
         }
 
         LocalAssignment::new(name_list).with_local_token(local_token)
     } else {
         let mut expr_list = local_assignment.expressions().to_owned();
         if let Some(last_pair) = expr_list.pop() {
-            expr_list.push(last_pair.map(|value| {
-                trivia_formatter::expression_add_trailing_trivia(
-                    value,
-                    FormatTriviaType::Replace(vec![]),
-                )
-            }));
+            expr_list.push(
+                last_pair
+                    .map(|value| value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))),
+            );
         }
         LocalAssignment::new(local_assignment.names().to_owned())
             .with_local_token(local_token)
@@ -184,11 +166,8 @@ impl CodeFormatter {
             .map(|x| x.to_owned())
             .collect();
 
-            trivia_formatter::token_reference_add_trivia(
-                equal_token,
-                FormatTriviaType::NoChange,
-                FormatTriviaType::Replace(equal_token_trailing_trivia),
-            )
+            equal_token
+                .update_trailing_trivia(FormatTriviaType::Replace(equal_token_trailing_trivia))
         } else {
             equal_token
         }
@@ -255,15 +234,10 @@ impl CodeFormatter {
                 .chain(trailing_trivia.iter())
                 .map(|x| x.to_owned())
                 .collect(),
-            trivia_formatter::expression_add_trailing_trivia,
         );
 
         // Add on leading trivia
-        let formatted_var_list = add_punctuated_leading_trivia(
-            var_list,
-            leading_trivia,
-            trivia_formatter::var_add_leading_trivia,
-        );
+        let formatted_var_list = add_punctuated_leading_trivia(var_list, leading_trivia);
 
         formatted_assignment
             .with_variables(formatted_var_list)
@@ -284,11 +258,8 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let local_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, assignment.local_token(), "local "),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::NoChange,
-        );
+        let local_token = crate::fmt_symbol!(self, assignment.local_token(), "local ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
 
         let (mut name_list, name_list_comments_buf) = self.format_punctuated(
             assignment.names(),
@@ -311,11 +282,9 @@ impl CodeFormatter {
 
             #[cfg(feature = "luau")]
             if let Some(Some(specifier)) = type_specifiers.pop() {
-                let specifier = trivia_formatter::type_specifier_add_trailing_trivia(
-                    specifier,
+                type_specifiers.push(Some(specifier.update_trailing_trivia(
                     FormatTriviaType::Append(trailing_trivia.to_owned()),
-                );
-                type_specifiers.push(Some(specifier));
+                )));
                 new_line_added = true;
             }
 
@@ -330,7 +299,6 @@ impl CodeFormatter {
                         .map(|x| x.to_owned())
                         .collect(),
                 },
-                token_reference_add_trailing_trivia,
             );
 
             let local_assignment = LocalAssignment::new(name_list)
@@ -396,7 +364,6 @@ impl CodeFormatter {
                     .chain(trailing_trivia.iter())
                     .map(|x| x.to_owned())
                     .collect(),
-                trivia_formatter::expression_add_trailing_trivia,
             );
 
             // Update our local assignment

--- a/src/formatters/block_formatter.rs
+++ b/src/formatters/block_formatter.rs
@@ -1,6 +1,6 @@
 use crate::formatters::{
     trivia_formatter::{
-        self, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
+        strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
     },
     trivia_util, CodeFormatter, Range,
 };
@@ -102,8 +102,10 @@ impl CodeFormatter {
             )
         } else {
             // Determine if we need to hang the condition
-            let first_line_str =
-                trivia_formatter::no_comments(return_node.token()) + &formatted_returns.to_string();
+            let first_line_str = strip_trivia(return_node.token()).to_string()
+                + " "
+                + &strip_trivia(&formatted_returns).to_string();
+
             let indent_spacing = (self.indent_level + additional_indent_level.unwrap_or(0))
                 * self.config.indent_width;
             let require_multiline_expression = (indent_spacing

--- a/src/formatters/lua52_formatter.rs
+++ b/src/formatters/lua52_formatter.rs
@@ -1,5 +1,5 @@
 use crate::formatters::{
-    trivia_formatter::{self, FormatTriviaType},
+    trivia_formatter::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
     CodeFormatter,
 };
 use full_moon::ast::lua52::{Goto, Label};
@@ -13,17 +13,12 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let goto_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, goto.goto_token(), "goto "),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::NoChange,
-        );
+        let goto_token = crate::fmt_symbol!(self, goto.goto_token(), "goto ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
 
-        let label_name = trivia_formatter::token_reference_add_trivia(
-            self.format_token_reference(goto.label_name()),
-            FormatTriviaType::NoChange,
-            FormatTriviaType::Append(trailing_trivia),
-        );
+        let label_name = self
+            .format_token_reference(goto.label_name())
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
         Goto::new(label_name).with_goto_token(goto_token)
     }
@@ -35,18 +30,12 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let left_colons = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, label.left_colons(), "::"),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::NoChange,
-        );
+        let left_colons = crate::fmt_symbol!(self, label.left_colons(), "::")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
         let name = self.format_token_reference(label.name());
 
-        let right_colons = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, label.right_colons(), "::"),
-            FormatTriviaType::NoChange,
-            FormatTriviaType::Append(trailing_trivia),
-        );
+        let right_colons = crate::fmt_symbol!(self, label.right_colons(), "::")
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
         Label::new(name)
             .with_left_colons(left_colons)

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -1,5 +1,7 @@
 use crate::formatters::{
-    trivia_formatter::{self, FormatTriviaType},
+    trivia_formatter::{
+        self, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
+    },
     trivia_util, CodeFormatter,
 };
 use full_moon::ast::{Do, ElseIf, FunctionCall, GenericFor, If, NumericFor, Repeat, Stmt, While};
@@ -28,16 +30,11 @@ impl CodeFormatter {
             FormatTriviaType::Append(vec![self.create_indent_trivia(additional_indent_level)]);
         let trailing_trivia = FormatTriviaType::Append(vec![self.create_newline_trivia()]);
 
-        let do_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, do_block.do_token(), "do"),
-            leading_trivia.to_owned(),
-            trailing_trivia.to_owned(),
-        );
-        let end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(do_block.end_token()),
-            leading_trivia,
-            trailing_trivia,
-        );
+        let do_token = crate::fmt_symbol!(self, do_block.do_token(), "do")
+            .update_trivia(leading_trivia.to_owned(), trailing_trivia.to_owned());
+        let end_token = self
+            .format_end_token(do_block.end_token())
+            .update_trivia(leading_trivia, trailing_trivia);
 
         do_block
             .to_owned()
@@ -53,11 +50,8 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let mut trailing_trivia = vec![self.create_newline_trivia()];
 
-        let for_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, generic_for.for_token(), "for "),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let for_token = crate::fmt_symbol!(self, generic_for.for_token(), "for ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
         let (formatted_names, mut names_comments_buf) = self.format_punctuated(
             generic_for.names(),
             &CodeFormatter::format_token_reference_mut,
@@ -81,17 +75,15 @@ impl CodeFormatter {
         // Append trailing trivia to the end
         names_comments_buf.append(&mut trailing_trivia);
 
-        let do_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, generic_for.do_token(), " do"),
-            FormatTriviaType::NoChange,
-            FormatTriviaType::Append(names_comments_buf),
-        );
+        let do_token = crate::fmt_symbol!(self, generic_for.do_token(), " do")
+            .update_trailing_trivia(FormatTriviaType::Append(names_comments_buf));
 
-        let end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(generic_for.end_token()),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(vec![self.create_newline_trivia()]), // trailing_trivia was emptied when it was appended to names_comment_buf
-        );
+        let end_token = self
+            .format_end_token(generic_for.end_token())
+            .update_trivia(
+                FormatTriviaType::Append(leading_trivia),
+                FormatTriviaType::Append(vec![self.create_newline_trivia()]), // trailing_trivia was emptied when it was appended to names_comment_buf
+            );
 
         let generic_for = generic_for
             .to_owned()
@@ -131,11 +123,9 @@ impl CodeFormatter {
             ("elseif ", " then")
         };
 
-        let formatted_else_if_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, else_if_node.else_if_token(), else_if_text),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let formatted_else_if_token =
+            crate::fmt_symbol!(self, else_if_node.else_if_token(), else_if_text)
+                .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -146,25 +136,23 @@ impl CodeFormatter {
             self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
             let condition = self.format_expression(else_if_node.condition());
-            trivia_formatter::expression_add_leading_trivia(
-                self.hang_expression(condition, additional_indent_level, None),
-                FormatTriviaType::Append(vec![
+            self.hang_expression(condition, additional_indent_level, None)
+                .update_leading_trivia(FormatTriviaType::Append(vec![
                     self.create_indent_trivia(Some(additional_indent_level.unwrap_or(0) + 1))
-                ]),
-            )
+                ]))
         } else {
             self.format_expression(else_if_node.condition())
         };
 
-        let formatted_then_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, else_if_node.then_token(), then_text),
-            if require_multiline_expression {
-                FormatTriviaType::Append(leading_trivia)
-            } else {
-                FormatTriviaType::NoChange
-            },
-            FormatTriviaType::Append(trailing_trivia),
-        );
+        let formatted_then_token = crate::fmt_symbol!(self, else_if_node.then_token(), then_text)
+            .update_trivia(
+                if require_multiline_expression {
+                    FormatTriviaType::Append(leading_trivia)
+                } else {
+                    FormatTriviaType::NoChange
+                },
+                FormatTriviaType::Append(trailing_trivia),
+            );
 
         else_if_node
             .to_owned()
@@ -197,11 +185,8 @@ impl CodeFormatter {
             ("if ", " then")
         };
 
-        let formatted_if_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, if_node.if_token(), if_text),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let formatted_if_token = crate::fmt_symbol!(self, if_node.if_token(), if_text)
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -212,27 +197,24 @@ impl CodeFormatter {
             self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
             let condition = self.format_expression(if_node.condition());
-            trivia_formatter::expression_add_leading_trivia(
-                self.hang_expression(condition, additional_indent_level, None),
-                FormatTriviaType::Append(vec![
+            self.hang_expression(condition, additional_indent_level, None)
+                .update_leading_trivia(FormatTriviaType::Append(vec![
                     self.create_indent_trivia(Some(additional_indent_level.unwrap_or(0) + 1))
-                ]),
-            )
+                ]))
         } else {
             self.format_expression(if_node.condition())
         };
 
-        let formatted_then_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, if_node.then_token(), then_text),
-            if require_multiline_expression {
-                FormatTriviaType::Append(leading_trivia.to_owned())
-            } else {
-                FormatTriviaType::NoChange
-            },
-            FormatTriviaType::Append(trailing_trivia.to_owned()),
-        );
-        let formatted_end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(if_node.end_token()),
+        let formatted_then_token = crate::fmt_symbol!(self, if_node.then_token(), then_text)
+            .update_trivia(
+                if require_multiline_expression {
+                    FormatTriviaType::Append(leading_trivia.to_owned())
+                } else {
+                    FormatTriviaType::NoChange
+                },
+                FormatTriviaType::Append(trailing_trivia.to_owned()),
+            );
+        let formatted_end_token = self.format_end_token(if_node.end_token()).update_trivia(
             FormatTriviaType::Append(leading_trivia.to_owned()),
             FormatTriviaType::Append(trailing_trivia.to_owned()),
         );
@@ -249,8 +231,7 @@ impl CodeFormatter {
 
         let formatted_else_token = match if_node.else_token() {
             Some(token) => {
-                let formatted = trivia_formatter::token_reference_add_trivia(
-                    crate::fmt_symbol!(self, token, "else"),
+                let formatted = crate::fmt_symbol!(self, token, "else").update_trivia(
                     FormatTriviaType::Append(leading_trivia),
                     FormatTriviaType::Append(trailing_trivia),
                 );
@@ -277,11 +258,8 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let for_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, numeric_for.for_token(), "for "),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let for_token = crate::fmt_symbol!(self, numeric_for.for_token(), "for ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
         let formatted_index_variable = self.format_token_reference(numeric_for.index_variable());
 
         #[cfg(feature = "luau")]
@@ -307,16 +285,14 @@ impl CodeFormatter {
             None => (None, None),
         };
 
-        let do_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, numeric_for.do_token(), " do"),
-            FormatTriviaType::NoChange,
-            FormatTriviaType::Append(trailing_trivia.to_owned()),
-        );
-        let end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(numeric_for.end_token()),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(trailing_trivia),
-        );
+        let do_token = crate::fmt_symbol!(self, numeric_for.do_token(), " do")
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
+        let end_token = self
+            .format_end_token(numeric_for.end_token())
+            .update_trivia(
+                FormatTriviaType::Append(leading_trivia),
+                FormatTriviaType::Append(trailing_trivia),
+            );
 
         let numeric_for = numeric_for
             .to_owned()
@@ -344,16 +320,13 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let repeat_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, repeat_block.repeat_token(), "repeat"),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::Append(trailing_trivia.to_owned()),
-        );
-        let until_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, repeat_block.until_token(), "until "),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let repeat_token = crate::fmt_symbol!(self, repeat_block.repeat_token(), "repeat")
+            .update_trivia(
+                FormatTriviaType::Append(leading_trivia.to_owned()),
+                FormatTriviaType::Append(trailing_trivia.to_owned()),
+            );
+        let until_token = crate::fmt_symbol!(self, repeat_block.until_token(), "until ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
 
         // Determine if we need to hang the until expression
         let last_line_str = trivia_formatter::no_comments(repeat_block.until_token())
@@ -375,10 +348,9 @@ impl CodeFormatter {
                 self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
                 self.hang_expression(formatted_until, additional_indent_level, None)
             }
-            false => trivia_formatter::expression_add_trailing_trivia(
-                formatted_until,
-                FormatTriviaType::Append(trailing_trivia),
-            ),
+            false => {
+                formatted_until.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia))
+            }
         };
 
         repeat_block
@@ -412,11 +384,8 @@ impl CodeFormatter {
             ("while ", " do")
         };
 
-        let while_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, while_block.while_token(), while_text),
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::NoChange,
-        );
+        let while_token = crate::fmt_symbol!(self, while_block.while_token(), while_text)
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
 
         let formatted_condition = if require_multiline_expression {
             // Add the expression list into the indent range, as it will be indented by one
@@ -427,27 +396,23 @@ impl CodeFormatter {
             self.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
             let condition = self.format_expression(while_block.condition());
-            trivia_formatter::expression_add_leading_trivia(
-                self.hang_expression(condition, additional_indent_level, None),
-                FormatTriviaType::Append(vec![
+            self.hang_expression(condition, additional_indent_level, None)
+                .update_leading_trivia(FormatTriviaType::Append(vec![
                     self.create_indent_trivia(Some(additional_indent_level.unwrap_or(0) + 1))
-                ]),
-            )
+                ]))
         } else {
             self.format_expression(while_block.condition())
         };
 
-        let do_token = trivia_formatter::token_reference_add_trivia(
-            crate::fmt_symbol!(self, while_block.do_token(), do_text),
-            FormatTriviaType::NoChange,
-            FormatTriviaType::Append(trailing_trivia.to_owned()),
-        );
+        let do_token = crate::fmt_symbol!(self, while_block.do_token(), do_text)
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
 
-        let end_token = trivia_formatter::token_reference_add_trivia(
-            self.format_end_token(while_block.end_token()),
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(trailing_trivia),
-        );
+        let end_token = self
+            .format_end_token(while_block.end_token())
+            .update_trivia(
+                FormatTriviaType::Append(leading_trivia),
+                FormatTriviaType::Append(trailing_trivia),
+            );
 
         while_block
             .to_owned()
@@ -470,13 +435,8 @@ impl CodeFormatter {
         let leading_trivia = vec![self.create_indent_trivia(additional_indent_level)];
         let trailing_trivia = vec![self.create_newline_trivia()];
 
-        let formatted_function_call = self.format_function_call(function_call);
-
-        trivia_formatter::function_call_add_trailing_trivia(
-            trivia_formatter::function_call_add_leading_trivia(
-                formatted_function_call,
-                FormatTriviaType::Append(leading_trivia),
-            ),
+        self.format_function_call(function_call).update_trivia(
+            FormatTriviaType::Append(leading_trivia),
             FormatTriviaType::Append(trailing_trivia),
         )
     }

--- a/src/formatters/stmt_formatter.rs
+++ b/src/formatters/stmt_formatter.rs
@@ -1,6 +1,6 @@
 use crate::formatters::{
     trivia_formatter::{
-        self, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
+        strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
     },
     trivia_util, CodeFormatter,
 };
@@ -108,12 +108,14 @@ impl CodeFormatter {
         let trailing_trivia = vec![self.create_newline_trivia()];
 
         // Determine if we need to hang the condition
-        let last_line_str = trivia_formatter::no_comments(else_if_node.else_if_token())
-            + &else_if_node.condition().to_string()
-            + &trivia_formatter::no_comments(else_if_node.then_token());
+        let last_line_str_len = (strip_trivia(else_if_node.else_if_token()).to_string()
+            + &strip_trivia(else_if_node.condition()).to_string()
+            + &strip_trivia(else_if_node.then_token()).to_string())
+            .len()
+            + 2; // Include space before and after condition
         let indent_spacing =
             (self.indent_level + additional_indent_level.unwrap_or(0)) * self.config.indent_width;
-        let require_multiline_expression = (indent_spacing + last_line_str.len())
+        let require_multiline_expression = (indent_spacing + last_line_str_len)
             > self.config.column_width
             || trivia_util::expression_contains_inline_comments(else_if_node.condition());
 
@@ -170,12 +172,14 @@ impl CodeFormatter {
         let trailing_trivia = vec![self.create_newline_trivia()];
 
         // Determine if we need to hang the condition
-        let last_line_str = trivia_formatter::no_comments(if_node.if_token())
-            + &if_node.condition().to_string()
-            + &trivia_formatter::no_comments(if_node.then_token());
+        let last_line_str_len = (strip_trivia(if_node.if_token()).to_string()
+            + &strip_trivia(if_node.condition()).to_string()
+            + &strip_trivia(if_node.then_token()).to_string())
+            .len()
+            + 2; // Include space before and after condition
         let indent_spacing =
             (self.indent_level + additional_indent_level.unwrap_or(0)) * self.config.indent_width;
-        let require_multiline_expression = (indent_spacing + last_line_str.len())
+        let require_multiline_expression = (indent_spacing + last_line_str_len)
             > self.config.column_width
             || trivia_util::expression_contains_inline_comments(if_node.condition());
 
@@ -328,12 +332,15 @@ impl CodeFormatter {
         let until_token = crate::fmt_symbol!(self, repeat_block.until_token(), "until ")
             .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
 
-        // Determine if we need to hang the until expression
-        let last_line_str = trivia_formatter::no_comments(repeat_block.until_token())
-            + &repeat_block.until().to_string();
+        // Determine if we need to hang the condition
+        let last_line_str_len = (strip_trivia(repeat_block.until_token()).to_string()
+            + &strip_trivia(repeat_block.until()).to_string())
+            .len()
+            + 1; // Include space before until and condition
+
         let indent_spacing =
             (self.indent_level + additional_indent_level.unwrap_or(0)) * self.config.indent_width;
-        let require_multiline_expression = (indent_spacing + last_line_str.len())
+        let require_multiline_expression = (indent_spacing + last_line_str_len)
             > self.config.column_width
             || trivia_util::expression_contains_inline_comments(repeat_block.until());
 
@@ -369,12 +376,14 @@ impl CodeFormatter {
         let trailing_trivia = vec![self.create_newline_trivia()];
 
         // Determine if we need to hang the condition
-        let last_line_str = trivia_formatter::no_comments(while_block.while_token())
-            + &while_block.condition().to_string()
-            + &trivia_formatter::no_comments(while_block.do_token());
+        let last_line_str = strip_trivia(while_block.while_token()).to_string()
+            + &strip_trivia(while_block.condition()).to_string()
+            + &strip_trivia(while_block.do_token()).to_string();
+        let last_line_str_len = last_line_str.len() + 2; // Include space before and after condition
+
         let indent_spacing =
             (self.indent_level + additional_indent_level.unwrap_or(0)) * self.config.indent_width;
-        let require_multiline_expression = (indent_spacing + last_line_str.len())
+        let require_multiline_expression = (indent_spacing + last_line_str_len)
             > self.config.column_width
             || trivia_util::expression_contains_inline_comments(while_block.condition());
 

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -22,9 +22,14 @@ pub enum FormatTriviaType<'ast> {
     NoChange,
 }
 
-/// Returns a string presentation of a TokenReference with all trivia removed
-pub fn no_comments(token: &TokenReference) -> String {
-    token.token().to_string()
+/// Strips all leading and trailing trivia from a specific node.
+/// This is useful if we need to use the node to calculate sizing, whilst we do not want trivia included
+pub fn strip_trivia<'ast, T>(item: &T) -> T
+where
+    T: UpdateLeadingTrivia<'ast> + UpdateTrailingTrivia<'ast>,
+{
+    item.update_leading_trivia(FormatTriviaType::Replace(vec![]))
+        .update_trailing_trivia(FormatTriviaType::Replace(vec![]))
 }
 
 impl CodeFormatter {

--- a/src/formatters/trivia_formatter.rs
+++ b/src/formatters/trivia_formatter.rs
@@ -429,7 +429,8 @@ define_update_trailing_trivia!(FunctionArgs, |this, trailing| {
 });
 
 define_update_trailing_trivia!(FunctionBody, |this, trailing| {
-    this.with_end_token(this.end_token().update_trailing_trivia(trailing))
+    this.to_owned()
+        .with_end_token(this.end_token().update_trailing_trivia(trailing))
 });
 
 define_update_trivia!(FunctionCall, |this, leading, trailing| {
@@ -448,7 +449,7 @@ define_update_trivia!(FunctionCall, |this, leading, trailing| {
         }
     };
 
-    this.with_prefix(prefix).with_suffixes(suffixes)
+    this.to_owned().with_prefix(prefix).with_suffixes(suffixes)
 });
 
 define_update_trailing_trivia!(Index, |this, trailing| {
@@ -469,7 +470,8 @@ define_update_trailing_trivia!(Index, |this, trailing| {
 });
 
 define_update_trailing_trivia!(MethodCall, |this, trailing| {
-    this.with_args(this.args().update_trailing_trivia(trailing))
+    this.to_owned()
+        .with_args(this.args().update_trailing_trivia(trailing))
 });
 
 define_update_trivia!(Parameter, |this, leading, trailing| {
@@ -501,7 +503,8 @@ define_update_trailing_trivia!(Suffix, |this, trailing| {
 });
 
 define_update_trivia!(TableConstructor, |this, leading, trailing| {
-    this.with_braces(this.braces().update_trivia(leading, trailing))
+    this.to_owned()
+        .with_braces(this.braces().update_trivia(leading, trailing))
 });
 
 define_update_leading_trivia!(UnOp, |this, leading| {
@@ -607,7 +610,7 @@ define_update_trivia!(VarExpression, |this, leading, trailing| {
         }
     };
 
-    this.with_prefix(prefix).with_suffixes(suffixes)
+    this.to_owned().with_prefix(prefix).with_suffixes(suffixes)
 });
 
 #[cfg(feature = "luau")]
@@ -721,10 +724,12 @@ define_update_trailing_trivia!(IndexedTypeInfo, |this, trailing| {
 
 #[cfg(feature = "luau")]
 define_update_trailing_trivia!(TypeAssertion, |this, trailing| {
-    this.with_cast_to(this.cast_to().update_trailing_trivia(trailing))
+    this.to_owned()
+        .with_cast_to(this.cast_to().update_trailing_trivia(trailing))
 });
 
 #[cfg(feature = "luau")]
 define_update_trailing_trivia!(TypeSpecifier, |this, trailing| {
-    this.with_type_info(this.type_info().update_trailing_trivia(trailing))
+    this.to_owned()
+        .with_type_info(this.type_info().update_trailing_trivia(trailing))
 });

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -1,10 +1,12 @@
 use crate::formatters::trivia_formatter::{FormatTriviaType, UpdateTrailingTrivia};
 #[cfg(feature = "luau")]
+use full_moon::ast::span::ContainedSpan;
+#[cfg(feature = "luau")]
 use full_moon::ast::types::{IndexedTypeInfo, TypeDeclaration, TypeInfo};
 use full_moon::{
     ast::{
-        span::ContainedSpan, BinOp, Call, Expression, Field, FunctionArgs, Index, LastStmt, Prefix,
-        Stmt, Suffix, TableConstructor, UnOp, Value, Var,
+        BinOp, Call, Expression, Field, FunctionArgs, Index, LastStmt, Prefix, Stmt, Suffix,
+        TableConstructor, UnOp, Value, Var,
     },
     node::Node,
     tokenizer::{Token, TokenKind, TokenReference, TokenType},
@@ -710,11 +712,9 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                 .trailing_trivia()
                 .map(|x| x.to_owned())
                 .collect();
-            let label_name = trivia_formatter::token_reference_add_trivia(
-                stmt.label_name().to_owned(),
-                FormatTriviaType::NoChange,
-                FormatTriviaType::Replace(vec![]),
-            );
+            let label_name = stmt
+                .label_name()
+                .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
             (
                 Stmt::Goto(stmt.with_label_name(label_name)),
                 trailing_trivia,
@@ -727,11 +727,9 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                 .trailing_trivia()
                 .map(|x| x.to_owned())
                 .collect();
-            let right_colons = trivia_formatter::token_reference_add_trivia(
-                stmt.right_colons().to_owned(),
-                FormatTriviaType::NoChange,
-                FormatTriviaType::Replace(vec![]),
-            );
+            let right_colons = stmt
+                .right_colons()
+                .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
             (
                 Stmt::Label(stmt.with_right_colons(right_colons)),
                 trailing_trivia,


### PR DESCRIPTION
Makes internal code for trivia formatting more generic, and easier to use in the long run
- Introduces traits `UpdateLeadingTrivia`, `UpdateTrailingTrivia` and `UpdateTrivia`, which contain methods `update_leading_trivia()`, `update_trailing_trivia()`, and `update_trivia()` respectively.
- Implement trait for all relevant full_moon nodes, scrapping the legacy `XXXX_add_leading_trivia()` etc. methods.
- Use trait for more generic function signatures, so we can cover more areas with less duplicated code.
- Implement trivia formatting for Punctuated sequences, and make it more generic.
- Introduce a trivia stripping function, allowing us to get just the node without any leading or trailing trivia, which helps in length calculations. This supersedes the original `no_comments` function.