### PR TITLE
Fix trailing comma mistransformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed an incorrect trailing comma being added to function args as part of a multiline expression list leading to a syntax error. ([#227](https://github.com/JohnnyMorganz/StyLua/issues/227))
 
 ## [0.10.0] - 2021-07-11
 ### Added

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -137,18 +137,21 @@ fn attempt_assignment_tactics(
             // Look through each punctuated expression to see if we need to hang the item further
             let mut output_expr = Punctuated::new();
 
-            for (idx, pair) in multiline_expr.into_pairs().enumerate() {
+            for (idx, (formatted, original)) in
+                multiline_expr.into_pairs().zip(expressions).enumerate()
+            {
                 // Recreate the shape
                 let shape = if idx == 0 { shape } else { shape.reset() };
 
-                if trivia_util::contains_comments(&pair)
-                    || shape.take_first_line(&pair).over_budget()
+                if trivia_util::contains_comments(&formatted)
+                    || shape.take_first_line(&formatted).over_budget()
                 {
-                    // Hang the pair
-                    output_expr.push(pair.map(|value| hang_expression(ctx, &value, shape, Some(1))))
+                    // Hang the pair, using the original expression for formatting
+                    output_expr
+                        .push(formatted.map(|_| hang_expression(ctx, original, shape, Some(1))))
                 } else {
                     // Add the pair as it is
-                    output_expr.push(pair);
+                    output_expr.push(formatted);
                 }
             }
 

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -82,7 +82,11 @@ pub fn format_return(ctx: &Context, return_node: &Return, shape: Shape) -> Retur
                 let mut output_returns = Punctuated::new();
 
                 // Look through each punctuated sequence to see if we need to hang the item further
-                for (idx, pair) in multiline_returns.into_pairs().enumerate() {
+                for (idx, (formatted, original)) in multiline_returns
+                    .into_pairs()
+                    .zip(returns)
+                    .enumerate()
+                {
                     // Recreate the shape
                     let shape = if idx == 0 {
                         shape
@@ -92,15 +96,17 @@ pub fn format_return(ctx: &Context, return_node: &Return, shape: Shape) -> Retur
                             .with_indent(shape.indent().add_indent_level(hang_level.unwrap()))
                     };
 
-                    if trivia_util::contains_comments(&pair)
-                        || shape.take_first_line(&pair).over_budget()
+                    if trivia_util::contains_comments(&formatted)
+                        || shape.take_first_line(&formatted).over_budget()
                     {
-                        // Hang the pair
-                        output_returns
-                            .push(pair.map(|value| hang_expression(ctx, &value, shape, Some(1))))
+                        // Hang the pair, using the original expression for formatting
+                        output_returns.push(
+                            formatted
+                                .map(|_| hang_expression(ctx, original, shape, Some(1))),
+                        )
                     } else {
                         // Add the pair as it is
-                        output_returns.push(pair);
+                        output_returns.push(formatted);
                     }
                 }
 

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -82,10 +82,8 @@ pub fn format_return(ctx: &Context, return_node: &Return, shape: Shape) -> Retur
                 let mut output_returns = Punctuated::new();
 
                 // Look through each punctuated sequence to see if we need to hang the item further
-                for (idx, (formatted, original)) in multiline_returns
-                    .into_pairs()
-                    .zip(returns)
-                    .enumerate()
+                for (idx, (formatted, original)) in
+                    multiline_returns.into_pairs().zip(returns).enumerate()
                 {
                     // Recreate the shape
                     let shape = if idx == 0 {
@@ -100,10 +98,8 @@ pub fn format_return(ctx: &Context, return_node: &Return, shape: Shape) -> Retur
                         || shape.take_first_line(&formatted).over_budget()
                     {
                         // Hang the pair, using the original expression for formatting
-                        output_returns.push(
-                            formatted
-                                .map(|_| hang_expression(ctx, original, shape, Some(1))),
-                        )
+                        output_returns
+                            .push(formatted.map(|_| hang_expression(ctx, original, shape, Some(1))))
                     } else {
                         // Add the pair as it is
                         output_returns.push(formatted);

--- a/tests/inputs/return-hanging-expression-2.lua
+++ b/tests/inputs/return-hanging-expression-2.lua
@@ -1,0 +1,5 @@
+return cframe * Vector3.new( -- Clamp & transform into world space
+		math.clamp(transform.X, -halfSize.X, halfSize.X),
+		math.clamp(transform.Y, -halfSize.Y, halfSize.Y),
+		math.clamp(transform.Z, -halfSize.Z, halfSize.Z)
+	), cframe.Position

--- a/tests/snapshots/tests__standard@return-hanging-expression-2.lua.snap
+++ b/tests/snapshots/tests__standard@return-hanging-expression-2.lua.snap
@@ -1,0 +1,13 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+return cframe
+	* Vector3.new( -- Clamp & transform into world space
+		math.clamp(transform.X, -halfSize.X, halfSize.X),
+		math.clamp(transform.Y, -halfSize.Y, halfSize.Y),
+		math.clamp(transform.Z, -halfSize.Z, halfSize.Z)
+	),
+	cframe.Position
+


### PR DESCRIPTION
Occurred due to the formatting of a multiline expression list using an already formatted expression rather than the original expression when hanging.

Fixes #227 