### PR TITLE
Improve removing expression parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Parentheses around conditions are now removed, as they are not required in Lua. `if (foo and (not bar or baz)) then ... end` turns to `if foo and (not bar or baz) then ... end`
+
+### Changed
+- Changed the heursitics for when parentheses are removed around expressions. Parentheses will now never be removed around a function call prefix (e.g. `("hello"):len()`)
 
 ## [0.7.1] - 2021-04-19
 ### Fixed

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -59,18 +59,9 @@ impl CodeFormatter {
             Expression::BinaryOperator { .. } => false,
             Expression::Value { value, .. } => {
                 match &**value {
-                    // Internal expression is a function definition
-                    // This may be something like (function() ... end)(); removing the parentheses will break the code
-                    Value::Function(_) => false,
                     // Internal expression is a function call
                     // We could potentially be culling values, so we should not remove parentheses
                     Value::FunctionCall(_) => false,
-                    // Table wrapped around in parentheses
-                    // This could potentially be for a method call on the table, e.g. ({}):foo()
-                    Value::TableConstructor(_) => false,
-                    // String literal inside of parentheses
-                    // This could be a part of a function call e.g. ("hello"):sub(), so we must leave the parentheses
-                    Value::String(_) => false,
                     Value::Symbol(token_ref) => {
                         match token_ref.token_type() {
                             // If we have an ellipse inside of parentheses, we may also be culling values

--- a/src/formatters/expression_formatter.rs
+++ b/src/formatters/expression_formatter.rs
@@ -16,6 +16,14 @@ macro_rules! fmt_op {
     };
 }
 
+enum ExpressionContext {
+    /// Standard expression, with no special context
+    Standard,
+    /// The expression originates from a [`Prefix`] node. The special context here is that the expression will
+    /// always be wrapped in parentheses.
+    Prefix,
+}
+
 impl CodeFormatter {
     pub fn format_binop<'ast>(&self, binop: &BinOp<'ast>) -> BinOp<'ast> {
         fmt_op!(self, BinOp, binop, {
@@ -80,6 +88,15 @@ impl CodeFormatter {
 
     /// Formats an Expression node
     pub fn format_expression<'ast>(&mut self, expression: &Expression<'ast>) -> Expression<'ast> {
+        self.format_expression_(expression, ExpressionContext::Standard)
+    }
+
+    /// Internal expression formatter, with access to expression context
+    fn format_expression_<'ast>(
+        &mut self,
+        expression: &Expression<'ast>,
+        context: ExpressionContext,
+    ) -> Expression<'ast> {
         match expression {
             Expression::Value {
                 value,
@@ -98,12 +115,11 @@ impl CodeFormatter {
                 expression,
             } => {
                 // Examine whether the internal expression requires parentheses
-                // If it doesn't, `use_internal_expression` will return a Some(), containing the external expression
-                // We should then return that external expression
-                // Otherwise, it will return None, and therefore we should use the original expression
+                // If not, just format and return the internal expression. Otherwise, format the parentheses
                 let use_internal_expression = CodeFormatter::check_excess_parentheses(expression);
 
-                if use_internal_expression {
+                // If the context is for a prefix, we should always keep the parentheses, as they are always required
+                if use_internal_expression && !matches!(context, ExpressionContext::Prefix) {
                     self.format_expression(expression)
                 } else {
                     Expression::Parentheses {
@@ -148,7 +164,7 @@ impl CodeFormatter {
     pub fn format_prefix<'ast>(&mut self, prefix: &Prefix<'ast>) -> Prefix<'ast> {
         match prefix {
             Prefix::Expression(expression) => {
-                Prefix::Expression(self.format_expression(expression))
+                Prefix::Expression(self.format_expression_(expression, ExpressionContext::Prefix))
             }
             Prefix::Name(token_reference) => {
                 Prefix::Name(self.format_token_reference(token_reference))

--- a/tests/inputs/condition-parentheses.lua
+++ b/tests/inputs/condition-parentheses.lua
@@ -1,0 +1,13 @@
+if (foo) then
+	print("true")
+elseif (bar) then
+	print("false")
+end
+
+while (foo) do
+	print("true")
+end
+
+repeat
+	print("yes")
+until (foo)

--- a/tests/inputs/excess-parentheses.lua
+++ b/tests/inputs/excess-parentheses.lua
@@ -23,3 +23,10 @@ print(((x())))
 path = (function()
   return true
 end)()
+
+-- The following should have parentheses removed, but if they were a Prefix, they wouldn't be removed
+local x = ({})
+local y = ("hello")
+local z = (function()
+	return true
+end)

--- a/tests/snapshots/tests__standard@condition-parentheses.lua.snap
+++ b/tests/snapshots/tests__standard@condition-parentheses.lua.snap
@@ -1,0 +1,19 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+if foo then
+	print("true")
+elseif bar then
+	print("false")
+end
+
+while foo do
+	print("true")
+end
+
+repeat
+	print("yes")
+until foo
+

--- a/tests/snapshots/tests__standard@excess-parentheses.lua.snap
+++ b/tests/snapshots/tests__standard@excess-parentheses.lua.snap
@@ -29,7 +29,7 @@ path = (function()
 	return true
 end)()
 
--- The following should have parentheses removed, but if they were a Prefix, they shouldn't be removed
+-- The following should have parentheses removed, but if they were a Prefix, they wouldn't be removed
 local x = {}
 local y = "hello"
 local z = function()

--- a/tests/snapshots/tests__standard@excess-parentheses.lua.snap
+++ b/tests/snapshots/tests__standard@excess-parentheses.lua.snap
@@ -29,3 +29,10 @@ path = (function()
 	return true
 end)()
 
+-- The following should have parentheses removed, but if they were a Prefix, they shouldn't be removed
+local x = {}
+local y = "hello"
+local z = function()
+	return true
+end
+


### PR DESCRIPTION
- Adds context for formatting expressions. If the context is a `Prefix`, then we never remove excess parentheses (because a prefix expression is always required to have parentheses wrapped around it, such as `("hello"):len()`).
- Remove excess parentheses around conditions - these are not required in Lua. i.e. `if (foo) then ... end` turns to `if foo then ... end`

Closes #54 

TODO: Update changelog