### PR TITLE
Add CLI options to specify formatting config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added optional command line options `--column-width`, `--indent-type`, `--indent-width`, `--line-endings` and `--quote-style`, which, when provided, will override any configuration setting inferred from the default or a `stylua.toml`. ([#213](https://github.com/JohnnyMorganz/StyLua/issues/213))
+
 ### Changed
 - Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.
 - Luau typings now have improved checking against the current shape width to determine how to format if over column width.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -105,3 +105,26 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
         }
     }
 }
+
+/// Handles any overrides provided by command line options
+pub fn load_overrides(config: Config, opt: &Opt) -> Config {
+    let mut new_config = config;
+
+    if let Some(column_width) = opt.format_opts.column_width {
+        new_config = new_config.with_column_width(column_width);
+    };
+    if let Some(line_endings) = opt.format_opts.line_endings {
+        new_config = new_config.with_line_endings(line_endings.into());
+    };
+    if let Some(indent_type) = opt.format_opts.indent_type {
+        new_config = new_config.with_indent_type(indent_type.into());
+    };
+    if let Some(indent_width) = opt.format_opts.indent_width {
+        new_config = new_config.with_indent_width(indent_width);
+    };
+    if let Some(quote_style) = opt.format_opts.quote_style {
+        new_config = new_config.with_quote_style(quote_style.into());
+    };
+
+    new_config
+}

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -77,6 +77,10 @@ fn format(opt: opt::Opt) -> Result<i32> {
     // Load the configuration
     let config = config::load_config(&opt)?;
 
+    // Handle any configuration overrides provided by options
+    let config = config::load_overrides(config, &opt);
+    verbose_println!(opt.verbose, "config: {:#?}", config);
+
     // Create range if provided
     let range = if opt.range_start.is_some() || opt.range_end.is_some() {
         Some(Range::from_values(opt.range_start, opt.range_end))


### PR DESCRIPTION
Closes #213 

```
stylua 0.9.3
A utility to format Lua code

USAGE:
    stylua.exe [FLAGS] [OPTIONS] [--] [files]...

FLAGS:
    ...

OPTIONS:
        ...
        --column-width <column-width>        The column width to use to attempt to wrap lines
        --indent-type <indent-type>          The type of indents to use [possible values: Tabs, Spaces]
        --indent-width <indent-width>        The width of a single indentation level
        --line-endings <line-endings>        The type of line endings to use [possible values: Unix, Windows]
        --quote-style <quote-style>          The style of quotes to use in string literals [possible values:
                                             AutoPreferDouble, AutoPreferSingle, ForceDouble, ForceSingle]
        ...

ARGS:
    <files>...    A list of files to format
```