### PR TITLE
Fix binop chains with comment deep inside not being hung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed long binop chains with a comment deep inside not being hung, leading to a syntax error. ([#210](https://github.com/JohnnyMorganz/StyLua/issues/210))
 
 ## [0.9.2] - 2021-06-20
 ### Changed

--- a/tests/inputs/hang-binop-comments-2.lua
+++ b/tests/inputs/hang-binop-comments-2.lua
@@ -1,0 +1,26 @@
+local function logTiger(tiger, depth)
+	log(
+	string.rep("  ", depth) ..
+	"- " ..
+	-- need to explicitly coerce to a string
+	tiger.type and (tiger.type.name or tostring(tiger.type)) or "[r00t]",
+	"[" ..
+	tiger.commonExtraTentacles ..
+	(tiger.pendingPartyHats and "*" or "") ..
+	"]"
+	)
+	end
+	
+local function logTiger(tiger, depth)
+	log(
+	string.rep("  ", depth) ..
+	-- need to explicitly coerce to a string
+	"- " ..
+	tiger.type and (tiger.type.name or tostring(tiger.type)) or "[r00t]",
+	"[" ..
+	tiger.commonExtraTentacles ..
+	(tiger.pendingPartyHats and "*" or "") ..
+	"]"
+	)
+	end
+	

--- a/tests/snapshots/tests__standard@hang-binop-comments-2.lua.snap
+++ b/tests/snapshots/tests__standard@hang-binop-comments-2.lua.snap
@@ -6,11 +6,9 @@ expression: format(&contents)
 local function logTiger(tiger, depth)
 	log(
 		string.rep("  ", depth)
-					.. "- "
-					-- need to explicitly coerce to a string
-					.. tiger.type
-				and (tiger.type.name or tostring(tiger.type))
-			or "[r00t]",
+				.. "- "
+				-- need to explicitly coerce to a string
+				.. tiger.type and (tiger.type.name or tostring(tiger.type)) or "[r00t]",
 		"[" .. tiger.commonExtraTentacles .. (tiger.pendingPartyHats and "*" or "") .. "]"
 	)
 end
@@ -18,11 +16,9 @@ end
 local function logTiger(tiger, depth)
 	log(
 		string.rep("  ", depth)
-					-- need to explicitly coerce to a string
-					.. "- "
-					.. tiger.type
-				and (tiger.type.name or tostring(tiger.type))
-			or "[r00t]",
+				-- need to explicitly coerce to a string
+				.. "- "
+				.. tiger.type and (tiger.type.name or tostring(tiger.type)) or "[r00t]",
 		"[" .. tiger.commonExtraTentacles .. (tiger.pendingPartyHats and "*" or "") .. "]"
 	)
 end

--- a/tests/snapshots/tests__standard@hang-binop-comments-2.lua.snap
+++ b/tests/snapshots/tests__standard@hang-binop-comments-2.lua.snap
@@ -1,0 +1,29 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+local function logTiger(tiger, depth)
+	log(
+		string.rep("  ", depth)
+					.. "- "
+					-- need to explicitly coerce to a string
+					.. tiger.type
+				and (tiger.type.name or tostring(tiger.type))
+			or "[r00t]",
+		"[" .. tiger.commonExtraTentacles .. (tiger.pendingPartyHats and "*" or "") .. "]"
+	)
+end
+
+local function logTiger(tiger, depth)
+	log(
+		string.rep("  ", depth)
+					-- need to explicitly coerce to a string
+					.. "- "
+					.. tiger.type
+				and (tiger.type.name or tostring(tiger.type))
+			or "[r00t]",
+		"[" .. tiger.commonExtraTentacles .. (tiger.pendingPartyHats and "*" or "") .. "]"
+	)
+end
+


### PR DESCRIPTION
We only check on the first level of a binop expression whether there are comments. In some cases, there arent comments on the first level, but they are deep inside of it.

Since we don't look any further, we collapse the expression, leading to a syntax error.

This PR makes sure we check deeper inside the chain to see if there are still comments present

Fixes #210 