### PR TITLE
Improvements to Luau formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.
 - Luau type tables and their fields now have improved checking against the current shape width to determine how to format if over column width.
+- Luau callback types will now format multiline if they become over width under the `luau` feature flag.
 
 ### Fixed
 - Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.
-- Luau type tables and their fields now have improved checking against the current shape width to determine how to format if over column width.
+- Luau typings now have improved checking against the current shape width to determine how to format if over column width.
 - Luau callback types will now format multiline if they become over width under the `luau` feature flag.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.
+- Luau type tables and their fields now have improved checking against the current shape width to determine how to format if over column width.
+
+### Fixed
+- Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))
 
 ## [0.9.3] - 2021-06-26
 ### Added

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -369,6 +369,7 @@ pub fn format_type_field(
 
     let key = format_type_field_key(ctx, type_field.key(), leading_trivia, shape);
     let colon_token = fmt_symbol!(ctx, type_field.colon_token(), ": ", shape);
+    let shape = shape + (strip_leading_trivia(&key).to_string().len() + 2);
     let mut value = format_type_info(ctx, type_field.value(), shape);
 
     let trailing_trivia = type_info_trailing_trivia(&value);
@@ -400,7 +401,7 @@ pub fn format_type_field_key(
         TypeFieldKey::IndexSignature { brackets, inner } => TypeFieldKey::IndexSignature {
             brackets: format_contained_span(ctx, brackets, shape)
                 .update_leading_trivia(leading_trivia),
-            inner: format_type_info(ctx, inner, shape),
+            inner: format_type_info(ctx, inner, shape + 1), // 1 = "["
         },
         other => panic!("unknown node {:?}", other),
     }

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -491,8 +491,9 @@ fn format_type_declaration(
     };
 
     let mut equal_token = fmt_symbol!(ctx, type_declaration.equal_token(), " = ", shape);
-    let mut type_definition = format_type_info(ctx, type_declaration.type_definition(), shape + 3) // 3 = " = "
-        .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
+    let mut type_definition =
+        format_type_info(ctx, type_declaration.type_definition(), shape + 3) // 3 = " = "
+            .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
     let shape = shape.take_last_line(&strip_trailing_trivia(&type_definition));
 

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -8,13 +8,14 @@ use crate::{
             format_punctuated_multiline, format_symbol, format_token_reference,
             try_format_punctuated, EndTokenType,
         },
-        table::{create_table_braces, TableType},
+        table::{create_table_braces, format_multiline_table, format_singleline_table, TableType},
         trivia::{
             strip_leading_trivia, strip_trailing_trivia, FormatTriviaType, UpdateLeadingTrivia,
             UpdateTrailingTrivia,
         },
         trivia_util::{
-            contains_comments, take_type_field_trailing_comments, token_trivia_contains_comments,
+            contains_comments, token_trivia_contains_comments, trivia_is_comment,
+            type_info_trailing_trivia,
         },
     },
     shape::Shape,
@@ -23,10 +24,7 @@ use full_moon::ast::types::{
     CompoundAssignment, CompoundOp, ExportedTypeDeclaration, GenericDeclaration, IndexedTypeInfo,
     TypeArgument, TypeAssertion, TypeDeclaration, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier,
 };
-use full_moon::ast::{
-    punctuated::{Pair, Punctuated},
-    span::ContainedSpan,
-};
+use full_moon::ast::{punctuated::Punctuated, span::ContainedSpan};
 use full_moon::tokenizer::{Token, TokenReference, TokenType};
 use std::boxed::Box;
 
@@ -197,75 +195,46 @@ pub fn format_type_info(ctx: &Context, type_info: &TypeInfo, shape: Shape) -> Ty
 
         TypeInfo::Table { braces, fields } => {
             let (start_brace, end_brace) = braces.tokens().to_owned();
-            let braces_range = (
-                start_brace.token().end_position().bytes(),
-                end_brace.token().start_position().bytes(),
-            );
+            let contains_comments = start_brace.trailing_trivia().any(trivia_is_comment)
+                || end_brace.leading_trivia().any(trivia_is_comment)
+                || fields.pairs().any(|field| {
+                    contains_comments(field.punctuation()) || contains_comments(field.value())
+                });
 
-            let mut current_fields = fields.to_owned().into_pairs().peekable();
-            let is_multiline = (braces_range.1 - braces_range.0) > 30; // TODO: Properly determine this arbitrary number, and see if other factors should come into play
-            let table_type = match current_fields.peek() {
-                Some(_) => match is_multiline {
-                    true => TableType::MultiLine,
-                    false => TableType::SingleLine,
-                },
-                None => TableType::Empty,
-            };
+            let table_type = match (contains_comments, fields.iter().next()) {
+                // Table contains comments, so force multiline
+                (true, _) => TableType::MultiLine,
 
-            let braces = create_table_braces(ctx, start_brace, end_brace, table_type, shape);
+                (false, Some(_)) => {
+                    let braces_range = (
+                        start_brace.token().end_position().bytes(),
+                        end_brace.token().start_position().bytes(),
+                    );
 
-            let shape = if is_multiline {
-                shape.increment_additional_indent()
-            } else {
-                shape
-            };
+                    let singleline_shape = shape + (braces_range.1 - braces_range.0);
 
-            let mut fields = Punctuated::new();
-
-            while let Some(pair) = current_fields.next() {
-                let (field, punctuation) = pair.into_tuple();
-
-                let leading_trivia = match is_multiline {
-                    true => FormatTriviaType::Append(vec![create_indent_trivia(ctx, shape)]),
-                    false => FormatTriviaType::NoChange,
-                };
-
-                let mut formatted_field = format_type_field(ctx, &field, leading_trivia, shape);
-                let mut formatted_punctuation = None;
-
-                match is_multiline {
-                    true => {
-                        // Continue adding a comma and a new line for multiline tables
-                        // Add newline trivia to the end of the symbol
-
-                        let (field, mut trailing_comments) =
-                            take_type_field_trailing_comments(formatted_field);
-                        formatted_field = field;
-                        trailing_comments.push(create_newline_trivia(ctx));
-
-                        let symbol = match punctuation {
-                            Some(punctuation) => fmt_symbol!(ctx, &punctuation, ",", shape),
-                            None => TokenReference::symbol(",").unwrap(),
-                        }
-                        .update_trailing_trivia(FormatTriviaType::Append(trailing_comments));
-                        formatted_punctuation = Some(symbol)
-                    }
-
-                    false => {
-                        if current_fields.peek().is_some() {
-                            // Have more elements still to go
-                            formatted_punctuation = match punctuation {
-                                Some(punctuation) => {
-                                    Some(fmt_symbol!(ctx, &punctuation, ", ", shape))
-                                }
-                                None => Some(TokenReference::symbol(", ").unwrap()),
-                            }
-                        };
+                    match singleline_shape.over_budget() {
+                        true => TableType::MultiLine,
+                        false => TableType::SingleLine,
                     }
                 }
 
-                fields.push(Pair::new(formatted_field, formatted_punctuation));
-            }
+                (false, None) => TableType::Empty,
+            };
+
+            let (braces, fields) = match table_type {
+                TableType::Empty => {
+                    let braces =
+                        create_table_braces(ctx, start_brace, end_brace, table_type, shape);
+                    (braces, Punctuated::new())
+                }
+                TableType::SingleLine => {
+                    format_singleline_table(ctx, braces, fields, format_type_field, shape)
+                }
+                TableType::MultiLine => {
+                    format_multiline_table(ctx, braces, fields, format_type_field, shape)
+                }
+            };
 
             TypeInfo::Table { braces, fields }
         }
@@ -384,21 +353,38 @@ fn format_type_argument(ctx: &Context, type_argument: &TypeArgument, shape: Shap
         .with_type_info(type_info)
 }
 
+/// Formats a [`TypeField`] present inside of a [`TypeInfo::Table`]
+/// Returns the new [`TypeField`] and any trailing trivia associated with its value (as this may need to later be moved).
+/// If the [`TableType`] provided is [`TableType::MultiLine`] then the trailing trivia from the value will be removed.
 pub fn format_type_field(
     ctx: &Context,
     type_field: &TypeField,
-    leading_trivia: FormatTriviaType,
+    table_type: TableType,
     shape: Shape,
-) -> TypeField {
+) -> (TypeField, Vec<Token>) {
+    let leading_trivia = match table_type {
+        TableType::MultiLine => FormatTriviaType::Append(vec![create_indent_trivia(ctx, shape)]),
+        _ => FormatTriviaType::NoChange,
+    };
+
     let key = format_type_field_key(ctx, type_field.key(), leading_trivia, shape);
     let colon_token = fmt_symbol!(ctx, type_field.colon_token(), ": ", shape);
-    let value = format_type_info(ctx, type_field.value(), shape);
+    let mut value = format_type_info(ctx, type_field.value(), shape);
 
-    type_field
-        .to_owned()
-        .with_key(key)
-        .with_colon_token(colon_token)
-        .with_value(value)
+    let trailing_trivia = type_info_trailing_trivia(&value);
+
+    if let TableType::MultiLine = table_type {
+        value = value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
+    }
+
+    (
+        type_field
+            .to_owned()
+            .with_key(key)
+            .with_colon_token(colon_token)
+            .with_value(value),
+        trailing_trivia,
+    )
 }
 
 pub fn format_type_field_key(

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -89,7 +89,14 @@ pub fn format_type_info(ctx: &Context, type_info: &TypeInfo, shape: Shape) -> Ty
 
             let force_multiline = token_trivia_contains_comments(start_parens.trailing_trivia())
                 || token_trivia_contains_comments(end_parens.leading_trivia())
-                || contains_comments(arguments);
+                || contains_comments(arguments)
+                || shape
+                    .add_width(
+                        2 + 4
+                            + arguments.to_string().len()
+                            + strip_trailing_trivia(&**return_type).to_string().len(),
+                    )
+                    .over_budget(); // 2 = opening/closing parens, 4 = " -> "
 
             let (parentheses, arguments, shape) = if force_multiline {
                 let start_parens = fmt_symbol!(ctx, start_parens, "(", shape)

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "luau")]
-use full_moon::ast::types::{IndexedTypeInfo, TypeAssertion, TypeField, TypeInfo, TypeSpecifier};
+use full_moon::ast::types::{IndexedTypeInfo, TypeAssertion, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier};
 use full_moon::ast::{
     punctuated::Punctuated, span::ContainedSpan, BinOp, Call, Expression, FunctionArgs,
     FunctionBody, FunctionCall, FunctionName, Index, MethodCall, Parameter, Prefix, Suffix,
@@ -667,9 +667,27 @@ define_update_trailing_trivia!(TypeAssertion, |this, trailing| {
 });
 
 #[cfg(feature = "luau")]
+define_update_leading_trivia!(TypeField, |this, leading| {
+    this.to_owned()
+        .with_key(this.key().update_leading_trivia(leading))
+});
+
+#[cfg(feature = "luau")]
 define_update_trailing_trivia!(TypeField, |this, trailing| {
     this.to_owned()
         .with_value(this.value().update_trailing_trivia(trailing))
+});
+
+#[cfg(feature = "luau")]
+define_update_leading_trivia!(TypeFieldKey, |this, leading| {
+    match this {
+        TypeFieldKey::Name(token) => TypeFieldKey::Name(token.update_leading_trivia(leading)),
+        TypeFieldKey::IndexSignature { brackets, inner } => TypeFieldKey::IndexSignature {
+            brackets: brackets.update_leading_trivia(leading),
+            inner: inner.to_owned(),
+        },
+        other => panic!("unknown node {:?}", other),
+    }
 });
 
 #[cfg(feature = "luau")]

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "luau")]
-use full_moon::ast::types::{IndexedTypeInfo, TypeAssertion, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier};
+use full_moon::ast::types::{
+    IndexedTypeInfo, TypeAssertion, TypeField, TypeFieldKey, TypeInfo, TypeSpecifier,
+};
 use full_moon::ast::{
     punctuated::Punctuated, span::ContainedSpan, BinOp, Call, Expression, FunctionArgs,
     FunctionBody, FunctionCall, FunctionName, Index, MethodCall, Parameter, Prefix, Suffix,

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -2,7 +2,7 @@ use crate::formatters::trivia::{FormatTriviaType, UpdateLeadingTrivia, UpdateTra
 #[cfg(feature = "luau")]
 use full_moon::ast::span::ContainedSpan;
 #[cfg(feature = "luau")]
-use full_moon::ast::types::{IndexedTypeInfo, TypeDeclaration, TypeField, TypeInfo};
+use full_moon::ast::types::{IndexedTypeInfo, TypeDeclaration, TypeInfo};
 use full_moon::ast::{Block, FunctionBody};
 use full_moon::{
     ast::{
@@ -135,7 +135,7 @@ fn indexed_type_info_trailing_trivia(indexed_type_info: &IndexedTypeInfo) -> Vec
 }
 
 #[cfg(feature = "luau")]
-fn type_info_trailing_trivia(type_info: &TypeInfo) -> Vec<Token> {
+pub fn type_info_trailing_trivia(type_info: &TypeInfo) -> Vec<Token> {
     match type_info {
         TypeInfo::Array { braces, .. } => {
             let (_, end_brace) = braces.tokens();
@@ -409,26 +409,6 @@ pub fn take_expression_trailing_comments(expression: &Expression) -> (Expression
 
     (
         expression.update_trailing_trivia(
-            FormatTriviaType::Replace(vec![]), // TODO: Do we need to keep some trivia?
-        ),
-        trailing_comments,
-    )
-}
-
-#[cfg(feature = "luau")]
-pub fn take_type_field_trailing_comments(type_field: TypeField) -> (TypeField, Vec<Token>) {
-    let trailing_comments = type_info_trailing_trivia(type_field.value())
-        .iter()
-        .filter(|token| trivia_is_comment(token))
-        .map(|x| {
-            // Prepend a single space beforehand
-            vec![Token::new(TokenType::spaces(1)), x.to_owned()]
-        })
-        .flatten()
-        .collect();
-
-    (
-        type_field.update_trailing_trivia(
             FormatTriviaType::Replace(vec![]), // TODO: Do we need to keep some trivia?
         ),
         trailing_comments,

--- a/tests/inputs-luau/type-callback-hanging.lua
+++ b/tests/inputs-luau/type-callback-hanging.lua
@@ -1,0 +1,3 @@
+export type Thenable<R, U> = {
+	andTheeeeeeeeeeeeeeen: (any, (R) -> () | Thenable<R, U> | U, (any) -> () | Thenable<R, U> | U) -> () | Thenable<R, U>,
+}

--- a/tests/inputs-luau/type-tables-comments.lua
+++ b/tests/inputs-luau/type-tables-comments.lua
@@ -1,0 +1,3 @@
+export type Foo = {
+	test: boolean -- true
+}

--- a/tests/snapshots/tests__luau@type-callback-hanging.lua.snap
+++ b/tests/snapshots/tests__luau@type-callback-hanging.lua.snap
@@ -1,0 +1,13 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+export type Thenable<R, U> = {
+	andTheeeeeeeeeeeeeeen: (
+		any,
+		(R) -> () | Thenable<R, U> | U,
+		(any) -> () | Thenable<R, U> | U
+	) -> () | Thenable<R, U>,
+}
+

--- a/tests/snapshots/tests__luau@type-tables-comments.lua.snap
+++ b/tests/snapshots/tests__luau@type-tables-comments.lua.snap
@@ -1,0 +1,9 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+export type Foo = {
+	test: boolean, -- true
+}
+


### PR DESCRIPTION
This PR generalises the formatting of table constructors, allowing us to use the same general tactics to format TypeInfo::Tables aswell. In future, this means that the formatting of both these syntaxes are more aligned, so Luau is better up to date.

We also improve the use of shape throughout Luau formatters, so that the shape better represents the current column width used, and can help use better determine how to format.

We also format type callbacks if they are over the column width (originated from Discord):
![image](https://user-images.githubusercontent.com/19635171/124358802-d7569180-dc19-11eb-8ba0-806cf98c4836.png)

This PR also fixes #219 
