### PR TITLE
Exclude unnecessary files from the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["cli", "utility", "lua", "lua51", "formatter"]
 edition = "2018"
+exclude = ["stylua-vscode/**", "tests/**", "benches/**"]
 
 [lib]
 name = "stylua_lib"


### PR DESCRIPTION
By default, Rust publishes all content versioned by git in the package.
This excludes unnecessary files, making the crate leaner (going from 202KB for published stylua 0.7.0, to 62KB)
The crate was already pretty small, but this makes it much smaller!