### PR TITLE
Improve return formatting in line with assignment format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))
 - Fixed multiple assignment where an expression was originally hung due to comments being collapsed leading to malformed formatting. ([#222](https://github.com/JohnnyMorganz/StyLua/issues/222))
-- Fixed an issue when formatting a punctuated sequence multiline where the first item in the sequence would have an incorrect shape used.
 
 ## [0.9.3] - 2021-06-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.
 - Luau typings now have improved checking against the current shape width to determine how to format if over column width.
 - Luau callback types will now format multiline if they become over width under the `luau` feature flag.
+- Improved the formatting of return expressions, they are now more in line with assignment expressions. ([#194](https://github.com/JohnnyMorganz/StyLua/issues/194))
 
 ### Fixed
 - Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))
 - Fixed multiple assignment where an expression was originally hung due to comments being collapsed leading to malformed formatting. ([#222](https://github.com/JohnnyMorganz/StyLua/issues/222))
+- Fixed an issue when formatting a punctuated sequence multiline where the first item in the sequence would have an incorrect shape used.
 
 ## [0.9.3] - 2021-06-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed comments inside Luau type tables leading to malformed formatting under the `luau` feature flag. ([#219](https://github.com/JohnnyMorganz/StyLua/issues/219))
+- Fixed multiple assignment where an expression was originally hung due to comments being collapsed leading to malformed formatting. ([#222](https://github.com/JohnnyMorganz/StyLua/issues/222))
 
 ## [0.9.3] - 2021-06-26
 ### Added

--- a/tests/inputs/comments-keep-multiline.lua
+++ b/tests/inputs/comments-keep-multiline.lua
@@ -19,7 +19,7 @@ if -- comment
 then
 end
 
-if 
+if
 	foo
 	-- comment
 then
@@ -41,3 +41,7 @@ do
 		or bar, -- comment
 		baz and foo
 end
+
+local x = foo -- comment
+		or bar, -- comment
+		baz and foo

--- a/tests/inputs/return-hanging-expression.lua
+++ b/tests/inputs/return-hanging-expression.lua
@@ -1,0 +1,4 @@
+function foo()
+	return fooooooooooooooooooo(barrr) or foooooooooooooooooooooooooooooooooooooooooooooooooooooopppo(barrrrrrrrrrrrrr)(hello) or bazzzzzzzzzzzzzzzzzz
+  end
+

--- a/tests/snapshots/tests__standard@comments-keep-multiline.lua.snap
+++ b/tests/snapshots/tests__standard@comments-keep-multiline.lua.snap
@@ -48,5 +48,7 @@ do
 end
 
 local x =
-	foo -- comment or bar,  -- commentbaz and foo
+	foo -- comment
+	or bar, -- comment
+	baz and foo
 

--- a/tests/snapshots/tests__standard@comments-keep-multiline.lua.snap
+++ b/tests/snapshots/tests__standard@comments-keep-multiline.lua.snap
@@ -47,3 +47,6 @@ do
 		baz and foo
 end
 
+local x =
+	foo -- comment or bar,  -- commentbaz and foo
+

--- a/tests/snapshots/tests__standard@return-hanging-expression.lua.snap
+++ b/tests/snapshots/tests__standard@return-hanging-expression.lua.snap
@@ -1,0 +1,11 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+function foo()
+	return fooooooooooooooooooo(barrr) or foooooooooooooooooooooooooooooooooooooooooooooooooooooopppo(barrrrrrrrrrrrrr)(
+		hello
+	) or bazzzzzzzzzzzzzzzzzz
+end
+

--- a/tests/snapshots/tests__standard@return-hanging-expression.lua.snap
+++ b/tests/snapshots/tests__standard@return-hanging-expression.lua.snap
@@ -4,8 +4,8 @@ expression: format(&contents)
 
 ---
 function foo()
-	return fooooooooooooooooooo(barrr) or foooooooooooooooooooooooooooooooooooooooooooooooooooooopppo(barrrrrrrrrrrrrr)(
-		hello
-	) or bazzzzzzzzzzzzzzzzzz
+	return fooooooooooooooooooo(barrr)
+		or foooooooooooooooooooooooooooooooooooooooooooooooooooooopppo(barrrrrrrrrrrrrr)(hello)
+		or bazzzzzzzzzzzzzzzzzz
 end
 


### PR DESCRIPTION
This PR updates our return formatting to be more consistent with assignment formatting. This closes #194, as that was the issue present here.

As we aligned it more with assignment formatting, this change showed an issue within our current assignment formatting due to a testcase we have for returns (where multiple values being assigned, and an assigned expression was previously hung due to comments). Migrating this test case to assignment formatting allows us to fix this. Fixes #222.

In doing this I also uncovered a bug in `format_punctuated_multiline`, where the `shape` used for the first item in the sequence was also incremented by the hang level when it isn't being hung. This gave it less room to format (specifically one `indent_width` space).