### PR TITLE
Add support for ignoring a portion of code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added flag `--verify` which, when enabled, attempts to verify the generated output AST with the input AST to detect any changes to code correctness. Useful for adopting StyLua into a large codebase, at the cost of slower processing. ([#199](https://github.com/JohnnyMorganz/StyLua/issues/199))
 - Added optional command line options `--column-width`, `--indent-type`, `--indent-width`, `--line-endings` and `--quote-style`, which, when provided, will override any configuration setting inferred from the default or a `stylua.toml`. ([#213](https://github.com/JohnnyMorganz/StyLua/issues/213))
 - Added multithreaded support for formatting file in the CLI. Now each file will be formatted in its own thread. The number of threads used defaults to the number of cores on your computer, but can be set using `--num-threads`
+- Added support for disabling formatting over specific ranges. Use `-- stylua: ignore start` to disable formatting and `-- stylua: ignore end` to re-enable it. The comment must be preceding a statement and disabling formatting cannot cross block scope boundaries. ([#198](https://github.com/JohnnyMorganz/StyLua/issues/198))
 
 ### Changed
 - Luau type tables (`luau` feature flag) now use the same formatting strategy as normal expression tables, so that their formatting is more aligned.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ local matrix = {
     { 0, 0, 0 },
 }
 ```
+You can also disable formatting over a block of code by using `-- stylua: ignore start` / `-- stylua: ignore end` respectively.
+```lua
+local foo = true
+-- stylua: ignore start
+local   bar   =   false
+local  baz      = 0
+-- stylua: ignore end
+local foobar = false
+```
+Note: this comment must be preceding a statement (same as `-- stylua: ignore`), and cannot cross block scope boundaries
+(i.e. if formatting is disabled, and we exit a block, formatting is automatically re-enabled).
 
 ### Formatting Ranges
 If you only want to format a specific range within a file, you can pass the `--range-start <num>` and/or `--range-end <num>` arguments,

--- a/tests/test_ignore.rs
+++ b/tests/test_ignore.rs
@@ -1,0 +1,144 @@
+use stylua_lib::{format_code, Config, OutputVerification};
+
+fn format(input: &str) -> String {
+    format_code(input, Config::default(), None, OutputVerification::None).unwrap()
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_singleline_ignore() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+-- stylua: ignore
+local bar   =     baz
+            "###
+        ),
+        @r###""###
+    );
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_singleline_ignore_2() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+-- stylua: ignore
+local bar   =     baz
+local bar   =     baz
+            "###
+        ),
+        @r###""###
+    );
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+-- stylua: ignore start
+local bar   =     baz
+-- stylua: ignore end
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore_2() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+-- stylua: ignore start
+local bar   =     baz
+local bar   =     baz
+-- stylua: ignore end
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore_no_ending() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+-- stylua: ignore start
+local bar   =     baz
+local bar   =     baz
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore_no_starting() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+local bar   =     baz
+local bar   =     baz
+-- stylua: ignore end
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore_block_scope() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+do
+    -- stylua: ignore start
+    local bar   =     baz
+    -- stylua: ignore end
+    local bar   =     baz
+end
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_multiline_block_ignore_block_scope_no_ending() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local foo     =      bar
+do
+    -- stylua: ignore start
+    local bar   =     baz
+    local bar   =     baz
+end
+local bar   =     baz
+"###
+        ),
+    @r###"
+    "###);
+}

--- a/tests/test_ignore.rs
+++ b/tests/test_ignore.rs
@@ -15,7 +15,11 @@ local foo     =      bar
 local bar   =     baz
             "###
         ),
-        @r###""###
+        @r###"
+    local foo = bar
+    -- stylua: ignore
+    local bar   =     baz
+    "###
     );
 }
 
@@ -31,7 +35,12 @@ local bar   =     baz
 local bar   =     baz
             "###
         ),
-        @r###""###
+        @r###"
+    local foo = bar
+    -- stylua: ignore
+    local bar   =     baz
+    local bar = baz
+    "###
     );
 }
 
@@ -49,6 +58,11 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    -- stylua: ignore start
+    local bar   =     baz
+    -- stylua: ignore end
+    local bar = baz
     "###);
 }
 
@@ -67,6 +81,12 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    -- stylua: ignore start
+    local bar   =     baz
+    local bar   =     baz
+    -- stylua: ignore end
+    local bar = baz
     "###);
 }
 
@@ -84,6 +104,11 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    -- stylua: ignore start
+    local bar   =     baz
+    local bar   =     baz
+    local bar   =     baz
     "###);
 }
 
@@ -101,6 +126,11 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    local bar = baz
+    local bar = baz
+    -- stylua: ignore end
+    local bar = baz
     "###);
 }
 
@@ -121,6 +151,14 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    do
+        -- stylua: ignore start
+        local bar   =     baz
+    	-- stylua: ignore end
+    	local bar = baz
+    end
+    local bar = baz
     "###);
 }
 
@@ -140,5 +178,12 @@ local bar   =     baz
 "###
         ),
     @r###"
+    local foo = bar
+    do
+        -- stylua: ignore start
+        local bar   =     baz
+        local bar   =     baz
+    end
+    local bar = baz
     "###);
 }


### PR DESCRIPTION
This PR adds support for disabling formatting over blocks of code, for adoptability purposes.

To start ignoring, precede a statement with `-- stylua: ignore start`. To re-enable formatting, use `-- stylua: ignore end`.
Example:
```lua
local foo = true
-- stylua: ignore start
local   bar   =   false
local  baz      = 0
-- stylua: ignore end
local foobar = false
```

A few limitations:
- Similar to `-- stylua: ignore`, the comment must be preceding a statement. It will not work within a statement [e.g. before an expression]
- Disabling formatting cannot cross block scope boundaries. i.e., if formatting is disabled using `-- stylua: ignore start`, and we exit a block, formatting is automatically re-enabled even if the end comment hasn't been seen yet:
```lua
local foo = true
do
    -- stylua: ignore start
    local   bar   =   false
    local  baz      = 0
end
local     foobar    =    false
-- stylua: ignore end
local foobar    = false
```
... is formatted as ...
```lua
local    foo   = true
do
    -- stylua: ignore start
    local   bar   =   false
    local  baz      = 0
end
local foobar = false
-- stylua: ignore end
local foobar = false
```

Closes #198 