### PR TITLE
Hang prefix expressions which go over the column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Long prefix expressions which are hangable and go over the line limit (e.g. `("foooo" .. "barrrrrrr" .. "bazzzzzz"):format(...)`) will now hang multiline ([#139](https://github.com/JohnnyMorganz/StyLua/issues/139))
+
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed
 

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -687,7 +687,7 @@ pub fn format_function_call<'ast>(
         }
     };
 
-    let mut shape = shape + strip_leading_trivia(&formatted_prefix).to_string().len(); // TODO: can the prefix be multiline?
+    let mut shape = shape.take_last_line(&strip_leading_trivia(&formatted_prefix));
     let mut formatted_suffixes = Vec::with_capacity(num_suffixes);
     for suffix in function_call.suffixes() {
         // Calculate the range before formatting, otherwise it will reset to (0,0)

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -39,7 +39,18 @@ pub fn can_hang_expression(expression: &Expression) -> bool {
         Expression::Parentheses { expression, .. } => can_hang_expression(expression),
         Expression::UnaryOperator { expression, .. } => can_hang_expression(expression),
         Expression::BinaryOperator { .. } => true, // If a binop is present, then we can hang the expression
-        Expression::Value { .. } => false,
+        Expression::Value { value, .. } => match &**value {
+            Value::ParenthesesExpression(expression) => can_hang_expression(expression),
+            Value::FunctionCall(function_call) => match function_call.prefix() {
+                Prefix::Expression(expression) => can_hang_expression(expression),
+                _ => false,
+            },
+            Value::Var(Var::Expression(expression)) => match expression.prefix() {
+                Prefix::Expression(expression) => can_hang_expression(expression),
+                _ => false,
+            },
+            _ => false,
+        },
         other => panic!("unknown node {:?}", other),
     }
 }

--- a/tests/inputs/hang-prefix.lua
+++ b/tests/inputs/hang-prefix.lua
@@ -1,0 +1,7 @@
+("foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" .. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"):format()
+
+do
+	("foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" .. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"):format()
+end
+
+print(("foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" .. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"):format())

--- a/tests/snapshots/tests__standard@hang-prefix.lua.snap
+++ b/tests/snapshots/tests__standard@hang-prefix.lua.snap
@@ -1,0 +1,24 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+(
+	"foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+	.. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+):format()
+
+do
+	(
+		"foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+		.. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+	):format()
+end
+
+print(
+	(
+		"foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+		.. "barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+	):format()
+)
+


### PR DESCRIPTION
Closes #139 

```lua
("foooo" .. "barrrrrrrr" .. "bazzzzzzz"):format()
```
... will now become ...
```lua
(
    "foooo"
    .. "barrrrrrrr"
    .. "bazzzzzzz"
):format()
```
(truncated for simplicity, but this is assuming the prefix goes over the column width)