### PR TITLE
Preserve single whitespace infront of multiline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed
+- Fixed whitespace being lost before a multiline comment. We will now preserve a single space (e.g. `local test  --[[foo]] = true` -> `local test --[[foo]] = true`) ([#136](https://github.com/JohnnyMorganz/StyLua/issues/136))
 
 ## [0.8.1] - 2021-04-30
 ### Fixed

--- a/tests/inputs/multiline-comments.lua
+++ b/tests/inputs/multiline-comments.lua
@@ -1,0 +1,8 @@
+checkVisitorFnArgs(
+	expect,
+	ast,
+	{ ... },
+	true --[[ isEdited ]]
+)
+
+local test   --[[foo]] = true

--- a/tests/inputs/multiline-comments.lua
+++ b/tests/inputs/multiline-comments.lua
@@ -6,3 +6,6 @@ checkVisitorFnArgs(
 )
 
 local test   --[[foo]] = true
+
+   --[[test]]
+local x = true

--- a/tests/snapshots/tests__standard@multiline-comments.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-comments.lua.snap
@@ -12,3 +12,6 @@ checkVisitorFnArgs(
 
 local test --[[foo]] = true
 
+--[[test]]
+local x = true
+

--- a/tests/snapshots/tests__standard@multiline-comments.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-comments.lua.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+checkVisitorFnArgs(
+	expect,
+	ast,
+	{ ... },
+	true --[[ isEdited ]]
+)
+
+local test --[[foo]] = true
+


### PR DESCRIPTION
Fixes #136

Note, whitespace not preserved if the multiline comment is part of leading trivia