### PR TITLE
Always hang at equal token for multiple assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When hanging a binary expression, previously, we would always hang the "root" node of AST BinExp tree. Now we will check to see if is necessary (we are over width) before hanging ([#163](https://github.com/JohnnyMorganz/StyLua/issues/163))
 - StyLua will hug together table braces with function call parentheses when formatting a function call taking a single table as an argument. ([#182](https://github.com/JohnnyMorganz/StyLua/issues/182))
 - Function calls with more than one argument, where an argument is "complex", will now expand multiline. "complex" is an argument spanning multiple lines, but excludes a table or anonymous function, as we handle them explicitly. ([#183](https://github.com/JohnnyMorganz/StyLua/issues/183))
+- StyLua will always hang at the equals token for a multi-variable assignment. ([#185](https://github.com/JohnnyMorganz/StyLua/issues/185))
 
 ### Fixed
 - Fixed 1 or 2 digit numerical escapes being incorrectly removed

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -115,11 +115,17 @@ fn attempt_assignment_tactics<'ast>(
             .take_first_line(&strip_trivia(&expr_list))
             .over_budget()
         {
+            // See whether there is more than one item in the punctuated list
             // Hang the expressions on multiple lines
-            let multiline_expr =
-                format_punctuated_multiline(ctx, expressions, shape, format_expression, Some(1));
+            let multiline_expr = format_punctuated_multiline(
+                ctx,
+                expressions,
+                hanging_shape,
+                format_expression,
+                None,
+            );
             // TODO: should we check each multiline expr in the list, to see if we need to hang them?
-            (multiline_expr, equal_token.to_owned())
+            (multiline_expr, hanging_equal_token)
         } else {
             (expr_list, hanging_equal_token)
         }

--- a/tests/snapshots/tests__standard@long-assignment.lua.snap
+++ b/tests/snapshots/tests__standard@long-assignment.lua.snap
@@ -15,7 +15,8 @@ do
 end
 
 do
-	local XOffset, YOffset, ZOffset = CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0),
+	local XOffset, YOffset, ZOffset =
+		CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0),
 		CFrame.new(0, GlobalConfiguration.TPS_CAMERA_OFFSET.Y, 0),
 		CFrame.new(0, 0, GlobalConfiguration.TPS_CAMERA_OFFSET.Z)
 end


### PR DESCRIPTION
Always hang at the equals token for multiple assignment. It looked weird in a punctuated list for the first item to stay aligned.
```lua
local XOffset, YOffset, ZOffset = CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0),
    CFrame.new(0, GlobalConfiguration.TPS_CAMERA_OFFSET.Y, 0),
    CFrame.new(0, 0, GlobalConfiguration.TPS_CAMERA_OFFSET.Z)

local FrontDistanceX, FrontDistanceY = self.settings.FWsBoneLen * math.cos(
        math.rad(self.settings.FWsBoneAngle)
    ),
    self.settings.FWsBoneLen * math.sin(math.rad(self.settings.FWsBoneAngle))
local RearDistanceX, RearDistanceY = self.settings.RWsBoneLen * math.cos(
        math.rad(self.settings.RWsBoneAngle)
    ),
    self.settings.RWsBoneLen * math.sin(math.rad(self.settings.RWsBoneAngle))
```
... is now formatted as ...
```lua
local XOffset, YOffset, ZOffset =
    CFrame.new(GlobalConfiguration.TPS_CAMERA_OFFSET.X, 0, 0),
    CFrame.new(0, GlobalConfiguration.TPS_CAMERA_OFFSET.Y, 0),
    CFrame.new(0, 0, GlobalConfiguration.TPS_CAMERA_OFFSET.Z)
   
local FrontDistanceX, FrontDistanceY =
    self.settings.FWsBoneLen * math.cos(math.rad(self.settings.FWsBoneAngle)),
    self.settings.FWsBoneLen * math.sin(math.rad(self.settings.FWsBoneAngle))
local RearDistanceX, RearDistanceY =
    self.settings.RWsBoneLen * math.cos(math.rad(self.settings.RWsBoneAngle)),
    self.settings.RWsBoneLen * math.sin(math.rad(self.settings.RWsBoneAngle))
```

TODO: should we always hang at equals token even when its only a single assignment? I think prettier has started to do this - https://prettier.io/blog/2021/05/09/2.3.0.html#format-assignments-more-consistently-10222httpsgithubcomprettierprettierpull10222-10643httpsgithubcomprettierprettierpull10643-10672httpsgithubcomprettierprettierpull10672-by-thorn0httpsgithubcomthorn0-10158httpsgithubcomprettierprettierpull10158-by-sosukesuzukihttpsgithubcomsosukesuzuki