### PR TITLE
Add `--verbose` for debug printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `--verbose` to print debug information, including finding config files and time taken to format files.
+
 ### Fixed
 - Fixed severe performance regression due to a change in table formatting leading to exponential blowup for nested tables. ([#205](https://github.com/JohnnyMorganz/StyLua/issues/205))
 - Fixed long binop chains with a comment deep inside not being hung, leading to a syntax error. ([#210](https://github.com/JohnnyMorganz/StyLua/issues/210))

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,4 +1,5 @@
 use crate::opt::Opt;
+use crate::verbose_println;
 use anyhow::{Context, Result};
 use directories::{ProjectDirs, UserDirs};
 use std::env;
@@ -45,7 +46,14 @@ fn find_config_file(mut directory: PathBuf, recursive: bool) -> Result<Option<Co
 
 pub fn load_config(opt: &Opt) -> Result<Config> {
     match &opt.config_path {
-        Some(config_path) => read_config_file(config_path),
+        Some(config_path) => {
+            verbose_println!(
+                opt.verbose,
+                "config: explicit config path provided at {}",
+                config_path.display()
+            );
+            read_config_file(config_path)
+        }
         None => {
             let current_dir = match &opt.stdin_filepath {
                 Some(file_path) => file_path
@@ -54,13 +62,22 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
                     .to_path_buf(),
                 None => env::current_dir().context("Could not find current directory")?,
             };
+            verbose_println!(
+                opt.verbose,
+                "config: starting config search from {} - recurisvely searching parents: {}",
+                current_dir.display(),
+                opt.search_parent_directories
+            );
             let config = find_config_file(current_dir, opt.search_parent_directories)?;
             match config {
                 Some(config) => Ok(config),
                 None => {
+                    verbose_println!(opt.verbose, "config: no configuration file found");
+
                     // Search the configuration directory for a file, if necessary
                     if opt.search_parent_directories {
                         // Look in `$HOME/.config/stylua`
+                        verbose_println!(opt.verbose, "config: looking in $HOME/.config/stylua");
                         if let Some(project_dirs) = ProjectDirs::from("", "", "stylua") {
                             if let Some(config) =
                                 find_config_file(project_dirs.config_dir().to_path_buf(), false)?
@@ -68,7 +85,9 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
                                 return Ok(config);
                             }
                         }
+
                         // Look in `$HOME/.config`
+                        verbose_println!(opt.verbose, "config: looking in $HOME/.config");
                         if let Some(user_dirs) = UserDirs::new() {
                             if let Some(config) =
                                 find_config_file(user_dirs.home_dir().to_path_buf(), false)?
@@ -79,6 +98,7 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
                     }
 
                     // Fallback to a default configuration
+                    verbose_println!(opt.verbose, "config: falling back to default config");
                     Ok(Config::default())
                 }
             }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -3,7 +3,7 @@ use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use std::fs;
 use std::io::{stdin, stdout, Read, Write};
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use structopt::StructOpt;
 
 use stylua_lib::{format_code, Config, Range};
@@ -26,10 +26,6 @@ macro_rules! verbose_println {
     };
 }
 
-fn duration_to_f32(d: Duration) -> f32 {
-    d.as_secs() as f32 + d.subsec_nanos() as f32 / 1_000_000_000f32
-}
-
 fn format_file(path: &Path, config: Config, range: Option<Range>, opt: &opt::Opt) -> Result<i32> {
     let contents =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
@@ -41,9 +37,9 @@ fn format_file(path: &Path, config: Config, range: Option<Range>, opt: &opt::Opt
 
     verbose_println!(
         opt.verbose,
-        "formatted {} in {1:.3}s",
+        "formatted {} in {:?}",
         path.display(),
-        duration_to_f32(after_formatting.duration_since(before_formatting))
+        after_formatting.duration_since(before_formatting)
     );
 
     if opt.check {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -3,6 +3,7 @@ use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use std::fs;
 use std::io::{stdin, stdout, Read, Write};
 use std::path::Path;
+use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
 use stylua_lib::{format_code, Config, Range};
@@ -11,25 +12,47 @@ mod config;
 mod opt;
 mod output_diff;
 
-fn format_file(
-    path: &Path,
-    config: Config,
-    range: Option<Range>,
-    check_only: bool,
-    color: opt::Color,
-) -> Result<i32> {
+#[macro_export]
+macro_rules! verbose_println {
+    ($verbosity:expr, $str:expr) => {
+        if $verbosity {
+            println!($str);
+        }
+    };
+    ($verbosity:expr, $str:expr, $($arg:tt)*) => {
+        if $verbosity {
+            println!($str, $($arg)*);
+        }
+    };
+}
+
+fn duration_to_f32(d: Duration) -> f32 {
+    d.as_secs() as f32 + d.subsec_nanos() as f32 / 1_000_000_000f32
+}
+
+fn format_file(path: &Path, config: Config, range: Option<Range>, opt: &opt::Opt) -> Result<i32> {
     let contents =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    let before_formatting = Instant::now();
     let formatted_contents = format_code(&contents, config, range)
         .with_context(|| format!("Could not format file {}", path.display()))?;
+    let after_formatting = Instant::now();
 
-    if check_only {
+    verbose_println!(
+        opt.verbose,
+        "formatted {} in {1:.3}s",
+        path.display(),
+        duration_to_f32(after_formatting.duration_since(before_formatting))
+    );
+
+    if opt.check {
         let is_diff = output_diff::output_diff(
             &contents,
             &formatted_contents,
             3,
             format!("Diff in {}:", path.display()),
-            color,
+            opt.color,
         );
         Ok(if is_diff { 1 } else { 0 })
     } else {
@@ -83,11 +106,11 @@ fn format(opt: opt::Opt) -> Result<i32> {
         .add_custom_ignore_filename(".styluaignore");
 
     let use_default_glob = match opt.glob {
-        Some(globs) => {
+        Some(ref globs) => {
             // Build overriders with any patterns given
             let mut overrides = OverrideBuilder::new(cwd);
             for pattern in globs {
-                match overrides.add(&pattern) {
+                match overrides.add(pattern) {
                     Ok(_) => continue,
                     Err(err) => errors.push(format_err!(
                         "error: cannot parse glob pattern {}: {}",
@@ -139,7 +162,7 @@ fn format(opt: opt::Opt) -> Result<i32> {
                                 continue;
                             }
                         }
-                        match format_file(path, config, range, opt.check, opt.color) {
+                        match format_file(path, config, range, &opt) {
                             Ok(code) => {
                                 if code != 0 {
                                     error_code = code

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -28,6 +28,10 @@ pub struct Opt {
     #[structopt(short, long)]
     pub check: bool,
 
+    /// Whether to print out verbose output
+    #[structopt(short, long)]
+    pub verbose: bool,
+
     // Whether the output should include terminal colour or not
     #[structopt(long, possible_values = &Color::variants(), case_insensitive = true, default_value = "auto")]
     pub color: Color,


### PR DESCRIPTION
Currently prints out status when finding config file, and time taken to format each file.