### PR TITLE
Function call expanding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Long prefix expressions which are hangable and go over the line limit (e.g. `("foooo" .. "barrrrrrr" .. "bazzzzzz"):format(...)`) will now hang multiline ([#139](https://github.com/JohnnyMorganz/StyLua/issues/139))
-- Function calls with single arguments are now possible to be expanded. This will allow the call to be expanded if the line goes over budget.
+- Function calls with single arguments are now possible to be expanded. This will allow the call to be expanded if the line goes over budget. ([[#156](https://github.com/JohnnyMorganz/StyLua/issues/156)])
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Long prefix expressions which are hangable and go over the line limit (e.g. `("foooo" .. "barrrrrrr" .. "bazzzzzz"):format(...)`) will now hang multiline ([#139](https://github.com/JohnnyMorganz/StyLua/issues/139))
+- Function calls with single arguments are now possible to be expanded. This will allow the call to be expanded if the line goes over budget.
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -254,11 +254,18 @@ pub fn format_function_args<'ast>(
                                         if seen_multiline_arg {
                                             seen_other_arg_after_multiline = true;
                                         }
+
+                                        // Take the first line to see if we are over budget
+                                        if singleline_shape.take_first_line(argument).over_budget()
+                                        {
+                                            is_multiline = true;
+                                            break;
+                                        }
+
+                                        // Set the shape to the last line, then examine if over budget
                                         singleline_shape =
                                             singleline_shape.take_last_line(argument);
                                         if singleline_shape.over_budget() {
-                                            // We have passed 80 characters without a table or anonymous function
-                                            // There is nothing else stopping us from expanding - so we will
                                             is_multiline = true;
                                             break;
                                         }
@@ -274,10 +281,15 @@ pub fn format_function_args<'ast>(
                                     seen_other_arg_after_multiline = true;
                                 }
 
+                                // Take the first line to see if we are over budget
+                                if singleline_shape.take_first_line(argument).over_budget() {
+                                    is_multiline = true;
+                                    break;
+                                }
+
+                                // Set the shape to the last line, then examine if over budget
                                 singleline_shape = singleline_shape.take_last_line(argument);
                                 if singleline_shape.over_budget() {
-                                    // We have passed 80 characters without a table or anonymous function
-                                    // There is nothing else stopping us from expanding - so we will
                                     is_multiline = true;
                                     break;
                                 }

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -274,7 +274,7 @@ pub fn format_function_args<'ast>(
                                     seen_other_arg_after_multiline = true;
                                 }
 
-                                singleline_shape = singleline_shape + argument.to_string().len();
+                                singleline_shape = singleline_shape.take_last_line(argument);
                                 if singleline_shape.over_budget() {
                                     // We have passed 80 characters without a table or anonymous function
                                     // There is nothing else stopping us from expanding - so we will

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -84,6 +84,14 @@ impl Shape {
         }
     }
 
+    /// Subtracts a width offset from the current width total
+    pub fn sub_width(&self, width: usize) -> Shape {
+        Self {
+            offset: self.offset.saturating_sub(width),
+            ..*self
+        }
+    }
+
     /// Resets the offset for the shape
     pub fn reset(&self) -> Shape {
         Self { offset: 0, ..*self }

--- a/tests/inputs/single-arg-function-calls.lua
+++ b/tests/inputs/single-arg-function-calls.lua
@@ -1,0 +1,13 @@
+do
+	do
+		do
+			do
+				do
+					do
+						jestExpect(ReactIs.typeOf(React.createElement(React.Profiler, { id = "foo", onRender = jest.fn() }))).toBe(ReactIs.Profiler)
+					end
+				end
+			end
+		end
+	end
+end

--- a/tests/snapshots/tests__standard@large-example-2.lua.snap
+++ b/tests/snapshots/tests__standard@large-example-2.lua.snap
@@ -653,8 +653,7 @@ function oc(msg, speaker)
 			for i = 1, #player do
 				if player[i].Character ~= nil then
 					if player[i].Character:FindFirstChild("God FF") == nil then
-						createscript(
-							[[script.Parent.Humanoid.MaxHealth = 999999
+						createscript([[script.Parent.Humanoid.MaxHealth = 999999
 script.Parent.Humanoid.Health = 999999
 ff = Instance.new("ForceField")
 ff.Name = "God FF"
@@ -674,9 +673,7 @@ for i=1,#c do
 if c[i].className == "Part" then
 c[i].Touched:connect(ot)
 c[i].Reflectance = 1
-end end]],
-							player[i].Character
-						)
+end end]], player[i].Character)
 					end
 				end
 			end
@@ -1091,8 +1088,7 @@ end end]],
 							sm.MeshType = "Sphere"
 							sm.Parent = ball
 							ball.Parent = player[i].Character
-							createscript(
-								[[ 
+							createscript([[ 
 function ot(hit) 
 if hit.Parent ~= nil then 
 if hit.Parent ~= script.Parent.Parent then 
@@ -1102,9 +1098,7 @@ local pos = script.Parent.CFrame * (Vector3.new(0, 1.4, 0) * script.Parent.Size)
 hit.Velocity = ((hit.Position - pos).unit + Vector3.new(0, 0.5, 0)) * 150 + hit.Velocity	
 hit.RotVelocity = hit.RotVelocity + Vector3.new(hit.Position.z - pos.z, 0, pos.x - hit.Position.x).unit * 40
 end end end end
-script.Parent.Touched:connect(ot) ]],
-								ball
-							)
+script.Parent.Touched:connect(ot) ]], ball)
 							local bf = Instance.new("BodyForce")
 							bf.force = Vector3.new(0, 5e004, 0)
 							bf.Parent = ball
@@ -1142,8 +1136,7 @@ script.Parent.Touched:connect(ot) ]],
 		if player ~= 0 then
 			for i = 1, #player do
 				local s = Instance.new("Script")
-				createscript(
-					[[name = "]] .. player[i].Name .. [[" 
+				createscript([[name = "]] .. player[i].Name .. [[" 
 ov = Instance.new("ObjectValue")
 ov.Value = game.Players:FindFirstChild(name)
 ov.Name = "elplayerioloopkillioperson299io"
@@ -1158,9 +1151,7 @@ if humanoid ~= nil then
 humanoid.Health = 0 
 end end end end
 game.Workspace.ChildAdded:connect(oa)
-]],
-					game.Workspace
-				)
+]], game.Workspace)
 				if player[i].Character ~= nil then
 					local human = player[i].Character:FindFirstChild("Humanoid")
 					if human ~= nil then
@@ -1328,8 +1319,7 @@ game.Workspace.ChildAdded:connect(oa)
 						zarm.TopSurface = "Smooth"
 						zarm.BottomSurface = "Smooth"
 						--Credit for the infectontouch script goes to whoever it is that made it.
-						createscript(
-							[[
+						createscript([[
 wait(1)
 function onTouched(part)
 if part.Parent ~= nil then
@@ -1373,9 +1363,7 @@ end
 end
 end
 script.Parent.Touched:connect(onTouched)
-]],
-							zarm
-						)
+]], zarm)
 						zarm.Name = "zarm"
 						local zarm2 = zarm:clone()
 						zarm2.CFrame = torso.CFrame * CFrame.new(Vector3.new(-1.5, 0.5, -0.5)) * rot
@@ -1431,8 +1419,7 @@ script.Parent.Touched:connect(onTouched)
 						bt.Parent = r
 						r.Parent = player[i].Character
 						w.Parent = torso
-						createscript(
-							[[
+						createscript([[
 for i=1,120 do
 local ex = Instance.new("Explosion")
 ex.BlastRadius = 0
@@ -1446,9 +1433,7 @@ ex.Position = script.Parent.Position
 ex.Parent = game.Workspace
 script.Parent.BodyThrust:remove()
 script.Parent.Parent.Humanoid.Health = 0
-]],
-							r
-						)
+]], r)
 					end
 				end
 			end

--- a/tests/snapshots/tests__standard@large-example.lua.snap
+++ b/tests/snapshots/tests__standard@large-example.lua.snap
@@ -128,13 +128,10 @@ do
 		}
 
 		for _, runtimeError in ipairs(self:getErrorChain()) do
-			table.insert(
-				errorStrings,
-				table.concat({
-					runtimeError.trace or runtimeError.error,
-					runtimeError.context,
-				}, "\n")
-			)
+			table.insert(errorStrings, table.concat({
+				runtimeError.trace or runtimeError.error,
+				runtimeError.context,
+			}, "\n"))
 		end
 
 		return table.concat(errorStrings, "\n")
@@ -830,17 +827,15 @@ function Promise.prototype:timeout(seconds, rejectionValue)
 
 	return Promise.race({
 		Promise.delay(seconds):andThen(function()
-			return Promise.reject(
-				rejectionValue == nil and Error.new({
-					kind = Error.Kind.TimedOut,
-					error = "Timed out",
-					context = string.format(
-						"Timeout of %d seconds exceeded.\n:timeout() called at:\n\n%s",
-						seconds,
-						traceback
-					),
-				}) or rejectionValue
-			)
+			return Promise.reject(rejectionValue == nil and Error.new({
+				kind = Error.Kind.TimedOut,
+				error = "Timed out",
+				context = string.format(
+					"Timeout of %d seconds exceeded.\n:timeout() called at:\n\n%s",
+					seconds,
+					traceback
+				),
+			}) or rejectionValue)
 		end),
 		self,
 	})
@@ -1326,13 +1321,11 @@ function Promise.prototype:now(rejectionValue)
 			return ...
 		end)
 	else
-		return Promise.reject(
-			rejectionValue == nil and Error.new({
-				kind = Error.Kind.NotResolvedInTime,
-				error = "This Promise was not resolved in time for :now()",
-				context = ":now() was called at:\n\n" .. traceback,
-			}) or rejectionValue
-		)
+		return Promise.reject(rejectionValue == nil and Error.new({
+			kind = Error.Kind.NotResolvedInTime,
+			error = "This Promise was not resolved in time for :now()",
+			context = ":now() was called at:\n\n" .. traceback,
+		}) or rejectionValue)
 	end
 end
 

--- a/tests/snapshots/tests__standard@single-arg-function-calls.lua.snap
+++ b/tests/snapshots/tests__standard@single-arg-function-calls.lua.snap
@@ -1,0 +1,21 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+do
+	do
+		do
+			do
+				do
+					do
+						jestExpect(
+							ReactIs.typeOf(React.createElement(React.Profiler, { id = "foo", onRender = jest.fn() }))
+						).toBe(ReactIs.Profiler)
+					end
+				end
+			end
+		end
+	end
+end
+


### PR DESCRIPTION
Fixes #148 - allows expanding of calls which contain single function args.

This PR also uses an infinite width shape for the first iteration of formatting arguments, so that they line up on a single line as much as possible - making it easier to determine whether we need to wrap.
It also uses `.take_last_line()` instead of `.to_string().len()`, as some values are function calls with a multiline arg inside of them.
Also checks the shape after the loop through arguments is complete, as we may be over budget.

Still need to decide on one thing: might want to make the function args formatting as a whole simpler and more akin to prettier - where we expand function args onto multiple lines if there is a multiline arg present within it (excluding if the multiline arg is the last arg/only arg).
We will then, however, need to add special cases for things like `Roact.createElement()` or `setmetatable`, as they are normally inlined rather than expanded. Going to think about this