### PR TITLE
Improve formatting contextual info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Parentheses around conditions are now removed, as they are not required in Lua. `if (foo and (not bar or baz)) then ... end` turns to `if foo and (not bar or baz) then ... end`
+- Long multi-variable assignments which surpass the column width, even when hanging on the equals token, will now hang on multiple lines.
 
 ### Changed
 - Changed the heursitics for when parentheses are removed around expressions. Parentheses will now never be removed around a function call prefix (e.g. `("hello"):len()`)
 - Changed formatting for comma-separated lists. Previously, we would buffer the comments to the end of the list, but now we keep the comments next to where they original were.
+- Improved contextual formatting informattion when formatting deep in the AST. We can now better determine how much space is left on the current line, before we need to change formatting
+- Improved formatting of function declarations. It will now properly take into account the amount of space left on the column width.
+- Improve formatting for assignments with expressions such as function calls. The whole assignment is now taken into account, so we can better determine whether to split the expression.
 
 ## [0.7.1] - 2021-04-19
 ### Fixed

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,17 +41,6 @@ impl Context {
         self.indent_level
     }
 
-    /// Returns the size of the current indent level in characters
-    pub fn indent_width(&self) -> usize {
-        (self.indent_level() - 1) * self.config().indent_width
-    }
-
-    /// Returns the size of the current indent level in characters, including any additional indent level
-    pub fn indent_width_additional(&self, additional_indent_level: Option<usize>) -> usize {
-        (self.indent_level() - 1 + additional_indent_level.unwrap_or(0))
-            * self.config().indent_width
-    }
-
     /// Increase the level of indention at the current position of the formatter
     pub fn increment_indent_level(&mut self) {
         self.indent_level += 1;

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -5,7 +5,7 @@ use full_moon::ast::{
     Assignment, Expression, LocalAssignment,
 };
 use full_moon::node::Node;
-use full_moon::tokenizer::{TokenKind, TokenReference};
+use full_moon::tokenizer::{Token, TokenKind, TokenReference};
 
 #[cfg(feature = "luau")]
 use crate::formatters::luau::format_type_specifier;
@@ -14,51 +14,19 @@ use crate::{
     fmt_symbol,
     formatters::{
         expression::{format_expression, format_var, hang_expression},
-        general::{format_punctuated, format_token_reference_mut, try_format_punctuated},
-        trivia::{strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
+        general::{
+            format_punctuated, format_punctuated_multiline, format_token_reference_mut,
+            try_format_punctuated,
+        },
+        trivia::{
+            strip_leading_trivia, strip_trailing_trivia, strip_trivia, FormatTriviaType,
+            UpdateLeadingTrivia, UpdateTrailingTrivia,
+        },
         trivia_util,
         util::token_range,
     },
     shape::Shape,
 };
-
-/// Returns an Assignment with leading and trailing trivia removed
-fn strip_assignment_trivia<'ast>(assignment: &Assignment<'ast>) -> Assignment<'ast> {
-    let var_list = assignment
-        .variables()
-        .update_leading_trivia(FormatTriviaType::Replace(vec![]));
-    let expr_list = assignment
-        .expressions()
-        .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
-
-    Assignment::new(var_list, expr_list).with_equal_token(assignment.equal_token().to_owned())
-}
-
-/// Returns a LocalAssignment with leading and trailing trivia removed
-fn strip_local_assignment_trivia<'ast>(
-    local_assignment: &LocalAssignment<'ast>,
-) -> LocalAssignment<'ast> {
-    let local_token = local_assignment
-        .local_token()
-        .update_leading_trivia(FormatTriviaType::Replace(vec![]));
-
-    if local_assignment.expressions().is_empty() {
-        let name_list = local_assignment
-            .names()
-            .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
-
-        LocalAssignment::new(name_list).with_local_token(local_token)
-    } else {
-        let expr_list = local_assignment
-            .expressions()
-            .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
-
-        LocalAssignment::new(local_assignment.names().to_owned())
-            .with_local_token(local_token)
-            .with_equal_token(local_assignment.equal_token().map(|x| x.to_owned()))
-            .with_expressions(expr_list)
-    }
-}
 
 pub fn hang_punctuated_list<'ast>(
     ctx: &mut Context,
@@ -78,8 +46,7 @@ pub fn hang_punctuated_list<'ast>(
     // Format each expression and hang them
     // We need to format again because we will now take into account the indent increase
     for pair in punctuated.pairs() {
-        let expr = format_expression(ctx, pair.value(), shape);
-        let value = hang_expression(ctx, expr, additional_indent_level, shape, None);
+        let value = hang_expression(ctx, pair.value(), shape, additional_indent_level, None);
         shape = shape.take_last_line(&strip_trivia(&value));
 
         output.push(Pair::new(
@@ -92,40 +59,28 @@ pub fn hang_punctuated_list<'ast>(
     output
 }
 
-/// Checks the list of assigned expressions to see if any were hangable.
-/// If not, then we still have a long list of assigned expressions - we split it onto a newline at the equal token.
+/// Hangs at the equal token, and indents the first item.
 /// Returns the new equal token [`TokenReference`]
-fn check_long_expression<'ast>(
+fn hang_equal_token<'ast>(
     ctx: &mut Context,
-    expressions: &Punctuated<'ast, Expression<'ast>>,
     equal_token: TokenReference<'ast>,
     additional_indent_level: Option<usize>,
 ) -> TokenReference<'ast> {
-    // See if any of our expressions were hangable.
-    // If not, then its still a big long line - we should newline at the end of the equals token,
-    // then indent the first item
-    if !expressions
-        .iter()
-        .any(|x| trivia_util::can_hang_expression(x))
-    {
-        let equal_token_trailing_trivia = vec![
-            create_newline_trivia(ctx),
-            create_indent_trivia(ctx, additional_indent_level.or(Some(0)).map(|x| x + 1)),
-        ]
-        .iter()
-        .chain(
-            // Remove the space that was present after the equal token
-            equal_token
-                .trailing_trivia()
-                .skip_while(|x| x.token_kind() == TokenKind::Whitespace),
-        )
-        .map(|x| x.to_owned())
-        .collect();
-
-        equal_token.update_trailing_trivia(FormatTriviaType::Replace(equal_token_trailing_trivia))
-    } else {
+    let equal_token_trailing_trivia = vec![
+        create_newline_trivia(ctx),
+        create_indent_trivia(ctx, additional_indent_level.or(Some(0)).map(|x| x + 1)),
+    ]
+    .iter()
+    .chain(
+        // Remove the space that was present after the equal token
         equal_token
-    }
+            .trailing_trivia()
+            .skip_while(|x| x.token_kind() == TokenKind::Whitespace),
+    )
+    .map(|x| x.to_owned())
+    .collect();
+
+    equal_token.update_trailing_trivia(FormatTriviaType::Replace(equal_token_trailing_trivia))
 }
 
 pub fn format_assignment<'ast>(
@@ -142,56 +97,151 @@ pub fn format_assignment<'ast>(
     let leading_trivia = vec![create_indent_trivia(ctx, additional_indent_level)];
     let trailing_trivia = vec![create_newline_trivia(ctx)];
 
-    let var_list = try_format_punctuated(ctx, assignment.variables(), shape, format_var);
+    // Check if the assignment expressions contain comments. If they do, we bail out of determining any tactics
+    // and format multiline
+    let contains_comments = assignment.expressions().pairs().any(|pair| {
+        pair.punctuation()
+            .map_or(false, |x| trivia_util::token_contains_comments(x))
+            || trivia_util::expression_contains_inline_comments(pair.value())
+    });
+
+    // Firstly attempt to format the assignment onto a single line, using an infinite column width shape
+    let mut var_list = try_format_punctuated(
+        ctx,
+        assignment.variables(),
+        shape.with_infinite_width(),
+        format_var,
+    );
     let mut equal_token = fmt_symbol!(ctx, assignment.equal_token(), " = ");
-    let shape = shape + (strip_trivia(&var_list).to_string().len() + 3); // 3 = " = "
+    let mut expr_list = format_punctuated(
+        ctx,
+        assignment.expressions(),
+        shape.with_infinite_width(),
+        format_expression,
+    );
 
-    let mut expr_list = format_punctuated(ctx, assignment.expressions(), shape, format_expression); // Don't need to worry about comments in expr_list, as it will automatically force multiline
+    // Test the assignment to see if its over width
+    let singleline_shape = shape
+        + (strip_leading_trivia(&var_list).to_string().len()
+            + 3
+            + strip_trailing_trivia(&expr_list).to_string().len());
+    if contains_comments || singleline_shape.over_budget() {
+        // We won't attempt anything else with the var_list. Format it normally
+        var_list = try_format_punctuated(ctx, assignment.variables(), shape, format_var);
+        let shape = shape + (strip_leading_trivia(&var_list).to_string().len() + 3);
+        // The next tactic will be to see if we can hang the expression
+        // We can either hang the expression list, or hang at the equals token
+        if assignment
+            .expressions()
+            .iter()
+            .any(|x| trivia_util::can_hang_expression(x))
+        {
+            expr_list = hang_punctuated_list(
+                ctx,
+                assignment.expressions(),
+                shape,
+                additional_indent_level,
+            );
+        } else {
+            // The next tactic is to see whether there is more than one item in the punctuated list
+            // If there is, we should put it on multiple lines
+            if expr_list.len() > 1 {
+                // First try hanging at the equal token, using an infinite width, to see if its enough
+                let hanging_equal_token =
+                    hang_equal_token(ctx, equal_token.to_owned(), additional_indent_level);
+                let hanging_shape = shape
+                    .reset()
+                    .with_additional_indent(Some(additional_indent_level.unwrap_or(0) + 1));
+                expr_list = format_punctuated(
+                    ctx,
+                    assignment.expressions(),
+                    hanging_shape.with_infinite_width(),
+                    format_expression,
+                );
 
-    // Create preliminary assignment
-    let formatted_assignment = Assignment::new(var_list.to_owned(), expr_list.to_owned())
-        .with_equal_token(equal_token.to_owned());
+                if hanging_shape
+                    .take_first_line(&strip_trivia(&expr_list))
+                    .over_budget()
+                {
+                    // Hang the expressions on multiple lines
+                    expr_list = format_punctuated_multiline(
+                        ctx,
+                        assignment.expressions(),
+                        shape,
+                        format_expression,
+                        Some(1),
+                    );
+                } else {
+                    equal_token = hanging_equal_token;
+                }
+            } else {
+                // Format the expressions normally. If still over budget, hang at the equals token
+                expr_list =
+                    format_punctuated(ctx, assignment.expressions(), shape, format_expression);
+                let shape = shape.take_first_line(&strip_trailing_trivia(&expr_list));
 
-    // Test whether we need to hang the expression, using the updated assignment
-    // We have to format normally before this, since we may be expanding the expression onto multiple lines
-    // (e.g. if it was a table). We only want to use the first line to determine if we need to hang the expression
-    let require_multiline_expression = shape
-        .reset()
-        .take_first_line(&strip_assignment_trivia(&formatted_assignment))
-        .over_budget()
-        || assignment.expressions().pairs().any(|pair| {
-            pair.punctuation()
-                .map_or(false, |punc| trivia_util::token_contains_comments(punc))
-                || trivia_util::expression_contains_inline_comments(pair.value())
-        });
-
-    if require_multiline_expression {
-        expr_list = hang_punctuated_list(
-            ctx,
-            assignment.expressions(),
-            shape,
-            additional_indent_level,
-        );
-
-        equal_token = check_long_expression(
-            ctx,
-            assignment.expressions(),
-            equal_token,
-            additional_indent_level,
-        );
+                if shape.over_budget() {
+                    equal_token = hang_equal_token(ctx, equal_token, additional_indent_level)
+                    // TODO: reformat expr_list with indent
+                }
+            }
+        }
     }
 
-    // Add any trailing trivia to the end of the expression list
+    // Add necessary trivia
+    let var_list = var_list.update_leading_trivia(FormatTriviaType::Append(leading_trivia));
     let expr_list = expr_list.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
-    // Add on leading trivia
-    let formatted_var_list =
-        var_list.update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+    Assignment::new(var_list, expr_list).with_equal_token(equal_token)
+}
 
-    formatted_assignment
-        .with_variables(formatted_var_list)
-        .with_equal_token(equal_token)
-        .with_expressions(expr_list)
+fn format_local_no_assignment<'ast>(
+    ctx: &mut Context,
+    assignment: &LocalAssignment<'ast>,
+    shape: Shape,
+    leading_trivia: Vec<Token<'ast>>,
+    trailing_trivia: Vec<Token<'ast>>,
+) -> LocalAssignment<'ast> {
+    let local_token = fmt_symbol!(ctx, assignment.local_token(), "local ")
+        .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+    let shape = shape + 6; // 6 = "local "
+    let mut name_list =
+        try_format_punctuated(ctx, assignment.names(), shape, format_token_reference_mut);
+
+    #[cfg(feature = "luau")]
+    let mut type_specifiers: Vec<Option<TypeSpecifier<'ast>>> = assignment
+        .type_specifiers()
+        .map(|x| match x {
+            Some(type_specifier) => Some(format_type_specifier(ctx, type_specifier)),
+            None => None,
+        })
+        .collect();
+
+    // See if the last variable assigned has a type specifier, and add a new line to that
+    #[allow(unused_mut)]
+    let mut new_line_added = false;
+
+    #[cfg(feature = "luau")]
+    if let Some(Some(specifier)) = type_specifiers.pop() {
+        type_specifiers.push(Some(specifier.update_trailing_trivia(
+            FormatTriviaType::Append(trailing_trivia.to_owned()),
+        )));
+        new_line_added = true;
+    }
+
+    // Add any trailing trivia to the end of the expression list, if we haven't already added a newline
+    if !new_line_added {
+        name_list = name_list.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia))
+    }
+
+    let local_assignment = LocalAssignment::new(name_list)
+        .with_local_token(local_token)
+        .with_equal_token(None)
+        .with_expressions(Punctuated::new());
+
+    #[cfg(feature = "luau")]
+    let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
+    local_assignment
 }
 
 pub fn format_local_assignment<'ast>(
@@ -208,98 +258,137 @@ pub fn format_local_assignment<'ast>(
     let leading_trivia = vec![create_indent_trivia(ctx, additional_indent_level)];
     let trailing_trivia = vec![create_newline_trivia(ctx)];
 
-    let local_token = fmt_symbol!(ctx, assignment.local_token(), "local ")
-        .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
-    let shape = shape + 6; // 6 = "local "
-    let mut name_list =
-        try_format_punctuated(ctx, assignment.names(), shape, format_token_reference_mut);
-
-    #[cfg(feature = "luau")]
-    let mut type_specifiers: Vec<Option<TypeSpecifier<'ast>>> = assignment
-        .type_specifiers()
-        .map(|x| match x {
-            Some(type_specifier) => Some(format_type_specifier(ctx, type_specifier)),
-            None => None,
-        })
-        .collect();
-
     if assignment.expressions().is_empty() {
-        // See if the last variable assigned has a type specifier, and add a new line to that
-        #[allow(unused_mut)]
-        let mut new_line_added = false;
-
-        #[cfg(feature = "luau")]
-        if let Some(Some(specifier)) = type_specifiers.pop() {
-            type_specifiers.push(Some(specifier.update_trailing_trivia(
-                FormatTriviaType::Append(trailing_trivia.to_owned()),
-            )));
-            new_line_added = true;
-        }
-
-        // Add any trailing trivia to the end of the expression list, if we haven't already added a newline
-        if !new_line_added {
-            name_list = name_list.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia))
-        }
-
-        let local_assignment = LocalAssignment::new(name_list)
-            .with_local_token(local_token)
-            .with_equal_token(None)
-            .with_expressions(Punctuated::new());
-
-        #[cfg(feature = "luau")]
-        let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
-        local_assignment
+        format_local_no_assignment(ctx, assignment, shape, leading_trivia, trailing_trivia)
     } else {
+        // Check if the assignment expressions contain comments. If they do, we bail out of determining any tactics
+        // and format multiline
+        let contains_comments = assignment.expressions().pairs().any(|pair| {
+            pair.punctuation()
+                .map_or(false, |x| trivia_util::token_contains_comments(x))
+                || trivia_util::expression_contains_inline_comments(pair.value())
+        });
+
+        // Firstly attempt to format the assignment onto a single line, using an infinite column width shape
+        let local_token = fmt_symbol!(ctx, assignment.local_token(), "local ")
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+
+        let mut name_list = try_format_punctuated(
+            ctx,
+            assignment.names(),
+            shape.with_infinite_width(),
+            format_token_reference_mut,
+        );
         let mut equal_token = fmt_symbol!(ctx, assignment.equal_token().unwrap(), " = ");
-        let shape = shape + (strip_trivia(&name_list).to_string().len() + 3); // 3 = " = "
-        let mut expr_list =
-            // Format the expression normally - if there are any comments, it will automatically force multiline
-            format_punctuated(ctx, assignment.expressions(), shape, format_expression);
+        let mut expr_list = format_punctuated(
+            ctx,
+            assignment.expressions(),
+            shape.with_infinite_width(),
+            format_expression,
+        );
 
-        // Create our preliminary new assignment
-        let local_assignment = LocalAssignment::new(name_list)
-            .with_local_token(local_token)
-            .with_equal_token(Some(equal_token.to_owned()))
-            .with_expressions(expr_list.to_owned());
         #[cfg(feature = "luau")]
-        let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
-
-        // Test whether we need to hang the expression, using the updated assignment
-        // We have to format normally before this, since we may be expanding the expression onto multiple lines
-        // (e.g. if it was a table). We only want to use the first line to determine if we need to hang the expression
-        let require_multiline_expression = shape
-            .reset()
-            .take_first_line(&strip_local_assignment_trivia(&local_assignment))
-            .over_budget()
-            || assignment.expressions().pairs().any(|pair| {
-                pair.punctuation()
-                    .map_or(false, |punc| trivia_util::token_contains_comments(punc))
-                    || trivia_util::expression_contains_inline_comments(pair.value())
+        let type_specifiers: Vec<Option<TypeSpecifier<'ast>>> = assignment
+            .type_specifiers()
+            .map(|x| match x {
+                Some(type_specifier) => Some(format_type_specifier(ctx, type_specifier)),
+                None => None,
+            })
+            .collect();
+        let type_specifier_len;
+        #[cfg(feature = "luau")]
+        {
+            type_specifier_len = type_specifiers.iter().fold(0, |acc, x| {
+                acc + x.as_ref().map_or(0, |y| y.to_string().len())
             });
-
-        // Format the expression depending on whether we are multline or not
-        if require_multiline_expression {
-            expr_list = hang_punctuated_list(
-                ctx,
-                assignment.expressions(),
-                shape,
-                additional_indent_level,
-            );
-
-            equal_token = check_long_expression(
-                ctx,
-                assignment.expressions(),
-                equal_token,
-                additional_indent_level,
-            );
+        }
+        #[cfg(not(feature = "luau"))]
+        {
+            type_specifier_len = 0;
         }
 
-        // Add any trailing trivia to the end of the expression list
+        // Test the assignment to see if its over width
+        let singleline_shape = shape
+            + (strip_leading_trivia(&name_list).to_string().len()
+                + 6 // 6 = "local "
+                + 3 // 3 = " = "
+                + type_specifier_len
+                + strip_trailing_trivia(&expr_list).to_string().len());
+
+        if contains_comments || singleline_shape.over_budget() {
+            // We won't attempt anything else with the name_list. Format it normally
+            name_list =
+                try_format_punctuated(ctx, assignment.names(), shape, format_token_reference_mut);
+            let shape = shape
+                + (strip_leading_trivia(&name_list).to_string().len() + 6 + 3 + type_specifier_len);
+            // The next tactic will be to see if we can hang the expression
+            // We can either hang the expression list, or hang at the equals token
+            if assignment
+                .expressions()
+                .iter()
+                .any(|x| trivia_util::can_hang_expression(x))
+            {
+                expr_list = hang_punctuated_list(
+                    ctx,
+                    assignment.expressions(),
+                    shape,
+                    additional_indent_level,
+                );
+            } else {
+                // The next tactic is to see whether there is more than one item in the punctuated list
+                // If there is, we should put it on multiple lines
+                if expr_list.len() > 1 {
+                    // First try hanging at the equal token, using an infinite width, to see if its enough
+                    let hanging_equal_token =
+                        hang_equal_token(ctx, equal_token.to_owned(), additional_indent_level);
+                    let hanging_shape = shape
+                        .reset()
+                        .with_additional_indent(Some(additional_indent_level.unwrap_or(0) + 1));
+                    expr_list = format_punctuated(
+                        ctx,
+                        assignment.expressions(),
+                        hanging_shape.with_infinite_width(),
+                        format_expression,
+                    );
+
+                    if hanging_shape
+                        .take_first_line(&strip_trivia(&expr_list))
+                        .over_budget()
+                    {
+                        // Hang the expressions on multiple lines
+                        expr_list = format_punctuated_multiline(
+                            ctx,
+                            assignment.expressions(),
+                            shape,
+                            format_expression,
+                            Some(1),
+                        );
+                    } else {
+                        equal_token = hanging_equal_token;
+                    }
+                } else {
+                    // Format the expressions normally. If still over budget, hang at the equals token
+                    expr_list =
+                        format_punctuated(ctx, assignment.expressions(), shape, format_expression);
+                    let shape = shape.take_first_line(&strip_trailing_trivia(&expr_list));
+
+                    if shape.over_budget() {
+                        equal_token = hang_equal_token(ctx, equal_token, additional_indent_level)
+                        // TODO: reformat expr_list with indent
+                    }
+                }
+            }
+        }
+
+        // Add necessary trivia
         let expr_list = expr_list.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
-        // Update our local assignment
-        local_assignment
+        let local_assignment = LocalAssignment::new(name_list)
+            .with_local_token(local_token)
             .with_equal_token(Some(equal_token))
-            .with_expressions(expr_list)
+            .with_expressions(expr_list);
+        #[cfg(feature = "luau")]
+        let local_assignment = local_assignment.with_type_specifiers(type_specifiers);
+        local_assignment
     }
 }

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -178,11 +178,18 @@ pub fn format_assignment<'ast>(
                 // Format the expressions normally. If still over budget, hang at the equals token
                 expr_list =
                     format_punctuated(ctx, assignment.expressions(), shape, format_expression);
-                let shape = shape.take_first_line(&strip_trailing_trivia(&expr_list));
+                let formatting_shape = shape.take_first_line(&strip_trailing_trivia(&expr_list));
 
-                if shape.over_budget() {
-                    equal_token = hang_equal_token(ctx, equal_token, additional_indent_level)
-                    // TODO: reformat expr_list with indent
+                if formatting_shape.over_budget() {
+                    equal_token = hang_equal_token(ctx, equal_token, additional_indent_level);
+                    // Add the expression list into the indent range, as it will be indented by one
+                    let expr_range = assignment
+                        .expressions()
+                        .range()
+                        .expect("no range for assignment punctuated list");
+                    ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
+                    expr_list =
+                        format_punctuated(ctx, assignment.expressions(), shape, format_expression);
                 }
             }
         }
@@ -370,11 +377,23 @@ pub fn format_local_assignment<'ast>(
                     // Format the expressions normally. If still over budget, hang at the equals token
                     expr_list =
                         format_punctuated(ctx, assignment.expressions(), shape, format_expression);
-                    let shape = shape.take_first_line(&strip_trailing_trivia(&expr_list));
+                    let formatting_shape =
+                        shape.take_first_line(&strip_trailing_trivia(&expr_list));
 
-                    if shape.over_budget() {
-                        equal_token = hang_equal_token(ctx, equal_token, additional_indent_level)
-                        // TODO: reformat expr_list with indent
+                    if formatting_shape.over_budget() {
+                        equal_token = hang_equal_token(ctx, equal_token, additional_indent_level);
+                        // Add the expression list into the indent range, as it will be indented by one
+                        let expr_range = assignment
+                            .expressions()
+                            .range()
+                            .expect("no range for assignment punctuated list");
+                        ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
+                        expr_list = format_punctuated(
+                            ctx,
+                            assignment.expressions(),
+                            shape,
+                            format_expression,
+                        );
                     }
                 }
             }

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -13,7 +13,7 @@ use crate::{
     context::{create_indent_trivia, create_newline_trivia, Context},
     fmt_symbol,
     formatters::{
-        expression::{format_expression, format_var, hang_expression_no_trailing_newline},
+        expression::{format_expression, format_var, hang_expression},
         general::{format_punctuated, format_token_reference_mut, try_format_punctuated},
         trivia::{strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
         trivia_util,
@@ -79,8 +79,7 @@ pub fn hang_punctuated_list<'ast>(
     // We need to format again because we will now take into account the indent increase
     for pair in punctuated.pairs() {
         let expr = format_expression(ctx, pair.value(), shape);
-        let value =
-            hang_expression_no_trailing_newline(ctx, expr, additional_indent_level, shape, None);
+        let value = hang_expression(ctx, expr, additional_indent_level, shape, None);
         shape = shape.take_last_line(&strip_trivia(&value));
 
         output.push(Pair::new(

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -79,7 +79,8 @@ pub fn hang_punctuated_list<'ast>(
     // We need to format again because we will now take into account the indent increase
     for pair in punctuated.pairs() {
         let expr = format_expression(ctx, pair.value(), shape);
-        let value = hang_expression_no_trailing_newline(ctx, expr, additional_indent_level, None);
+        let value =
+            hang_expression_no_trailing_newline(ctx, expr, additional_indent_level, shape, None);
         shape = shape.take_last_line(&strip_trivia(&value));
 
         output.push(Pair::new(

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -12,6 +12,7 @@ use crate::{
         trivia_util,
         util::token_range,
     },
+    shape::Shape,
 };
 use full_moon::ast::{
     punctuated::{Pair, Punctuated},
@@ -328,7 +329,8 @@ pub fn format_block<'ast>(ctx: &mut Context, block: Block<'ast>) -> Block<'ast> 
     let mut found_first_stmt = false;
     let mut stmt_iterator = block.stmts_with_semicolon().peekable();
     while let Some((stmt, semi)) = stmt_iterator.next() {
-        let mut stmt = format_stmt(ctx, stmt);
+        let shape = Shape::from_context(ctx);
+        let mut stmt = format_stmt(ctx, stmt, shape);
 
         // If this is the first stmt, then remove any leading newlines
         if !found_first_stmt {

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -3,8 +3,11 @@ use crate::{
     context::{create_indent_trivia, create_newline_trivia, Context},
     fmt_symbol,
     formatters::{
+        assignment::hang_punctuated_list,
         expression::{format_expression, hang_expression_no_trailing_newline},
-        general::{format_symbol, try_format_punctuated},
+        general::{
+            format_punctuated, format_punctuated_multiline, format_symbol, try_format_punctuated,
+        },
         stmt::format_stmt,
         trivia::{
             strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
@@ -32,9 +35,63 @@ macro_rules! update_first_token {
     }};
 }
 
-pub fn format_return<'ast>(ctx: &mut Context, return_node: &Return<'ast>) -> Return<'ast> {
+// /// Attempts to fit a punctuated list inside the column width.
+// /// Input takes in a shape, which is already primed with the current indent level.
+// fn fit_punctuated_list<'ast>(
+//     ctx: &mut Context,
+//     shape: Shape,
+//     list: &Punctuated<'ast, Expression<'ast>>,
+// ) -> Punctuated<'ast, Expression<'ast>> {
+//     // Firstly try fitting on a single line [TODO: Make sure to take into account if its multiline [table/function]]
+//     // If it fails, see if there is more than one item in the list
+//     //  1) Only one item -> attempt to hang the expression. Cannot do any further
+//     //  2) More than one item -> hang based on the punctuation
+//     //      Go through each item, and check individually for failure. If it fails, hang that item
+
+//     // Firstly try fitting the list on a single line [TODO: take into account multiline (table/function)]
+//     let mut output = format_punctuated(ctx, list, format_expression).0; // TODO: trailing comments buffer -> we don't want it
+//     let single_line_list_shape = shape + strip_trivia(&output).to_string().len();
+//     if single_line_list_shape.over_budget() {
+//         // The list is over budget, so try changing the formatting
+//         if list.len() > 1 {
+//             // More than one item -> first try hanging based on punctuation
+//             output = format_punctuated_multiline(ctx, list, format_expression, None);
+//             // Check each item in the shape
+//         }
+
+//         // Only one item. Attempt to hang the expression. We can't do anything else
+//         // Add the expression list into the indent range, as it will be indented by one
+//         let expr_range = list.range().expect("no range for punctuated");
+//         ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
+
+//         let mut new_list = Punctuated::new();
+//         for pair in output.pairs() {
+//             new_list.push(pair.map(|value| {
+//                 if trivia_util::can_hang_expression(value) {
+//                     hang_expression_no_trailing_newline(
+//                         ctx,
+//                         value.to_owned(),
+//                         additional_indent_level,
+//                         None,
+//                     );
+//                 }
+//             }))
+//         }
+
+//         output = new_list;
+//     }
+
+//     output
+// }
+
+pub fn format_return<'ast>(
+    ctx: &mut Context,
+    return_node: &Return<'ast>,
+    shape: Shape,
+) -> Return<'ast> {
     // Calculate trivia
     let additional_indent_level = ctx.get_range_indent_increase(token_range(return_node.token()));
+    let shape = shape.with_additional_indent(additional_indent_level);
     let leading_trivia = vec![create_indent_trivia(ctx, additional_indent_level)];
     let trailing_trivia = vec![create_newline_trivia(ctx)];
 
@@ -49,41 +106,18 @@ pub fn format_return<'ast>(ctx: &mut Context, return_node: &Return<'ast>) -> Ret
         let token = fmt_symbol!(ctx, return_node.token(), "return ")
             .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
 
+        let shape = shape + (strip_trivia(return_node.token()).to_string().len() + 1); // 1 = " "
         let mut formatted_returns =
-            try_format_punctuated(ctx, return_node.returns(), format_expression);
+            try_format_punctuated(ctx, return_node.returns(), shape, format_expression);
 
         // Determine if we need to hang the condition
-        let first_line_str = strip_trivia(return_node.token()).to_string()
-            + " "
-            + &strip_trivia(&formatted_returns).to_string();
-
-        let indent_spacing = ctx.indent_width_additional(additional_indent_level);
-        let require_multiline_expression = (indent_spacing
-            + first_line_str
-                .trim()
-                .lines()
-                .next()
-                .expect("no lines")
-                .len())
-            > ctx.config().column_width;
+        let require_multiline_expression = shape
+            .take_first_line(&strip_trivia(&formatted_returns))
+            .over_budget();
 
         if require_multiline_expression {
-            // Add the expression list into the indent range, as it will be indented by one
-            let expr_range = return_node.returns().range().expect("no range for returns");
-            ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-
-            // Hang each expression
-            let mut new_list = Punctuated::new();
-            for pair in return_node.returns().pairs() {
-                let expr = format_expression(ctx, pair.value());
-                let value =
-                    hang_expression_no_trailing_newline(ctx, expr, additional_indent_level, None);
-                new_list.push(Pair::new(
-                    value,
-                    pair.punctuation().map(|x| fmt_symbol!(ctx, x, ", ")),
-                ));
-            }
-            formatted_returns = new_list
+            formatted_returns =
+                hang_punctuated_list(ctx, return_node.returns(), shape, additional_indent_level);
         }
 
         if let Some(pair) = formatted_returns.pop() {
@@ -98,7 +132,11 @@ pub fn format_return<'ast>(ctx: &mut Context, return_node: &Return<'ast>) -> Ret
     }
 }
 
-pub fn format_last_stmt<'ast>(ctx: &mut Context, last_stmt: &LastStmt<'ast>) -> LastStmt<'ast> {
+pub fn format_last_stmt<'ast>(
+    ctx: &mut Context,
+    last_stmt: &LastStmt<'ast>,
+    shape: Shape,
+) -> LastStmt<'ast> {
     check_should_format!(ctx, last_stmt);
 
     match last_stmt {
@@ -110,7 +148,7 @@ pub fn format_last_stmt<'ast>(ctx: &mut Context, last_stmt: &LastStmt<'ast>) -> 
             FormatTriviaType::Append(vec![create_newline_trivia(ctx)]),
         )),
 
-        LastStmt::Return(return_node) => LastStmt::Return(format_return(ctx, return_node)),
+        LastStmt::Return(return_node) => LastStmt::Return(format_return(ctx, return_node, shape)),
         #[cfg(feature = "luau")]
         LastStmt::Continue(token) => LastStmt::Continue(
             format_symbol(
@@ -402,7 +440,8 @@ pub fn format_block<'ast>(ctx: &mut Context, block: Block<'ast>) -> Block<'ast> 
 
     let formatted_last_stmt = match block.last_stmt_with_semicolon() {
         Some((last_stmt, semi)) => {
-            let mut last_stmt = format_last_stmt(ctx, last_stmt);
+            let shape = Shape::from_context(ctx);
+            let mut last_stmt = format_last_stmt(ctx, last_stmt, shape);
             // If this is the first stmt, then remove any leading newlines
             if !found_first_stmt && ctx.should_format_node(&last_stmt) {
                 last_stmt = last_stmt_remove_leading_newlines(last_stmt);

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -4,10 +4,8 @@ use crate::{
     fmt_symbol,
     formatters::{
         assignment::hang_punctuated_list,
-        expression::{format_expression, hang_expression_no_trailing_newline},
-        general::{
-            format_punctuated, format_punctuated_multiline, format_symbol, try_format_punctuated,
-        },
+        expression::format_expression,
+        general::{format_symbol, try_format_punctuated},
         stmt::format_stmt,
         trivia::{
             strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
@@ -18,10 +16,8 @@ use crate::{
     shape::Shape,
 };
 use full_moon::ast::{
-    punctuated::{Pair, Punctuated},
-    Block, Expression, LastStmt, Prefix, Return, Stmt, Var,
+    punctuated::Punctuated, Block, Expression, LastStmt, Prefix, Return, Stmt, Var,
 };
-use full_moon::node::Node;
 use full_moon::tokenizer::TokenType;
 use full_moon::tokenizer::{Token, TokenReference};
 #[cfg(feature = "luau")]
@@ -34,55 +30,6 @@ macro_rules! update_first_token {
         Stmt::$enum($var.$update_method(new_token))
     }};
 }
-
-// /// Attempts to fit a punctuated list inside the column width.
-// /// Input takes in a shape, which is already primed with the current indent level.
-// fn fit_punctuated_list<'ast>(
-//     ctx: &mut Context,
-//     shape: Shape,
-//     list: &Punctuated<'ast, Expression<'ast>>,
-// ) -> Punctuated<'ast, Expression<'ast>> {
-//     // Firstly try fitting on a single line [TODO: Make sure to take into account if its multiline [table/function]]
-//     // If it fails, see if there is more than one item in the list
-//     //  1) Only one item -> attempt to hang the expression. Cannot do any further
-//     //  2) More than one item -> hang based on the punctuation
-//     //      Go through each item, and check individually for failure. If it fails, hang that item
-
-//     // Firstly try fitting the list on a single line [TODO: take into account multiline (table/function)]
-//     let mut output = format_punctuated(ctx, list, format_expression).0; // TODO: trailing comments buffer -> we don't want it
-//     let single_line_list_shape = shape + strip_trivia(&output).to_string().len();
-//     if single_line_list_shape.over_budget() {
-//         // The list is over budget, so try changing the formatting
-//         if list.len() > 1 {
-//             // More than one item -> first try hanging based on punctuation
-//             output = format_punctuated_multiline(ctx, list, format_expression, None);
-//             // Check each item in the shape
-//         }
-
-//         // Only one item. Attempt to hang the expression. We can't do anything else
-//         // Add the expression list into the indent range, as it will be indented by one
-//         let expr_range = list.range().expect("no range for punctuated");
-//         ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-
-//         let mut new_list = Punctuated::new();
-//         for pair in output.pairs() {
-//             new_list.push(pair.map(|value| {
-//                 if trivia_util::can_hang_expression(value) {
-//                     hang_expression_no_trailing_newline(
-//                         ctx,
-//                         value.to_owned(),
-//                         additional_indent_level,
-//                         None,
-//                     );
-//                 }
-//             }))
-//         }
-
-//         output = new_list;
-//     }
-
-//     output
-// }
 
 pub fn format_return<'ast>(
     ctx: &mut Context,

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -489,7 +489,7 @@ fn expression_split_binop<'ast>(
     }
 }
 
-pub fn hang_expression_no_trailing_newline<'ast>(
+pub fn hang_expression<'ast>(
     ctx: &Context,
     expression: Expression<'ast>,
     additional_indent_level: Option<usize>,
@@ -502,13 +502,13 @@ pub fn hang_expression_no_trailing_newline<'ast>(
     expression_split_binop(ctx, expression, shape, hang_level)
 }
 
-pub fn hang_expression<'ast>(
+pub fn hang_expression_trailing_newline<'ast>(
     ctx: &Context,
     expression: Expression<'ast>,
     additional_indent_level: Option<usize>,
     shape: Shape,
     hang_level: Option<usize>,
 ) -> Expression<'ast> {
-    hang_expression_no_trailing_newline(ctx, expression, additional_indent_level, shape, hang_level)
+    hang_expression(ctx, expression, additional_indent_level, shape, hang_level)
         .update_trailing_trivia(FormatTriviaType::Append(vec![create_newline_trivia(ctx)]))
 }

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -14,9 +14,7 @@ use crate::{
     context::{create_indent_trivia, create_newline_trivia, Context},
     fmt_symbol,
     formatters::{
-        expression::{
-            format_expression, format_prefix, format_suffix, hang_expression_no_trailing_newline,
-        },
+        expression::{format_expression, format_prefix, format_suffix, hang_expression},
         general::{
             format_contained_span, format_end_token, format_punctuated, format_symbol,
             format_token_reference, EndTokenType,
@@ -349,7 +347,7 @@ pub fn format_function_args<'ast>(
 
                     // Hang the expression if necessary
                     if require_multiline_expression {
-                        formatted_argument = hang_expression_no_trailing_newline(
+                        formatted_argument = hang_expression(
                             ctx,
                             formatted_argument,
                             additional_indent_level,

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -361,6 +361,7 @@ pub fn format_function_args<'ast>(
                             ctx,
                             formatted_argument,
                             additional_indent_level,
+                            shape,
                             None,
                         );
                     }

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -779,8 +779,7 @@ pub fn format_function_declaration<'ast>(
     let formatted_function_name = format_function_name(ctx, function_declaration.name());
 
     let shape = shape.with_additional_indent(additional_indent_level)
-        + (strip_trivia(&function_token).to_string().len()
-            + strip_trivia(&formatted_function_name).to_string().len());
+        + (9 + strip_trivia(&formatted_function_name).to_string().len()); // 9 = "function "
     let formatted_function_body =
         format_function_body(ctx, function_declaration.body(), true, shape);
 

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -349,9 +349,9 @@ pub fn format_function_args<'ast>(
                     if require_multiline_expression {
                         formatted_argument = hang_expression(
                             ctx,
-                            formatted_argument,
-                            additional_indent_level,
+                            argument.value(),
                             shape,
+                            additional_indent_level,
                             None,
                         );
                     }

--- a/src/formatters/lua52.rs
+++ b/src/formatters/lua52.rs
@@ -6,11 +6,12 @@ use crate::{
         trivia::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
         util::token_range,
     },
+    shape::Shape,
 };
 use full_moon::ast::lua52::{Goto, Label};
 use full_moon::tokenizer::TokenReference;
 
-pub fn format_goto<'ast>(ctx: &Context, goto: &Goto<'ast>) -> Goto<'ast> {
+pub fn format_goto<'ast>(ctx: &Context, goto: &Goto<'ast>, _shape: Shape) -> Goto<'ast> {
     // Calculate trivia
     let additional_indent_level = ctx.get_range_indent_increase(token_range(goto.goto_token()));
     let leading_trivia = vec![create_indent_trivia(ctx, additional_indent_level)];
@@ -25,7 +26,7 @@ pub fn format_goto<'ast>(ctx: &Context, goto: &Goto<'ast>) -> Goto<'ast> {
     Goto::new(label_name).with_goto_token(goto_token)
 }
 
-pub fn format_label<'ast>(ctx: &Context, label: &Label<'ast>) -> Label<'ast> {
+pub fn format_label<'ast>(ctx: &Context, label: &Label<'ast>, _shape: Shape) -> Label<'ast> {
     // Calculate trivia
     let additional_indent_level = ctx.get_range_indent_increase(token_range(label.left_colons()));
     let leading_trivia = vec![create_indent_trivia(ctx, additional_indent_level)];

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -57,7 +57,7 @@ fn remove_condition_parentheses(expression: Expression) -> Expression {
 }
 
 /// Format a Do node
-pub fn format_do_block<'ast>(ctx: &Context, do_block: &Do<'ast>, shape: Shape) -> Do<'ast> {
+pub fn format_do_block<'ast>(ctx: &Context, do_block: &Do<'ast>, _shape: Shape) -> Do<'ast> {
     // Create trivia
     let additional_indent_level = ctx.get_range_indent_increase(token_range(do_block.do_token()));
     let leading_trivia =
@@ -79,7 +79,7 @@ pub fn format_do_block<'ast>(ctx: &Context, do_block: &Do<'ast>, shape: Shape) -
 pub fn format_generic_for<'ast>(
     ctx: &mut Context,
     generic_for: &GenericFor<'ast>,
-    shape: Shape,
+    _shape: Shape,
 ) -> GenericFor<'ast> {
     // Create trivia
     let additional_indent_level =
@@ -299,7 +299,7 @@ pub fn format_if<'ast>(ctx: &mut Context, if_node: &If<'ast>, shape: Shape) -> I
 pub fn format_numeric_for<'ast>(
     ctx: &mut Context,
     numeric_for: &NumericFor<'ast>,
-    shape: Shape,
+    _shape: Shape,
 ) -> NumericFor<'ast> {
     // Create trivia
     let additional_indent_level =

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -177,8 +177,7 @@ fn format_else_if<'ast>(
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
-        let condition = format_expression(ctx, &condition, shape);
-        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+        hang_expression_trailing_newline(ctx, &condition, shape, additional_indent_level, None)
             .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
                 ctx,
                 indent_level,
@@ -239,8 +238,7 @@ pub fn format_if<'ast>(ctx: &mut Context, if_node: &If<'ast>, shape: Shape) -> I
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
-        let condition = format_expression(ctx, &condition, shape);
-        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+        hang_expression_trailing_newline(ctx, &condition, shape, additional_indent_level, None)
             .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
                 ctx,
                 indent_level,
@@ -389,8 +387,7 @@ pub fn format_repeat_block<'ast>(
         || trivia_util::expression_contains_inline_comments(&condition);
 
     let shape = shape + 6; // 6 = "until "
-    let formatted_until = format_expression(ctx, &condition, shape);
-    let formatted_until_trivia = match require_multiline_expression {
+    let formatted_until = match require_multiline_expression {
         true => {
             // Add the expression list into the indent range, as it will be indented by one
             let expr_range = repeat_block
@@ -398,22 +395,17 @@ pub fn format_repeat_block<'ast>(
                 .range()
                 .expect("no range for repeat until");
             ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-            hang_expression_trailing_newline(
-                ctx,
-                formatted_until,
-                additional_indent_level,
-                shape,
-                None,
-            )
+            hang_expression_trailing_newline(ctx, &condition, shape, additional_indent_level, None)
         }
-        false => formatted_until.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia)),
+        false => format_expression(ctx, &condition, shape)
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia)),
     };
 
     repeat_block
         .to_owned()
         .with_repeat_token(repeat_token)
         .with_until_token(until_token)
-        .with_until(formatted_until_trivia)
+        .with_until(formatted_until)
 }
 
 /// Format a While node
@@ -456,8 +448,7 @@ pub fn format_while_block<'ast>(
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
-        let condition = format_expression(ctx, &condition, shape);
-        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+        hang_expression_trailing_newline(ctx, &condition, shape, additional_indent_level, None)
             .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
                 ctx,
                 indent_level,

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -176,12 +176,9 @@ fn format_else_if<'ast>(
         ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
-        let condition = format_expression(
-            ctx,
-            &condition,
-            shape.reset().with_additional_indent(indent_level),
-        );
-        hang_expression(ctx, condition, additional_indent_level, None).update_leading_trivia(
+        let shape = shape.reset().with_additional_indent(indent_level);
+        let condition = format_expression(ctx, &condition, shape);
+        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
             FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
         )
     } else {
@@ -239,12 +236,9 @@ pub fn format_if<'ast>(ctx: &mut Context, if_node: &If<'ast>, shape: Shape) -> I
         ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
-        let condition = format_expression(
-            ctx,
-            &condition,
-            shape.reset().with_additional_indent(indent_level),
-        );
-        hang_expression(ctx, condition, additional_indent_level, None).update_leading_trivia(
+        let shape = shape.reset().with_additional_indent(indent_level);
+        let condition = format_expression(ctx, &condition, shape);
+        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
             FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
         )
     } else {
@@ -390,7 +384,8 @@ pub fn format_repeat_block<'ast>(
     let require_multiline_expression = singleline_shape.over_budget()
         || trivia_util::expression_contains_inline_comments(&condition);
 
-    let formatted_until = format_expression(ctx, &condition, shape + 6); // 6 = "until "
+    let shape = shape + 6; // 6 = "until "
+    let formatted_until = format_expression(ctx, &condition, shape);
     let formatted_until_trivia = match require_multiline_expression {
         true => {
             // Add the expression list into the indent range, as it will be indented by one
@@ -399,7 +394,7 @@ pub fn format_repeat_block<'ast>(
                 .range()
                 .expect("no range for repeat until");
             ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-            hang_expression(ctx, formatted_until, additional_indent_level, None)
+            hang_expression(ctx, formatted_until, additional_indent_level, shape, None)
         }
         false => formatted_until.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia)),
     };
@@ -450,12 +445,9 @@ pub fn format_while_block<'ast>(
         ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
 
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
-        let condition = format_expression(
-            ctx,
-            &condition,
-            shape.reset().with_additional_indent(indent_level),
-        );
-        hang_expression(ctx, condition, additional_indent_level, None).update_leading_trivia(
+        let shape = shape.reset().with_additional_indent(indent_level);
+        let condition = format_expression(ctx, &condition, shape);
+        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
             FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
         )
     } else {

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -11,7 +11,7 @@ use crate::{
     fmt_symbol,
     formatters::{
         assignment::{format_assignment, format_local_assignment},
-        expression::{format_expression, hang_expression},
+        expression::{format_expression, hang_expression_trailing_newline},
         functions::{format_function_call, format_function_declaration, format_local_function},
         general::{
             format_end_token, format_punctuated_buffer, format_token_reference,
@@ -178,9 +178,11 @@ fn format_else_if<'ast>(
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
         let condition = format_expression(ctx, &condition, shape);
-        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
-            FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
-        )
+        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+            .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
+                ctx,
+                indent_level,
+            )]))
     } else {
         format_expression(ctx, &condition, shape + 7) // 7 = "elseif "
     };
@@ -238,9 +240,11 @@ pub fn format_if<'ast>(ctx: &mut Context, if_node: &If<'ast>, shape: Shape) -> I
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
         let condition = format_expression(ctx, &condition, shape);
-        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
-            FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
-        )
+        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+            .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
+                ctx,
+                indent_level,
+            )]))
     } else {
         format_expression(ctx, &condition, shape + 3) // 3 = "if "
     };
@@ -394,7 +398,13 @@ pub fn format_repeat_block<'ast>(
                 .range()
                 .expect("no range for repeat until");
             ctx.add_indent_range((expr_range.0.bytes(), expr_range.1.bytes()));
-            hang_expression(ctx, formatted_until, additional_indent_level, shape, None)
+            hang_expression_trailing_newline(
+                ctx,
+                formatted_until,
+                additional_indent_level,
+                shape,
+                None,
+            )
         }
         false => formatted_until.update_trailing_trivia(FormatTriviaType::Append(trailing_trivia)),
     };
@@ -447,9 +457,11 @@ pub fn format_while_block<'ast>(
         let indent_level = Some(additional_indent_level.unwrap_or(0) + 1);
         let shape = shape.reset().with_additional_indent(indent_level);
         let condition = format_expression(ctx, &condition, shape);
-        hang_expression(ctx, condition, additional_indent_level, shape, None).update_leading_trivia(
-            FormatTriviaType::Append(vec![create_indent_trivia(ctx, indent_level)]),
-        )
+        hang_expression_trailing_newline(ctx, condition, additional_indent_level, shape, None)
+            .update_leading_trivia(FormatTriviaType::Append(vec![create_indent_trivia(
+                ctx,
+                indent_level,
+            )]))
     } else {
         format_expression(ctx, &condition, shape + 6) // 6 = "while "
     };

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -180,10 +180,10 @@ pub fn format_table_constructor<'ast>(
             || trivia_util::table_fields_contains_comments(table_constructor)
     };
 
-    let table_type = match is_multiline {
-        true => TableType::MultiLine,
-        false => match current_fields.peek() {
-            Some(_) => {
+    let table_type = match current_fields.peek() {
+        Some(_) => match is_multiline {
+            true => TableType::MultiLine,
+            false => {
                 // Determine if there was a new line at the end of the start brace
                 // If so, then we should always be multiline
                 if start_brace
@@ -195,8 +195,8 @@ pub fn format_table_constructor<'ast>(
                     TableType::SingleLine
                 }
             }
-            None => TableType::Empty,
         },
+        None => TableType::Empty,
     };
 
     if let TableType::MultiLine = table_type {

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -7,10 +7,11 @@ use crate::{
             format_contained_span, format_end_token, format_symbol, format_token_reference,
             EndTokenType,
         },
-        trivia::{FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
+        trivia::{strip_trivia, FormatTriviaType, UpdateLeadingTrivia, UpdateTrailingTrivia},
         trivia_util,
         util::{expression_range, token_range},
     },
+    shape::Shape,
 };
 use full_moon::ast::{
     punctuated::{Pair, Punctuated},
@@ -34,6 +35,7 @@ pub fn format_field<'ast>(
     ctx: &mut Context,
     field: &Field<'ast>,
     leading_trivia: FormatTriviaType<'ast>,
+    shape: Shape,
 ) -> (Field<'ast>, Vec<Token<'ast>>) {
     let trailing_trivia;
     let field = match field {
@@ -44,28 +46,33 @@ pub fn format_field<'ast>(
             value,
         } => {
             trailing_trivia = trivia_util::get_expression_trailing_trivia(value);
+            let brackets =
+                format_contained_span(ctx, brackets).update_leading_trivia(leading_trivia);
+            let key = format_expression(ctx, key, shape + 1); // 1 = opening bracket
+            let equal = fmt_symbol!(ctx, equal, " = ");
+            let shape = shape.take_last_line(&key) + (2 + 3); // 2 = brackets, 3 = " = "
+            let value = format_expression(ctx, value, shape)
+                .update_trailing_trivia(FormatTriviaType::Replace(vec![])); // We will remove all the trivia from this value, and place it after the comma
             Field::ExpressionKey {
-                brackets: format_contained_span(ctx, brackets)
-                    .update_leading_trivia(leading_trivia),
-                key: format_expression(ctx, key),
-                equal: fmt_symbol!(ctx, equal, " = "),
-                // We will remove all the trivia from this value, and place it after the comma
-                value: format_expression(ctx, value)
-                    .update_trailing_trivia(FormatTriviaType::Replace(vec![])),
+                brackets,
+                key,
+                equal,
+                value,
             }
         }
         Field::NameKey { key, equal, value } => {
             trailing_trivia = trivia_util::get_expression_trailing_trivia(value);
-            Field::NameKey {
-                key: format_token_reference(ctx, key).update_leading_trivia(leading_trivia),
-                equal: fmt_symbol!(ctx, equal, " = "),
-                value: format_expression(ctx, value)
-                    .update_trailing_trivia(FormatTriviaType::Replace(vec![])),
-            }
+            let key = format_token_reference(ctx, key).update_leading_trivia(leading_trivia);
+            let equal = fmt_symbol!(ctx, equal, " = ");
+            let shape = shape + (strip_trivia(&key).to_string().len() + 3); // 3 = " = "
+            let value = format_expression(ctx, value, shape)
+                .update_trailing_trivia(FormatTriviaType::Replace(vec![]));
+
+            Field::NameKey { key, equal, value }
         }
         Field::NoKey(expression) => {
             trailing_trivia = trivia_util::get_expression_trailing_trivia(expression);
-            let formatted_expression = format_expression(ctx, expression);
+            let formatted_expression = format_expression(ctx, expression, shape);
             if let FormatTriviaType::NoChange = leading_trivia {
                 Field::NoKey(formatted_expression)
             } else {
@@ -139,6 +146,7 @@ pub fn create_table_braces<'ast>(
 pub fn format_table_constructor<'ast>(
     ctx: &mut Context,
     table_constructor: &TableConstructor<'ast>,
+    shape: Shape,
 ) -> TableConstructor<'ast> {
     let mut fields = Punctuated::new();
     let mut current_fields = table_constructor
@@ -153,10 +161,10 @@ pub fn format_table_constructor<'ast>(
         end_brace.token().start_position().bytes(),
     );
 
-    // We subtract 20 as we don't have full information about what preceded this table constructor (e.g. the assignment).
-    // This is used as a general estimate. TODO: see if we can improve this calculation
-    let mut is_multiline =
-        (braces_range.1 - braces_range.0) + ctx.indent_width() > ctx.config().column_width - 20;
+    // Use input shape to determine if we are over budget
+    // TODO: should we format the table onto a single line first?
+    let singleline_shape = shape + (braces_range.1 - braces_range.0);
+    let mut is_multiline = singleline_shape.over_budget();
 
     // Determine if there are any comments within the table. If so, we should go multiline
     if !is_multiline {
@@ -205,6 +213,12 @@ pub fn format_table_constructor<'ast>(
         additional_indent_level,
     );
 
+    let mut shape = match table_type {
+        TableType::SingleLine => shape + 2, // 1 = opening brace, 1 = space
+        TableType::MultiLine => shape.reset(), // Will take new line
+        TableType::Empty => shape,
+    };
+
     while let Some(pair) = current_fields.next() {
         let (field, punctuation) = pair.into_tuple();
 
@@ -219,12 +233,16 @@ pub fn format_table_constructor<'ast>(
                     other => panic!("unknown node {:?}", other),
                 };
                 let additional_indent_level = ctx.get_range_indent_increase(range);
+                shape = shape
+                    .reset()
+                    .with_additional_indent(additional_indent_level);
                 FormatTriviaType::Append(vec![create_indent_trivia(ctx, additional_indent_level)])
             }
             _ => FormatTriviaType::NoChange,
         };
 
-        let (formatted_field, mut trailing_trivia) = format_field(ctx, &field, leading_trivia);
+        let (formatted_field, mut trailing_trivia) =
+            format_field(ctx, &field, leading_trivia, shape);
         // Filter trailing_trivia for any newlines
         trailing_trivia = trailing_trivia
             .iter()
@@ -249,6 +267,7 @@ pub fn format_table_constructor<'ast>(
             _ => {
                 if current_fields.peek().is_some() {
                     // Have more elements still to go
+                    shape = shape + (formatted_field.to_string().len() + 2); // 2 = ", "
                     formatted_punctuation = match punctuation {
                         Some(punctuation) => Some(format_symbol(
                             ctx,

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -35,6 +35,13 @@ where
     item.update_leading_trivia(FormatTriviaType::Replace(vec![]))
 }
 
+pub fn strip_trailing_trivia<'ast, T>(item: &T) -> T
+where
+    T: UpdateTrailingTrivia<'ast>,
+{
+    item.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
+}
+
 pub trait UpdateLeadingTrivia<'ast> {
     fn update_leading_trivia(&self, leading_trivia: FormatTriviaType<'ast>) -> Self;
 }

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -28,6 +28,13 @@ where
         .update_trailing_trivia(FormatTriviaType::Replace(vec![]))
 }
 
+pub fn strip_leading_trivia<'ast, T>(item: &T) -> T
+where
+    T: UpdateLeadingTrivia<'ast>,
+{
+    item.update_leading_trivia(FormatTriviaType::Replace(vec![]))
+}
+
 pub trait UpdateLeadingTrivia<'ast> {
     fn update_leading_trivia(&self, leading_trivia: FormatTriviaType<'ast>) -> Self;
 }

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -2,8 +2,8 @@
 use full_moon::ast::types::{IndexedTypeInfo, TypeAssertion, TypeInfo, TypeSpecifier};
 use full_moon::ast::{
     punctuated::Punctuated, span::ContainedSpan, BinOp, Call, Expression, FunctionArgs,
-    FunctionBody, FunctionCall, Index, MethodCall, Parameter, Prefix, Suffix, TableConstructor,
-    UnOp, Value, Var, VarExpression,
+    FunctionBody, FunctionCall, FunctionName, Index, MethodCall, Parameter, Prefix, Suffix,
+    TableConstructor, UnOp, Value, Var, VarExpression,
 };
 use full_moon::tokenizer::{Token, TokenReference};
 
@@ -309,6 +309,22 @@ define_update_trivia!(FunctionCall, |this, leading, trailing| {
     };
 
     this.to_owned().with_prefix(prefix).with_suffixes(suffixes)
+});
+
+define_update_trivia!(FunctionName, |this, leading, trailing| {
+    if let Some(method_name) = this.method_name() {
+        let names = this.names().update_leading_trivia(leading);
+        let method_name = method_name.update_trailing_trivia(trailing);
+        this.to_owned()
+            .with_names(names)
+            .with_method(Some((this.method_colon().unwrap().to_owned(), method_name)))
+    } else {
+        let names = this
+            .names()
+            .update_leading_trivia(leading)
+            .update_trailing_trivia(trailing);
+        this.to_owned().with_names(names)
+    }
 });
 
 define_update_trivia!(Index, |this, leading, trailing| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 #[macro_use]
 mod context;
 mod formatters;
+mod shape;
 
 /// The type of indents to use when indenting
 #[derive(Debug, Copy, Clone, Deserialize)]

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,4 +1,5 @@
 use crate::context::Context;
+use std::fmt::Display;
 use std::ops::Add;
 
 #[derive(Clone, Copy, Debug)]
@@ -67,6 +68,32 @@ impl Shape {
     /// Resets the offset for the shape
     pub fn reset(&self) -> Shape {
         Self { offset: 0, ..*self }
+    }
+
+    /// Takes the first line from an item which can be converted into a string, and sets that to the the shape
+    pub fn take_first_line<T: Display>(&self, item: &T) -> Shape {
+        let string = format!("{}", item);
+        let mut lines = string.lines();
+        let width = lines.next().expect("no lines").len();
+        self.add_width(width)
+    }
+
+    /// Takes an item which could possibly span multiple lines. If it spans multiple lines, the shape is reset
+    /// and the last line is added to the width. If it only takes a single line, we just continue adding to the current
+    /// width
+    pub fn take_last_line<T: Display>(&self, item: &T) -> Shape {
+        let string = format!("{}", item);
+        let mut lines = string.lines();
+        let last_item = lines.next_back().expect("no lines");
+
+        // Check if we have any more lines remaining
+        if lines.count() > 0 {
+            // Reset the shape and add the last line
+            self.reset().add_width(last_item.len())
+        } else {
+            // Continue adding to the current shape
+            self.add_width(last_item.len())
+        }
     }
 }
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -53,7 +53,7 @@ impl Shape {
 
     /// Check to see whether our current width is above the budget available
     pub fn over_budget(&self) -> bool {
-        self.used_width() > self.column_width
+        self.used_width() >= self.column_width
     }
 
     /// Adds a width offset to the current width total

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,0 +1,79 @@
+use crate::context::Context;
+use std::ops::Add;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Shape {
+    /// The current indentation level. Note: this is not the indentation width
+    indent_level: usize,
+    /// How many characters a single indent level represents. This is inferred from the configuration
+    indent_width: usize,
+    /// Any additional indent level that we are currently in.
+    additional_indent_level: usize,
+    /// The current width we have taken on the line, excluding any indentation.
+    offset: usize,
+    /// The maximum number of characters we want to fit on a line. This is inferred from the configuration
+    column_width: usize,
+}
+
+impl Shape {
+    pub fn from_context(ctx: &Context) -> Self {
+        Self {
+            indent_level: ctx.indent_level(),
+            indent_width: ctx.config().indent_width,
+            additional_indent_level: 0,
+            offset: 0,
+            column_width: ctx.config().column_width,
+        }
+    }
+
+    /// Create a new shape containing any additional indent level
+    pub fn with_additional_indent(&self, additional_indent_level: Option<usize>) -> Shape {
+        match additional_indent_level {
+            Some(t) => Self {
+                additional_indent_level: t,
+                ..*self
+            },
+            None => *self,
+        }
+    }
+
+    pub fn indent_width(&self) -> usize {
+        (self.indent_level - 1 + self.additional_indent_level) * self.indent_width
+    }
+
+    /// The width currently taken up for this line
+    pub fn used_width(&self) -> usize {
+        self.indent_width() + self.offset
+    }
+
+    /// The available width left for this line
+    pub fn available_width(&self) -> usize {
+        self.column_width.saturating_sub(self.used_width())
+    }
+
+    /// Check to see whether our current width is above the budget available
+    pub fn over_budget(&self) -> bool {
+        self.used_width() > self.column_width
+    }
+
+    /// Adds a width offset to the current width total
+    pub fn add_width(&self, width: usize) -> Shape {
+        Self {
+            offset: self.offset + width,
+            ..*self
+        }
+    }
+
+    /// Resets the offset for the shape
+    pub fn reset(&self) -> Shape {
+        Self { offset: 0, ..*self }
+    }
+}
+
+impl Add<usize> for Shape {
+    type Output = Shape;
+
+    fn add(self, rhs: usize) -> Shape {
+        self.add_width(rhs)
+    }
+}

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -4,7 +4,7 @@ use std::ops::Add;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Shape {
-    /// The current indentation level. Note: this is not the indentation width
+    /// The current block indentation level. The base indentation level is 0. Note: this is not the indentation width
     indent_level: usize,
     /// How many characters a single indent level represents. This is inferred from the configuration
     indent_width: usize,
@@ -19,7 +19,7 @@ pub struct Shape {
 impl Shape {
     pub fn from_context(ctx: &Context) -> Self {
         Self {
-            indent_level: ctx.indent_level(),
+            indent_level: ctx.indent_level().saturating_sub(1),
             indent_width: ctx.config().indent_width,
             additional_indent_level: 0,
             offset: 0,
@@ -50,7 +50,7 @@ impl Shape {
     }
 
     pub fn indent_width(&self) -> usize {
-        (self.indent_level - 1 + self.additional_indent_level) * self.indent_width
+        (self.indent_level + self.additional_indent_level) * self.indent_width
     }
 
     /// The width currently taken up for this line

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -27,6 +27,17 @@ impl Shape {
         }
     }
 
+    /// Create a shape with a given block indent level
+    pub fn with_indent_level(ctx: &Context, indent_level: usize) -> Self {
+        Self {
+            indent_level,
+            indent_width: ctx.config().indent_width,
+            additional_indent_level: 0,
+            offset: 0,
+            column_width: ctx.config().column_width,
+        }
+    }
+
     /// Create a new shape containing any additional indent level
     pub fn with_additional_indent(&self, additional_indent_level: Option<usize>) -> Shape {
         match additional_indent_level {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -49,6 +49,19 @@ impl Shape {
         }
     }
 
+    /// Sets the column width to the provided width. Normally only used to set an infinite width when testing layouts
+    pub fn with_column_width(&self, column_width: usize) -> Self {
+        Self {
+            column_width,
+            ..*self
+        }
+    }
+
+    /// Recreates the shape with an infinite width. Useful when testing layouts and want to force code onto a single line
+    pub fn with_infinite_width(&self) -> Self {
+        self.with_column_width(usize::MAX)
+    }
+
     pub fn indent_width(&self) -> usize {
         (self.indent_level + self.additional_indent_level) * self.indent_width
     }
@@ -60,7 +73,7 @@ impl Shape {
 
     /// Check to see whether our current width is above the budget available
     pub fn over_budget(&self) -> bool {
-        self.used_width() >= self.column_width
+        self.used_width() > self.column_width
     }
 
     /// Adds a width offset to the current width total

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -58,11 +58,6 @@ impl Shape {
         self.indent_width() + self.offset
     }
 
-    /// The available width left for this line
-    pub fn available_width(&self) -> usize {
-        self.column_width.saturating_sub(self.used_width())
-    }
-
     /// Check to see whether our current width is above the budget available
     pub fn over_budget(&self) -> bool {
         self.used_width() >= self.column_width

--- a/tests/inputs/context-long-lines.lua
+++ b/tests/inputs/context-long-lines.lua
@@ -1,0 +1,17 @@
+do
+	local region = Region3.new(part.Position - (0.5 * part.Size), part.Position + (0.5 * part.Size))
+
+	do
+		do
+			return function(...)
+				callback(LOG_FORMAT:format(os.date("%H:%M:%S"), key, level, fmt.fmt(...)))
+			end
+		end
+	end
+
+	self.digits = math.ceil(math.log10(math.max(math.abs(self.props.maxValue), math.abs(self.props.minValue))))
+end
+
+local gamemodes, keysById, idsByKey = createDataIndex(script.AllGamemodes, validateGamemodeSchema)
+
+HealthRegen.ValidateInstance = t.intersection(ComponentUtil.HasComponentValidator("Health"), ComponentUtil.HasComponentValidator("Target"))

--- a/tests/inputs/function-def-multiline.lua
+++ b/tests/inputs/function-def-multiline.lua
@@ -1,4 +1,7 @@
-function foo(fooooo, barrrrrrrrrr, bazzzzzzzzzzzzzzz, fooooooooooo, bazzzzzzzzzzzzzzzzzzz, barrrrrrrrrrrrrrrrrrrrrrrr, fooooooobarbaz)
+function foo(foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo, barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr)
+end
+
+function foobar(fooooo, barrrrrrrrrr, bazzzzzzzzzzzzzzz, fooooooooooo, bazzzzzzzzzzzzzzzzzzz, barrrrrrrrrrrrrrrrrrrrrrrr)
 	print("test")
 end
 
@@ -6,6 +9,11 @@ do
 	function foo(fooooo, barr -- test
 	)
 		print("test")
+	end
+end
+
+do
+	function bar(foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo, barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr)
 	end
 end
 

--- a/tests/inputs/long-assignment.lua
+++ b/tests/inputs/long-assignment.lua
@@ -5,3 +5,7 @@ LoadAddOn, UnitName, GetRealmName, UnitRace, UnitFactionGroup, IsInRaid = LoadAd
 do
 	local LoadAddOn, UnitName, GetRealmName, UnitRace, UnitFactionGroup, IsInRaid = LoadAddOn, UnitName, GetRealmName, UnitRace, UnitFactionGroup, IsInRaid
 end
+
+do
+	local XOffset, YOffset, ZOffset = CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0), CFrame.new(0, GlobalConfiguration.TPS_CAMERA_OFFSET.Y, 0), CFrame.new(0, 0, GlobalConfiguration.TPS_CAMERA_OFFSET.Z)
+end

--- a/tests/snapshots/tests__luau@large_example.lua.snap
+++ b/tests/snapshots/tests__luau@large_example.lua.snap
@@ -67,7 +67,11 @@ function API.isReady()
 	return not not dump
 end
 
-function API.getMembers(class: string, tagFilter: Array<string>?, securityFilter: Array<string>?): Dictionary<ApiTypes.Member>
+function API.getMembers(
+	class: string,
+	tagFilter: Array<string>?,
+	securityFilter: Array<string>?
+): Dictionary<ApiTypes.Member>
 	if not dump then
 		error(MODULE_NOT_READY_MESSAGE, 2)
 	end
@@ -97,7 +101,11 @@ function API.getMembers(class: string, tagFilter: Array<string>?, securityFilter
 	return memberList
 end
 
-function API.getProperties(class: string, tagFilter: Array<string>?, securityFilter: Array<string>?): Dictionary<ApiTypes.Property>
+function API.getProperties(
+	class: string,
+	tagFilter: Array<string>?,
+	securityFilter: Array<string>?
+): Dictionary<ApiTypes.Property>
 	if not dump then
 		error(MODULE_NOT_READY_MESSAGE, 2)
 	end
@@ -130,7 +138,11 @@ function API.getProperties(class: string, tagFilter: Array<string>?, securityFil
 	return memberList
 end
 
-function API.getFunctions(class: string, tagFilter: Array<string>?, securityFilter: Array<string>?): Dictionary<ApiTypes.Function>
+function API.getFunctions(
+	class: string,
+	tagFilter: Array<string>?,
+	securityFilter: Array<string>?
+): Dictionary<ApiTypes.Function>
 	if not dump then
 		error(MODULE_NOT_READY_MESSAGE, 2)
 	end
@@ -163,7 +175,11 @@ function API.getFunctions(class: string, tagFilter: Array<string>?, securityFilt
 	return memberList
 end
 
-function API.getEvents(class: string, tagFilter: Array<string>?, securityFilter: Array<string>?): Dictionary<ApiTypes.Event>
+function API.getEvents(
+	class: string,
+	tagFilter: Array<string>?,
+	securityFilter: Array<string>?
+): Dictionary<ApiTypes.Event>
 	if not dump then
 		error(MODULE_NOT_READY_MESSAGE, 2)
 	end
@@ -196,7 +212,11 @@ function API.getEvents(class: string, tagFilter: Array<string>?, securityFilter:
 	return memberList
 end
 
-function API.getCallbacks(class: string, tagFilter: Array<string>?, securityFilter: Array<string>?): Dictionary<ApiTypes.Callback>
+function API.getCallbacks(
+	class: string,
+	tagFilter: Array<string>?,
+	securityFilter: Array<string>?
+): Dictionary<ApiTypes.Callback>
 	if not dump then
 		error(MODULE_NOT_READY_MESSAGE, 2)
 	end

--- a/tests/snapshots/tests__standard@context-long-lines.lua.snap
+++ b/tests/snapshots/tests__standard@context-long-lines.lua.snap
@@ -1,0 +1,26 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+do
+	local region = Region3.new(part.Position - (0.5 * part.Size), part.Position + (0.5 * part.Size))
+
+	do
+		do
+			return function(...)
+				callback(LOG_FORMAT:format(os.date("%H:%M:%S"), key, level, fmt.fmt(...)))
+			end
+		end
+	end
+
+	self.digits = math.ceil(math.log10(math.max(math.abs(self.props.maxValue), math.abs(self.props.minValue))))
+end
+
+local gamemodes, keysById, idsByKey = createDataIndex(script.AllGamemodes, validateGamemodeSchema)
+
+HealthRegen.ValidateInstance = t.intersection(
+	ComponentUtil.HasComponentValidator("Health"),
+	ComponentUtil.HasComponentValidator("Target")
+)
+

--- a/tests/snapshots/tests__standard@function-def-multiline.lua.snap
+++ b/tests/snapshots/tests__standard@function-def-multiline.lua.snap
@@ -3,14 +3,16 @@ source: tests/tests.rs
 expression: format(&contents)
 
 ---
-function foo(
+function foo(foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo, barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr)
+end
+
+function foobar(
 	fooooo,
 	barrrrrrrrrr,
 	bazzzzzzzzzzzzzzz,
 	fooooooooooo,
 	bazzzzzzzzzzzzzzzzzzz,
-	barrrrrrrrrrrrrrrrrrrrrrrr,
-	fooooooobarbaz
+	barrrrrrrrrrrrrrrrrrrrrrrr
 )
 	print("test")
 end
@@ -21,6 +23,14 @@ do
 		barr -- test
 	)
 		print("test")
+	end
+end
+
+do
+	function bar(
+		foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
+		barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+	)
 	end
 end
 

--- a/tests/snapshots/tests__standard@long-assignment.lua.snap
+++ b/tests/snapshots/tests__standard@long-assignment.lua.snap
@@ -14,3 +14,9 @@ do
 		LoadAddOn, UnitName, GetRealmName, UnitRace, UnitFactionGroup, IsInRaid
 end
 
+do
+	local XOffset, YOffset, ZOffset = CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0),
+		CFrame.new(0, GlobalConfiguration.TPS_CAMERA_OFFSET.Y, 0),
+		CFrame.new(0, 0, GlobalConfiguration.TPS_CAMERA_OFFSET.Z)
+end
+


### PR DESCRIPTION
This PR implements a `Shape` struct, which contains information about the current amount of width left to format in a given line.
This allows us to provide contextual position information for each formatter, to improve the decisions made about when to format.

This greatly improves the formatting based on column width, and we no longer need to rely on taking away arbitrary values to make to code "fit".

TODO:
- Hang binary expressions before expanding them. We should try to hang binary expressions, rather than keeping them on the same line and expanding e.g. a function call.
e.g. 
```lua
EquippedLocalConfiguration = Tool:FindFirstChild("Configuration")
		or WeaponFunction:InvokeServer("InitialiseTool", Tool)
-- vs.
EquippedLocalConfiguration = Tool:FindFirstChild("Configuration") or WeaponFunction:InvokeServer(
	"InitialiseTool",
	Tool
)
```
- ~~Reformat binary expressions once they are hung. Currently, if a binary expression is hung, the expressions aren't collapsed back onto a single line if possible. Need to combine formatting and hanging together into one function.~~
- Look into improving "formatting tactics" in places. E.g. for assignments we should attempt the following four tactics in order: 1) format on single line, 2) hang a binary expression, 3) hang at the equals sign, 4) expand code onto multiple lines.
- Update changelog

Fixes #78 