### PR TITLE
Add extension version specification

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -10,9 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 To view the changelog of the StyLua binary, see [here](https://github.com/JohnnyMorganz/StyLua/blob/master/CHANGELOG.md)
 
 ## [Unreleased]
+
 ### Added
+
 - StyLua will now emit an error if the provided file path does not exist
 - StyLua will now hot reload the stylua binary if the configuration changes
+- Added StyLua version configuration.
+  - A release can be selected from a list of compatible minor versions.
+  - A target release version can be provided that overrides the selection.
+
+### Changed
+
+- Release information is now gathered directly from the GitHub REST API.
+- StyLua update prompts are now given for the configured version. If release
+  `v0.8` is selected only release versions matching it, such as `v0.8.2` will
+  be prompted for install.
 
 ## [1.2.0] - 2021-04-19
 

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -42,19 +42,6 @@
     "configuration": {
       "title": "StyLua",
       "properties": {
-        "stylua.management": {
-          "type": "string",
-          "default": "partial",
-          "enum": [
-            "partial",
-            "none"
-          ],
-          "enumDescriptions": [
-            "Manage StyLua installation just for this extension.",
-            "Do not manage StyLua installation."
-          ],
-          "description": "The management style of the StyLua installation."
-        },
         "stylua.releaseVersion": {
           "type": "string",
           "default": "latest",
@@ -64,18 +51,9 @@
             "v0.8",
             "v0.7",
             "v0.6",
-            "v0.5",
-            "v0.4",
-            "v0.3",
-            "v0.2",
-            "v0.1"
+            "v0.5"
           ],
           "description": "The release version to download."
-        },
-        "stylua.styluaBinary": {
-          "type": "string",
-          "default": "stylua",
-          "description": "The name or path of the StyLua binary."
         },
         "stylua.styluaPath": {
           "type": [

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -56,7 +56,7 @@
           "enumDescriptions": [
             "The most recent version released. This will always keep you up to date."
           ],
-          "description": "The release version to install."
+          "markdownDescription": "The release version to install. This is overridden by `#stylua.targetReleaseVersion#`."
         },
         "stylua.targetReleaseVersion": {
           "type": "string",

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -53,7 +53,15 @@
             "v0.6",
             "v0.5"
           ],
-          "description": "The release version to download."
+          "enumDescriptions": [
+            "The most recent version released. This will always keep you up to date."
+          ],
+          "description": "The release version to install."
+        },
+        "stylua.targetReleaseVersion": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Target a specific release version tag such as `v0.9.1` or `v0.9`. This overrides the version set by `#stylua.releaseVersion#`."
         },
         "stylua.styluaPath": {
           "type": [

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -42,6 +42,41 @@
     "configuration": {
       "title": "StyLua",
       "properties": {
+        "stylua.management": {
+          "type": "string",
+          "default": "partial",
+          "enum": [
+            "partial",
+            "none"
+          ],
+          "enumDescriptions": [
+            "Manage StyLua installation just for this extension.",
+            "Do not manage StyLua installation."
+          ],
+          "description": "The management style of the StyLua installation."
+        },
+        "stylua.releaseVersion": {
+          "type": "string",
+          "default": "latest",
+          "enum": [
+            "latest",
+            "v0.9",
+            "v0.8",
+            "v0.7",
+            "v0.6",
+            "v0.5",
+            "v0.4",
+            "v0.3",
+            "v0.2",
+            "v0.1"
+          ],
+          "description": "The release version to download."
+        },
+        "stylua.styluaBinary": {
+          "type": "string",
+          "default": "stylua",
+          "description": "The name or path of the StyLua binary."
+        },
         "stylua.styluaPath": {
           "type": [
             "string",

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -63,6 +63,15 @@ const getAssetFilenamePattern = () => {
   }
 };
 
+const getDesiredVersion = (): string => {
+  const config = vscode.workspace.getConfiguration("stylua");
+  const targetVersion = config.get<string>("targetReleaseVersion", "").trim();
+  if (targetVersion.length === 0) {
+    return config.get<string>("releaseVersion", "latest");
+  }
+  return targetVersion;
+};
+
 export const fileExists = (path: vscode.Uri | string): Thenable<boolean> => {
   const uri = path instanceof vscode.Uri ? path : vscode.Uri.file(path);
   return vscode.workspace.fs.stat(uri).then(
@@ -72,9 +81,7 @@ export const fileExists = (path: vscode.Uri | string): Thenable<boolean> => {
 };
 
 const downloadStylua = async (outputDirectory: vscode.Uri) => {
-  const version = vscode.workspace
-    .getConfiguration("stylua")
-    .get<string>("releaseVersion", "latest");
+  const version = getDesiredVersion();
   const release = await getRelease(version);
   const assetFilename = getAssetFilenamePattern();
   const outputFilename = getDownloadOutputFilename();
@@ -160,9 +167,7 @@ export const ensureStyluaExists = async (
 
     try {
       const currentVersion = (await executeStylua(path, ["--version"]))?.trim();
-      const desiredVersion = vscode.workspace
-        .getConfiguration("stylua")
-        .get<string>("releaseVersion", "latest");
+      const desiredVersion = getDesiredVersion();
       const release = await getRelease(desiredVersion);
       if (
         currentVersion !==

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -181,7 +181,7 @@ export const ensureStyluaExists = async (
       }
     } catch (err) {
       vscode.window.showWarningMessage(
-        `Error checking latest StyLua version, falling back to installed version:\n${err}`
+        `Error checking the selected StyLua version, falling back to the currently installed version:\n${err}`
       );
     }
 


### PR DESCRIPTION
Extension users will be able to select the release version used by the extension.

Versions options include all minor versions after v0.5 as well as a `latest` option. This allows an easy choice of version with the additional option of always updating to the latest version regardless of changes. A target version selector is included for users who need specific versions installed.

This resolves #196.