### PR TITLE
Hug function call with single table argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Function calls with single arguments are now possible to be expanded. This will allow the call to be expanded if the line goes over budget. ([#156](https://github.com/JohnnyMorganz/StyLua/issues/156))
 - StyLua will now firstly prefer hanging long arguments to function calls to try and fit under the width, before expanding them multiline. ([#159](https://github.com/JohnnyMorganz/StyLua/issues/159))
 - When hanging a binary expression, previously, we would always hang the "root" node of AST BinExp tree. Now we will check to see if is necessary (we are over width) before hanging ([#163](https://github.com/JohnnyMorganz/StyLua/issues/163))
+- StyLua will hug together table braces with function call parentheses when formatting a function call taking a single table as an argument. ([#182](https://github.com/JohnnyMorganz/StyLua/issues/182))
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -233,9 +233,9 @@ fn format_multiline_table<'ast>(
     let mut shape = shape.reset().increment_additional_indent(); // Will take new line, and additional indentation
 
     let mut fields = Punctuated::new();
-    let mut current_fields = table_constructor.fields().pairs().peekable();
+    let current_fields = table_constructor.fields().pairs();
 
-    while let Some(pair) = current_fields.next() {
+    for pair in current_fields {
         let (field, punctuation) = (pair.value(), pair.punctuation());
 
         // Reset the shape onto a new line, as we are a new field

--- a/tests/inputs/function-call-6.lua
+++ b/tests/inputs/function-call-6.lua
@@ -1,0 +1,6 @@
+-- hug table braces with parentheses
+
+print({ foo_variable = "some long value", foo_variable = "some long value", foo_variable = "some long value", foo_variable = "some long value", })
+
+print({ foo_variable = "somenge", foo_variable = "malue", foo_variable = "alueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" })
+

--- a/tests/snapshots/tests__standard@function-call-6.lua.snap
+++ b/tests/snapshots/tests__standard@function-call-6.lua.snap
@@ -1,0 +1,20 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- hug table braces with parentheses
+
+print({
+	foo_variable = "some long value",
+	foo_variable = "some long value",
+	foo_variable = "some long value",
+	foo_variable = "some long value",
+})
+
+print({
+	foo_variable = "somenge",
+	foo_variable = "malue",
+	foo_variable = "alueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+})
+


### PR DESCRIPTION
If we have a function call, which takes in a single table as arguments, we will hug the table braces with the function call parentheses:

```lua
foo(
	{
		bar = true,
		foobar = false,
	}
)
```
... is now formatted as ...
```lua
foo({
	bar = true,
	foobar = false,
})
```

This change also fixes #181 as we will now always format as above, preventing the unstable formatting.