### PR TITLE
Remove need for comments buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed the heursitics for when parentheses are removed around expressions. Parentheses will now never be removed around a function call prefix (e.g. `("hello"):len()`)
+- Changed formatting for comma-separated lists. Previously, we would buffer the comments to the end of the list, but now we keep the comments next to where they original were.
 
 ## [0.7.1] - 2021-04-19
 ### Fixed

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -14,7 +14,7 @@ use crate::{
     fmt_symbol,
     formatters::{
         expression::{format_expression, format_var, hang_expression_no_trailing_newline},
-        general::{format_punctuated_, format_token_reference_mut, try_format_punctuated},
+        general::{format_punctuated, format_token_reference_mut, try_format_punctuated},
         trivia::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
         trivia_util,
         util::token_range,
@@ -135,7 +135,7 @@ pub fn format_assignment<'ast>(
 
     let var_list = try_format_punctuated(ctx, assignment.variables(), format_var);
     // Don't need to worry about comments in expr_list, as it will automatically force multiline
-    let mut expr_list = format_punctuated_(ctx, assignment.expressions(), format_expression);
+    let mut expr_list = format_punctuated(ctx, assignment.expressions(), format_expression);
 
     let mut equal_token = fmt_symbol!(ctx, assignment.equal_token(), " = ");
 
@@ -240,7 +240,7 @@ pub fn format_local_assignment<'ast>(
     } else {
         let mut equal_token = fmt_symbol!(ctx, assignment.equal_token().unwrap(), " = ");
         // Format the expression normally - if there are any comments, it will automatically force multiline
-        let mut expr_list = format_punctuated_(ctx, assignment.expressions(), format_expression);
+        let mut expr_list = format_punctuated(ctx, assignment.expressions(), format_expression);
         // Create our preliminary new assignment
         let local_assignment = LocalAssignment::new(name_list)
             .with_local_token(local_token)

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -18,7 +18,7 @@ use crate::{
             format_expression, format_prefix, format_suffix, hang_expression_no_trailing_newline,
         },
         general::{
-            format_contained_span, format_end_token, format_punctuated_, format_symbol,
+            format_contained_span, format_end_token, format_punctuated, format_symbol,
             format_token_reference, EndTokenType,
         },
         trivia::{
@@ -387,7 +387,7 @@ pub fn format_function_args<'ast>(
                 // multiline function args
 
                 let parentheses = format_contained_span(ctx, &parentheses);
-                let arguments = format_punctuated_(ctx, arguments, format_expression);
+                let arguments = format_punctuated(ctx, arguments, format_expression);
 
                 FunctionArgs::Parentheses {
                     parentheses,

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -18,7 +18,7 @@ use crate::{
             format_expression, format_prefix, format_suffix, hang_expression_no_trailing_newline,
         },
         general::{
-            format_contained_span, format_end_token, format_punctuated, format_symbol,
+            format_contained_span, format_end_token, format_punctuated_, format_symbol,
             format_token_reference, EndTokenType,
         },
         trivia::{
@@ -383,39 +383,15 @@ pub fn format_function_args<'ast>(
                     arguments: formatted_arguments,
                 }
             } else {
+                // We don't need to worry about comments here, as if there were comments present, we would have
+                // multiline function args
+
                 let parentheses = format_contained_span(ctx, &parentheses);
-
-                // If theres comments connected to the opening parentheses, we need to move them
-                let (start_parens, end_parens) = parentheses.tokens();
-                let mut parens_comments: Vec<Token<'ast>> = start_parens
-                    .trailing_trivia()
-                    .filter(|token| {
-                        token.token_kind() == TokenKind::SingleLineComment
-                            || token.token_kind() == TokenKind::MultiLineComment
-                    })
-                    .map(|x| {
-                        // Prepend a single space beforehand
-                        vec![Token::new(TokenType::spaces(1)), x.to_owned()]
-                    })
-                    .flatten()
-                    .collect();
-
-                // Format the arguments, and move any comments within them
-                let (formatted_arguments, mut comments_buffer) =
-                    format_punctuated(ctx, arguments, format_expression);
-
-                parens_comments.append(&mut comments_buffer);
-
-                // Recreate parentheses with the comments removed from the opening parens
-                // and all the comments placed at the end of the closing parens
-                let parentheses = ContainedSpan::new(
-                    start_parens.update_trailing_trivia(FormatTriviaType::Replace(vec![])),
-                    end_parens.update_trailing_trivia(FormatTriviaType::Append(parens_comments)),
-                );
+                let arguments = format_punctuated_(ctx, arguments, format_expression);
 
                 FunctionArgs::Parentheses {
                     parentheses,
-                    arguments: formatted_arguments,
+                    arguments,
                 }
             }
         }

--- a/src/formatters/general.rs
+++ b/src/formatters/general.rs
@@ -495,17 +495,13 @@ where
     F: Fn(&mut Context, &T) -> T,
 {
     let mut format_multiline = false;
-    let mut pairs = old.pairs();
 
-    while let Some(pair) = pairs.next() {
-        match pair {
-            Pair::Punctuated(_, punctuation) => {
-                if trivia_util::contains_comments(punctuation) {
-                    format_multiline = true;
-                    break;
-                }
+    for pair in old.pairs() {
+        if let Pair::Punctuated(_, punctuation) = pair {
+            if trivia_util::contains_comments(punctuation) {
+                format_multiline = true;
+                break;
             }
-            _ => (),
         }
     }
 

--- a/src/formatters/general.rs
+++ b/src/formatters/general.rs
@@ -372,7 +372,7 @@ pub fn format_punctuation<'ast>(
 
 // Formats a Punctuated sequence with correct punctuated values
 // If there are any comments in between tied to the punctuation, they will be removed and stored in a returned comments buffer
-pub fn format_punctuated<'a, T, F>(
+pub fn format_punctuated_buffer<'a, T, F>(
     ctx: &mut Context,
     old: &Punctuated<'a, T>,
     value_formatter: F,
@@ -407,7 +407,7 @@ where
 /// Formats a Punctuated sequence with correct punctuated values.
 /// This function assumes that there are no comments present which would lead to a syntax error if the list was collapsed.
 /// If not sure about comments, [`try_format_punctuated`] should be used instead.
-pub fn format_punctuated_<'a, T, F>(
+pub fn format_punctuated<'a, T, F>(
     ctx: &mut Context,
     old: &Punctuated<'a, T>,
     value_formatter: F,
@@ -512,7 +512,7 @@ where
     if format_multiline {
         format_punctuated_multiline(ctx, old, value_formatter, Some(1))
     } else {
-        format_punctuated_(ctx, old, value_formatter)
+        format_punctuated(ctx, old, value_formatter)
     }
 }
 

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -4,8 +4,8 @@ use crate::{
     formatters::{
         expression::{format_expression, format_var},
         general::{
-            format_contained_span, format_punctuated, format_symbol, format_token_reference,
-            format_token_reference_mut,
+            format_contained_span, format_symbol, format_token_reference,
+            format_token_reference_mut, try_format_punctuated,
         },
         table::{create_table_braces, TableType},
         trivia::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
@@ -80,7 +80,7 @@ pub fn format_type_info<'ast>(ctx: &mut Context, type_info: &TypeInfo<'ast>) -> 
             return_type,
         } => {
             let parentheses = format_contained_span(ctx, parentheses);
-            let arguments = format_punctuated(ctx, arguments, format_type_info).0;
+            let arguments = try_format_punctuated(ctx, arguments, format_type_info);
             let arrow = fmt_symbol!(ctx, arrow, " -> ");
             let return_type = Box::new(format_type_info(ctx, return_type));
             TypeInfo::Callback {
@@ -98,7 +98,7 @@ pub fn format_type_info<'ast>(ctx: &mut Context, type_info: &TypeInfo<'ast>) -> 
         } => {
             let base = format_token_reference(ctx, base);
             let arrows = format_contained_span(ctx, arrows);
-            let generics = format_punctuated(ctx, generics, format_type_info).0;
+            let generics = try_format_punctuated(ctx, generics, format_type_info);
             TypeInfo::Generic {
                 base,
                 arrows,
@@ -257,7 +257,7 @@ pub fn format_type_info<'ast>(ctx: &mut Context, type_info: &TypeInfo<'ast>) -> 
 
         TypeInfo::Tuple { parentheses, types } => {
             let parentheses = format_contained_span(ctx, parentheses);
-            let types = format_punctuated(ctx, types, format_type_info).0;
+            let types = try_format_punctuated(ctx, types, format_type_info);
 
             TypeInfo::Tuple { parentheses, types }
         }
@@ -290,7 +290,7 @@ pub fn format_indexed_type_info<'ast>(
         } => {
             let base = format_token_reference(ctx, base);
             let arrows = format_contained_span(ctx, arrows);
-            let generics = format_punctuated(ctx, generics, format_type_info).0;
+            let generics = try_format_punctuated(ctx, generics, format_type_info);
             IndexedTypeInfo::Generic {
                 base,
                 arrows,
@@ -404,12 +404,11 @@ pub fn format_generic_declaration<'ast>(
     generic_declaration: &GenericDeclaration<'ast>,
 ) -> GenericDeclaration<'ast> {
     let arrows = format_contained_span(ctx, generic_declaration.arrows());
-    let generics = format_punctuated(
+    let generics = try_format_punctuated(
         ctx,
         generic_declaration.generics(),
         format_token_reference_mut,
-    )
-    .0;
+    );
 
     generic_declaration
         .to_owned()

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -14,7 +14,7 @@ use crate::{
         expression::{format_expression, hang_expression},
         functions::{format_function_call, format_function_declaration, format_local_function},
         general::{
-            format_end_token, format_punctuated, format_token_reference,
+            format_end_token, format_punctuated_buffer, format_token_reference,
             format_token_reference_mut, EndTokenType,
         },
         trivia::{
@@ -88,7 +88,7 @@ pub fn format_generic_for<'ast>(
     let for_token = fmt_symbol!(ctx, generic_for.for_token(), "for ")
         .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
     let (formatted_names, mut names_comments_buf) =
-        format_punctuated(ctx, generic_for.names(), format_token_reference_mut);
+        format_punctuated_buffer(ctx, generic_for.names(), format_token_reference_mut);
 
     #[cfg(feature = "luau")]
     let type_specifiers = generic_for
@@ -101,7 +101,7 @@ pub fn format_generic_for<'ast>(
 
     let in_token = fmt_symbol!(ctx, generic_for.in_token(), " in ");
     let (formatted_expr_list, mut expr_comments_buf) =
-        format_punctuated(ctx, generic_for.expressions(), format_expression);
+        format_punctuated_buffer(ctx, generic_for.expressions(), format_expression);
 
     // Create comments buffer and append to end of do token
     names_comments_buf.append(&mut expr_comments_buf);

--- a/tests/snapshots/tests__standard@comments-buffer.lua.snap
+++ b/tests/snapshots/tests__standard@comments-buffer.lua.snap
@@ -33,5 +33,6 @@ then
 	print(code)
 end
 
-return foo, bar -- a comment
+return foo, -- a comment
+	bar
 


### PR DESCRIPTION
We now keep comments as close as possible to where they originally were, and if comments are present, then we hang the punctuated list on multiple lines.

This also makes way for improving the formatting within the column width, as we can use the multiline punctuated formatter for future work.

Comments buffer is still present for the generic_for sequence, as it looked odd otherwise