### PR TITLE
Fix severe performance regression due to change of table formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed severe performance regression due to a change in table formatting leading to exponential blowup for nested tables. ([#205](https://github.com/JohnnyMorganz/StyLua/issues/205))
 
 ## [0.9.2] - 2021-06-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ insta = { version="1.7.1", features=["glob"] }
 [[bench]]
 name = "date"
 harness = false
+
+[[bench]]
+name = "nested_tables"
+harness = false

--- a/benches/nested_tables.lua
+++ b/benches/nested_tables.lua
@@ -1,0 +1,464 @@
+return function()
+	foo(function()
+		local foo = {
+			foooooooBar = true,
+			barrrrrrrr = false,
+			bazzzzzzzzzzzz = false
+		}
+
+		local data = {
+			foooooooobarrr = {
+				bazzzzzzzzing = {
+					abadndafffffffff = "baszzzzzzzzzzfooooo",
+				},
+				singalong = nil,
+				configurationn = nil,
+				moreeeeDATA = {
+					{
+						foooo1 = "DATATA",
+						fooooo2 = "SomethingElse",
+						areWeThereYet = false,
+						informationnn = {
+							{
+								moreItemss = "yessss",
+								thisAndThat = {},
+								foobarrrr = {
+									kind = "thsasdfa",
+									name = "pOEFKAPMAF",
+									farfga = nil,
+								},
+								aleknfapwringa = false,
+								ckvjnloanopfear = nil,
+							},
+						},
+						aoeiwnaofnaewofw = nil,
+						maavajneaafj = {},
+						apringparnga = nil,
+						lkxzncvlknpaga = nil,
+					},
+					{
+						foooo1 = "DATATA",
+						fooooo2 = "SomethingElse",
+						areWeThereYet = false,
+						informationnn = {
+							{
+								moreItemss = "yessss",
+								thisAndThat = {},
+								foobarrrr = {
+									kind = "thsasdfa",
+									name = "pOEFKAPMAF",
+									farfga = nil,
+								},
+								aleknfapwringa = false,
+								ckvjnloanopfear = nil,
+							},
+						},
+						aoeiwnaofnaewofw = nil,
+						maavajneaafj = {},
+						apringparnga = nil,
+						lkxzncvlknpaga = nil,
+					},
+					{
+						arbanrklagarga = "ASORGNAWRN;",
+						asdvaea = "SAGRAGARG",
+						sadvaeafa = nil,
+						eagawrgarfvsadv = {
+							{
+								zragar = "tnaesfsadfae",
+								asdefa = {},
+								faaega = {
+									foo = "BARRRR",
+									dasgeara = "DAKSJGNAKRJ",
+									ofType = nil,
+								},
+								wafargasfgvas = false,
+								aefawedfsafewad = nil,
+							},
+							{
+								arbharba = "rfrsbaa",
+								dsavWEASVDSA = {},
+								ARNAESFBdsa = {
+									eawfdsafawe = "DARAaADEGA",
+									basdfaewf = nil,
+									dsaarbasdfaefasdf = {
+										easfdasf = "fdabaeA",
+										sdavawef = nil,
+										dfasfeasdf = {
+											easdfaesd = "asrbharrba",
+											eas = nil,
+											easdfaesf = {
+												aefdsadfae = "AFBARGAS",
+												asdfasedf = "SDFAEASDF",
+												asdfeeasdfaesa = nil,
+											},
+										},
+									},
+								},
+								afcvaefasdfaesdfaes = false,
+								asdgaergasdfae = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+						},
+						DSAVGAWE = nil,
+						casdczxcvae = {},
+						awsdgawrga = nil,
+						sadfasedfaesd = nil,
+					},
+					{
+						afbasdfvase = "DSAGAESDF",
+						adfbarfase = "FASDFAESDF",
+						dsafaesdfaesadf = nil,
+						fiunsies = {
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+										somethingElse = {
+											fooo = bar,
+											barrr = bazzz,
+											fooobarr = {
+												hello = true
+											}
+										}
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+										somethingElse = {
+											fooo = bar,
+											barrr = bazzz,
+											fooobarr = {
+												hello = true
+											}
+										}
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+										somethingElse = {
+											fooo = bar,
+											barrr = bazzz,
+											fooobarr = {
+												hello = true
+											}
+										}
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+										somethingElse = {
+											fooo = bar,
+											barrr = bazzz,
+											fooobarr = {
+												hello = true
+											}
+										}
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+										somethingElse = {
+											fooo = bar,
+											barrr = bazzz,
+											fooobarr = {
+												hello = true
+											}
+										}
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+							{
+								foooo1 = "DATATA",
+								fooooo2 = "SomethingElse",
+								areWeThereYet = false,
+								informationnn = {
+									{
+										moreItemss = "yessss",
+										thisAndThat = {},
+										foobarrrr = {
+											kind = "thsasdfa",
+											name = "pOEFKAPMAF",
+											farfga = nil,
+										},
+										aleknfapwringa = false,
+										ckvjnloanopfear = nil,
+									},
+								},
+								aoeiwnaofnaewofw = nil,
+								maavajneaafj = {},
+								apringparnga = nil,
+								lkxzncvlknpaga = nil,
+							},
+						},
+						ragasdfaesfaes = nil,
+						DSAGASDVAF = {},
+						AASDFAEdsafea = nil,
+						sadgaefasfeasdfase = nil,
+					},
+				},
+			},
+		}
+	end)
+end

--- a/benches/nested_tables.rs
+++ b/benches/nested_tables.rs
@@ -1,0 +1,21 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use stylua_lib::{format_code, Config};
+
+pub fn format_date(c: &mut Criterion) {
+    c.bench_function("format nested_tables.lua", |b| {
+        b.iter(|| {
+            format_code(
+                black_box(include_str!("./nested_tables.lua")),
+                black_box(Config::default()),
+                black_box(None),
+            )
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(40);
+    targets = format_date
+}
+criterion_main!(benches);

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -322,30 +322,6 @@ fn should_expand(table_constructor: &TableConstructor) -> bool {
     }
 }
 
-/// A fail-fast check to determine whether the formatted fields are going over the budget.
-/// We format each field one at a time, then add its width to the shape, and check to see if the shape is over budget.
-/// Originally, we used `format_singleline_table()` to check this, which had exponential time complexity for nested tables.
-/// We don't need to format the whole table to see if we are going over budget.
-fn check_table_over_budget<'ast>(
-    ctx: &Context,
-    fields: &Punctuated<'ast, Field<'ast>>,
-    shape: Shape,
-) -> bool {
-    // Use an infinite width shape to force everything onto a single line as much as possible
-    // + 2 = opening brace plus space
-    let mut shape = shape.with_infinite_width() + 2;
-
-    for field in fields {
-        let formatted_field = format_field(ctx, field, TableType::SingleLine, shape).0;
-        shape = shape + (formatted_field.to_string().len() + 2); // 2 = ", "
-        if shape.over_budget() {
-            return true;
-        }
-    }
-
-    false
-}
-
 pub fn format_table_constructor<'ast>(
     ctx: &Context,
     table_constructor: &TableConstructor<'ast>,

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -338,9 +338,14 @@ pub fn format_table_constructor<'ast>(
 
         (false, Some(_)) => {
             // Format the table onto a single line, then take the shape to determine if we are over budget
-            let singleline_table =
-                format_singleline_table(ctx, table_constructor, shape.with_infinite_width());
-            let singleline_shape = shape.take_first_line(&strip_trivia(&singleline_table));
+            // let singleline_table =
+            //     format_singleline_table(ctx, table_constructor, shape.with_infinite_width());
+            // let singleline_shape = shape.take_first_line(&strip_trivia(&singleline_table));
+            let braces_range = (
+                start_brace.token().end_position().bytes(),
+                end_brace.token().start_position().bytes(),
+            );
+            let singleline_shape = shape + (braces_range.1 - braces_range.0);
 
             match singleline_shape.over_budget() {
                 true => TableType::MultiLine,


### PR DESCRIPTION
Fixes #205, which gives an explanation of what happened.

Our change in 0.9.0, as highlighted in #205, led to an exponential time complexity in formatting deeply nested tables. This is because we attempt to format the table on a single line to see if it is over width. This means, if the table contains more tables, we attempt this *again* for each table field, and this adds up exponentially the deeper the table.

Two solutions were attempted here:
1)  Revert back to our original, where we check the position between the opening and closing brace in the input. This is the cheapest solution (taking O(1) time), but isn't great since we rely on the input: if the input is badly formatted, it will lead to the table being pushed multiline when it could've been collapsed.
2) Implement a fail fast version of what we attempted in 0.9.0. Instead of formatting the whole table on a single line, then checking its width to determine if its over budget, we format a single field at a time and see if it has gone over the column width - if it has, bail early and expand multiline.

This PR adds a `nested_tables.lua` benchmark. Benchmarking this on current trunk took **3.0536s** for this single file.
Solution 1) leads to a performance improvement of **98.5%**, going from 3.0536s -> **44.26ms**
Solution 2) leads to a performance improvement of **40.0118%**, going from 3.0536s -> **1.8318s**. This however, is a performance **regression** of **4038.1%** compared to solution 1 (i.e. v0.8.2). Solution 2 is clearly still exponential (which makes sense, if we have tables early on in the fields).

We will revert back to solution 1, as present in v0.8.2. This is the best solution by far, and it was never actually flagged as problematic by any users before 0.9.0

