### PR TITLE
Expand function calls if it contains a complex arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - StyLua will now firstly prefer hanging long arguments to function calls to try and fit under the width, before expanding them multiline. ([#159](https://github.com/JohnnyMorganz/StyLua/issues/159))
 - When hanging a binary expression, previously, we would always hang the "root" node of AST BinExp tree. Now we will check to see if is necessary (we are over width) before hanging ([#163](https://github.com/JohnnyMorganz/StyLua/issues/163))
 - StyLua will hug together table braces with function call parentheses when formatting a function call taking a single table as an argument. ([#182](https://github.com/JohnnyMorganz/StyLua/issues/182))
+- Function calls with more than one argument, where an argument is "complex", will now expand multiline. "complex" is an argument spanning multiple lines, but excludes a table or anonymous function, as we handle them explicitly. ([#183](https://github.com/JohnnyMorganz/StyLua/issues/183))
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -104,6 +104,10 @@ fn is_table_constructor(expression: &Expression) -> bool {
     }
 }
 
+fn is_complex_arg(value: &Value) -> bool {
+    value.to_string().trim().contains('\n')
+}
+
 /// Formats a FunctionArgs node
 pub fn format_function_args<'ast>(
     ctx: &Context,
@@ -247,6 +251,13 @@ pub fn format_function_args<'ast>(
                                         // in the mix, update the state to respond to this
                                         if seen_multiline_arg {
                                             seen_other_arg_after_multiline = true;
+                                        }
+
+                                        // If the argument is complex (spans multiple lines), then we will immediately
+                                        // exit and span multiline - it is most likely too complex to keep going forward.
+                                        if is_complex_arg(value) && arguments.len() > 1 {
+                                            is_multiline = true;
+                                            break;
                                         }
 
                                         // Take the first line to see if we are over budget

--- a/tests/inputs/complex-args.lua
+++ b/tests/inputs/complex-args.lua
@@ -1,0 +1,3 @@
+React.createElement("span", { key = id }, React.createElement(Consumer, nil, function()
+	return React.createElement("span", nil, "inner")
+end), React.createElement("span", nil, "outer"))

--- a/tests/snapshots/tests__standard@complex-args.lua.snap
+++ b/tests/snapshots/tests__standard@complex-args.lua.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+React.createElement(
+	"span",
+	{ key = id },
+	React.createElement(Consumer, nil, function()
+		return React.createElement("span", nil, "inner")
+	end),
+	React.createElement("span", nil, "outer")
+)
+

--- a/tests/snapshots/tests__standard@large-example-2.lua.snap
+++ b/tests/snapshots/tests__standard@large-example-2.lua.snap
@@ -653,7 +653,8 @@ function oc(msg, speaker)
 			for i = 1, #player do
 				if player[i].Character ~= nil then
 					if player[i].Character:FindFirstChild("God FF") == nil then
-						createscript([[script.Parent.Humanoid.MaxHealth = 999999
+						createscript(
+							[[script.Parent.Humanoid.MaxHealth = 999999
 script.Parent.Humanoid.Health = 999999
 ff = Instance.new("ForceField")
 ff.Name = "God FF"
@@ -673,7 +674,9 @@ for i=1,#c do
 if c[i].className == "Part" then
 c[i].Touched:connect(ot)
 c[i].Reflectance = 1
-end end]], player[i].Character)
+end end]],
+							player[i].Character
+						)
 					end
 				end
 			end
@@ -1088,7 +1091,8 @@ end end]], player[i].Character)
 							sm.MeshType = "Sphere"
 							sm.Parent = ball
 							ball.Parent = player[i].Character
-							createscript([[ 
+							createscript(
+								[[ 
 function ot(hit) 
 if hit.Parent ~= nil then 
 if hit.Parent ~= script.Parent.Parent then 
@@ -1098,7 +1102,9 @@ local pos = script.Parent.CFrame * (Vector3.new(0, 1.4, 0) * script.Parent.Size)
 hit.Velocity = ((hit.Position - pos).unit + Vector3.new(0, 0.5, 0)) * 150 + hit.Velocity	
 hit.RotVelocity = hit.RotVelocity + Vector3.new(hit.Position.z - pos.z, 0, pos.x - hit.Position.x).unit * 40
 end end end end
-script.Parent.Touched:connect(ot) ]], ball)
+script.Parent.Touched:connect(ot) ]],
+								ball
+							)
 							local bf = Instance.new("BodyForce")
 							bf.force = Vector3.new(0, 5e004, 0)
 							bf.Parent = ball
@@ -1319,7 +1325,8 @@ game.Workspace.ChildAdded:connect(oa)
 						zarm.TopSurface = "Smooth"
 						zarm.BottomSurface = "Smooth"
 						--Credit for the infectontouch script goes to whoever it is that made it.
-						createscript([[
+						createscript(
+							[[
 wait(1)
 function onTouched(part)
 if part.Parent ~= nil then
@@ -1363,7 +1370,9 @@ end
 end
 end
 script.Parent.Touched:connect(onTouched)
-]], zarm)
+]],
+							zarm
+						)
 						zarm.Name = "zarm"
 						local zarm2 = zarm:clone()
 						zarm2.CFrame = torso.CFrame * CFrame.new(Vector3.new(-1.5, 0.5, -0.5)) * rot
@@ -1419,7 +1428,8 @@ script.Parent.Touched:connect(onTouched)
 						bt.Parent = r
 						r.Parent = player[i].Character
 						w.Parent = torso
-						createscript([[
+						createscript(
+							[[
 for i=1,120 do
 local ex = Instance.new("Explosion")
 ex.BlastRadius = 0
@@ -1433,7 +1443,9 @@ ex.Position = script.Parent.Position
 ex.Parent = game.Workspace
 script.Parent.BodyThrust:remove()
 script.Parent.Parent.Humanoid.Health = 0
-]], r)
+]],
+							r
+						)
 					end
 				end
 			end

--- a/tests/snapshots/tests__standard@large-example.lua.snap
+++ b/tests/snapshots/tests__standard@large-example.lua.snap
@@ -128,10 +128,13 @@ do
 		}
 
 		for _, runtimeError in ipairs(self:getErrorChain()) do
-			table.insert(errorStrings, table.concat({
-				runtimeError.trace or runtimeError.error,
-				runtimeError.context,
-			}, "\n"))
+			table.insert(
+				errorStrings,
+				table.concat({
+					runtimeError.trace or runtimeError.error,
+					runtimeError.context,
+				}, "\n")
+			)
 		end
 
 		return table.concat(errorStrings, "\n")


### PR DESCRIPTION
Expand function calls if they contain a complex argument, and there is more than one argument.
Complex argument is one which spans multiple lines. This excludes a general table or anonymous function as they are handled separately, but it could include an argument being another function call containing a table or function in it.

We immediately expand if we see one of these arguments, and there are > 1 arguments. This may be oversensitive, however it seems reasonable with our current test cases (need to test other items)

Fixes #175 - note we will do this even if we are below the column width, as it is a complex call and is hard to read otherwise.