### PR TITLE
Improve assignment formatting tactics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Long prefix expressions which are hangable and go over the line limit (e.g. `("foooo" .. "barrrrrrr" .. "bazzzzzz"):format(...)`) will now hang multiline ([#139](https://github.com/JohnnyMorganz/StyLua/issues/139))
+- Changed formatting for assignments. We will now try all tactics then determine the best one. Multiple assignments will now no longer attempt to hang a single expression first - we will hang the whole punctuated list. ([#157](https://github.com/JohnnyMorganz/StyLua/issues/157))
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 /// A Range, from a Start Position to an End Position
 pub type Range = (usize, usize);
 
+#[derive(Debug, Clone)]
 pub struct Context {
     /// The configuration passed to the formatter
     config: Config,

--- a/tests/inputs/long-assignment-2.lua
+++ b/tests/inputs/long-assignment-2.lua
@@ -1,0 +1,3 @@
+do
+	local HitPart, HitPoint, HitNormal, HitMaterial = nil, Ray.Origin + Ray.Direction, Vector3.new(0, 1, 0), Enum.Material.Air
+end

--- a/tests/snapshots/tests__standard@long-assignment-2.lua.snap
+++ b/tests/snapshots/tests__standard@long-assignment-2.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+do
+	local HitPart, HitPoint, HitNormal, HitMaterial =
+		nil, Ray.Origin + Ray.Direction, Vector3.new(0, 1, 0), Enum.Material.Air
+end
+


### PR DESCRIPTION
- Extract it out into a single function to use for both Assignment and LocalAssignment
- Try all tactics first, and then see which one is better
- Multiple assignment better formatting: don't try hanging a single expression in the list first, we will try hanging the whole list.

Had to clone context due to the mutable state persisting (see #153) - may want to find an alternative