### PR TITLE
Collapse guard statements on a single line

### DIFF
--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -219,13 +219,13 @@ fn is_if_guard(if_node: &If) -> bool {
 
 /// Formats an if statement onto a single line.
 /// This function performs no checking to see if we *should* do this - it will just return a singleline if statement.
-fn format_singeline_if<'ast>(ctx: &Context, if_node: &If, shape: Shape) -> If {
+fn format_singeline_if(ctx: &Context, if_node: &If, shape: Shape) -> If {
     // Calculate trivia
     let leading_trivia = vec![create_indent_trivia(ctx, shape)];
     let trailing_trivia = vec![create_newline_trivia(ctx)];
 
     let if_token = fmt_symbol!(ctx, if_node.if_token(), "if ", shape)
-        .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned()));
+        .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
 
     // Remove parentheses around the condition
     let condition = remove_condition_parentheses(if_node.condition().to_owned());
@@ -260,7 +260,7 @@ fn format_singeline_if<'ast>(ctx: &Context, if_node: &If, shape: Shape) -> If {
     let block = Block::new().with_last_stmt(Some((last_stmt, None)));
 
     let end_token = format_end_token(ctx, if_node.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
+        .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
 
     if_node
         .to_owned()

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -7,6 +7,7 @@ use full_moon::ast::{
     FunctionBody, FunctionCall, FunctionName, Index, MethodCall, Parameter, Prefix, Suffix,
     TableConstructor, UnOp, Value, Var, VarExpression,
 };
+use full_moon::ast::{If, Return};
 use full_moon::tokenizer::{Token, TokenReference};
 
 /// Enum to determine how trivia should be added when using trivia formatter functions
@@ -343,6 +344,12 @@ define_update_trivia!(FunctionName, |this, leading, trailing| {
     }
 });
 
+define_update_trivia!(If, |this, leading, trailing| {
+    this.to_owned()
+        .with_if_token(this.if_token().update_leading_trivia(leading))
+        .with_end_token(this.end_token().update_trailing_trivia(trailing))
+});
+
 define_update_trivia!(Index, |this, leading, trailing| {
     match this {
         Index::Brackets {
@@ -428,6 +435,17 @@ where
         punctuated
     }
 }
+
+define_update_trivia!(Return, |this, leading, trailing| {
+    if this.returns().is_empty() {
+        this.to_owned()
+            .with_token(this.token().update_trivia(leading, trailing))
+    } else {
+        this.to_owned()
+            .with_token(this.token().update_leading_trivia(leading))
+            .with_returns(this.returns().update_trailing_trivia(trailing))
+    }
+});
 
 define_update_trivia!(Suffix, |this, leading, trailing| {
     match this {

--- a/tests/snapshots/tests__standard@if-1.lua.snap
+++ b/tests/snapshots/tests__standard@if-1.lua.snap
@@ -3,7 +3,5 @@ source: tests/tests.rs
 expression: format(&contents)
 
 ---
-if x == true then
-	return
-end
+if x == true then return end
 

--- a/tests/snapshots/tests__standard@large-example-2.lua.snap
+++ b/tests/snapshots/tests__standard@large-example-2.lua.snap
@@ -286,9 +286,7 @@ function findplayer(name, speaker)
 		while true do
 			local c = game.Players:GetChildren()
 			local r = math.random(1, #c)
-			if c[r].className == "Player" then
-				return { c[r] }
-			end
+			if c[r].className == "Player" then return { c[r] } end
 		end
 	elseif string.sub(string.lower(name), 1, 6) == "guests" then
 		local gnum = 0
@@ -469,9 +467,7 @@ end
 
 function PERSON299(name)
 	for i = 1, #adminlist do
-		if adminlist[i] == name then
-			return true
-		end
+		if adminlist[i] == name then return true end
 	end
 	return false
 end
@@ -515,9 +511,7 @@ function oc(msg, speaker)
 				break
 			end
 		end
-		if danumber1 == nil then
-			return
-		end
+		if danumber1 == nil then return end
 		local it = nil
 		local all = true
 		if string.sub(string.lower(msg), danumber1 + 1, danumber1 + 4) ~= "all" then
@@ -530,9 +524,7 @@ function oc(msg, speaker)
 					itnum = itnum + 1
 				end
 			end
-			if itnum ~= 1 then
-				return
-			end
+			if itnum ~= 1 then return end
 		else
 			all = true
 		end
@@ -567,9 +559,7 @@ function oc(msg, speaker)
 				break
 			end
 		end
-		if danumber1 == nil then
-			return
-		end
+		if danumber1 == nil then return end
 		for i = danumber1 + 1, danumber1 + 100 do
 			if string.sub(msg, i, i) == "/" then
 				danumber2 = i
@@ -578,9 +568,7 @@ function oc(msg, speaker)
 				break
 			end
 		end
-		if danumber2 == nil then
-			return
-		end
+		if danumber2 == nil then return end
 		local player = findplayer(string.sub(msg, 8, danumber1 - 1), speaker)
 		if player ~= 0 then
 			for i = 1, #player do
@@ -1463,9 +1451,7 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber1 == nil then
-			return
-		end
+		if danumber1 == nil then return end
 		for i = danumber1 + 1, danumber1 + 100 do
 			if string.sub(msg, i, i) == "/" then
 				danumber2 = i
@@ -1474,9 +1460,7 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber2 == nil then
-			return
-		end
+		if danumber2 == nil then return end
 		game.Lighting.Ambient = Color3.new(
 			-string.sub(msg, 9, danumber1 - 1),
 			-string.sub(msg, danumber1 + 1, danumber2 - 1),
@@ -1497,9 +1481,7 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber1 == nil then
-			return
-		end
+		if danumber1 == nil then return end
 		for i = danumber1 + 1, danumber1 + 100 do
 			if string.sub(msg, i, i) == "/" then
 				danumber2 = i
@@ -1508,9 +1490,7 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber2 == nil then
-			return
-		end
+		if danumber2 == nil then return end
 		if speaker.Character ~= nil then
 			local head = speaker.Character:FindFirstChild("Head")
 			if head ~= nil then
@@ -1532,9 +1512,7 @@ script.Parent.Parent.Humanoid.Health = 0
 	if string.sub(msg, 1, 8) == "control/" then
 		local player = findplayer(string.sub(msg, 9), speaker)
 		if player ~= 0 then
-			if #player > 1 then
-				return
-			end
+			if #player > 1 then return end
 			for i = 1, #player do
 				if player[i].Character ~= nil then
 					speaker.Character = player[i].Character
@@ -1582,13 +1560,9 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player = findplayer(string.sub(msg, 9, danumber - 1), speaker)
-		if player == 0 then
-			return
-		end
+		if player == 0 then return end
 		for i = 1, #player do
 			if player[i].Character ~= nil then
 				local torso = player[i].Character:FindFirstChild("Torso")
@@ -1622,13 +1596,9 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player = findplayer(string.sub(msg, 11, danumber - 1), speaker)
-		if player == 0 then
-			return
-		end
+		if player == 0 then return end
 		for i = 1, #player do
 			if player[i].Character ~= nil then
 				humanoid = player[i].Character:FindFirstChild("Humanoid")
@@ -1647,13 +1617,9 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player = findplayer(string.sub(msg, 8, danumber - 1), speaker)
-		if player == 0 then
-			return
-		end
+		if player == 0 then return end
 		for i = 1, #player do
 			if player[i].Character ~= nil then
 				humanoid = player[i].Character:FindFirstChild("Humanoid")
@@ -1672,13 +1638,9 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player = findplayer(string.sub(msg, 8, danumber - 1), speaker)
-		if player == 0 then
-			return
-		end
+		if player == 0 then return end
 		for i = 1, #player do
 			if player[i].Character ~= nil then
 				humanoid = player[i].Character:FindFirstChild("Humanoid")
@@ -1705,20 +1667,12 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player1 = findplayer(string.sub(msg, 10, danumber - 1), speaker)
-		if player1 == 0 then
-			return
-		end
+		if player1 == 0 then return end
 		local player2 = findplayer(string.sub(msg, danumber + 1), speaker)
-		if player2 == 0 then
-			return
-		end
-		if #player2 > 1 then
-			return
-		end
+		if player2 == 0 then return end
+		if #player2 > 1 then return end
 		torso = nil
 		for i = 1, #player2 do
 			if player2[i].Character ~= nil then
@@ -1745,20 +1699,12 @@ script.Parent.Parent.Humanoid.Health = 0
 				break
 			end
 		end
-		if danumber == nil then
-			return
-		end
+		if danumber == nil then return end
 		local player1 = findplayer(string.sub(msg, 7, danumber - 1), speaker)
-		if player1 == 0 then
-			return
-		end
+		if player1 == 0 then return end
 		local player2 = findplayer(string.sub(msg, danumber + 1), speaker)
-		if player2 == 0 then
-			return
-		end
-		if #player2 > 1 then
-			return
-		end
+		if player2 == 0 then return end
+		if #player2 > 1 then return end
 		for i = 1, #player2 do
 			if player2[i].Character ~= nil then
 				player2 = player2[i].Character
@@ -2138,9 +2084,7 @@ if youcaughtme == 0 then
 end
 function oe(ack)
 	local adminned = false
-	if ack.className ~= "Player" then
-		return
-	end
+	if ack.className ~= "Player" then return end
 	for i = 1, #bannedlist do
 		if string.lower(bannedlist[i]) == string.lower(ack.Name) then
 			ack:remove()
@@ -2164,9 +2108,7 @@ function oe(ack)
 	local danumber = 0
 	while true do
 		wait(1)
-		if ack.Parent == nil then
-			return
-		end
+		if ack.Parent == nil then return end
 		if ack.Character ~= nil then
 			if adminned == true then
 				text("You're an admin.", 5, "Message", ack)
@@ -2194,9 +2136,7 @@ function oe(ack)
 						end
 					else
 						danumber = danumber + 1
-						if danumber >= 10 then
-							return
-						end
+						if danumber >= 10 then return end
 					end
 				end
 			end

--- a/tests/snapshots/tests__standard@large-example.lua.snap
+++ b/tests/snapshots/tests__standard@large-example.lua.snap
@@ -164,9 +164,7 @@ local function makeErrorHandler(traceback)
 		-- If the error object is already a table, forward it directly.
 		-- Should we extend the error here and add our own trace?
 
-		if type(err) == "table" then
-			return err
-		end
+		if type(err) == "table" then return err end
 
 		return Error.new({
 			error = err,
@@ -391,9 +389,7 @@ function Promise._all(traceback, promises, amount)
 	end
 
 	-- If there are no values then return an already resolved promise.
-	if #promises == 0 or amount == 0 then
-		return Promise.resolve({})
-	end
+	if #promises == 0 or amount == 0 then return Promise.resolve({}) end
 
 	return Promise._new(traceback, function(resolve, reject, onCancel)
 		-- An array to contain our resolved values from the given promises.
@@ -414,9 +410,7 @@ function Promise._all(traceback, promises, amount)
 
 		-- Called when a single value is resolved and resolves if all are done.
 		local function resolveOne(i, ...)
-			if done then
-				return
-			end
+			if done then return end
 
 			resolvedCount = resolvedCount + 1
 
@@ -500,9 +494,7 @@ function Promise.allSettled(promises)
 	end
 
 	-- If there are no values then return an already resolved promise.
-	if #promises == 0 then
-		return Promise.resolve({})
-	end
+	if #promises == 0 then return Promise.resolve({}) end
 
 	return Promise._new(debug.traceback(nil, 2), function(resolve, _, onCancel)
 		-- An array to contain our resolved values from the given promises.
@@ -569,9 +561,7 @@ function Promise.race(promises)
 			end
 		end
 
-		if onCancel(finalize(reject)) then
-			return
-		end
+		if onCancel(finalize(reject)) then return end
 
 		for i, promise in ipairs(promises) do
 			newPromises[i] = promise:andThen(finalize(resolve), finalize(reject))
@@ -662,9 +652,7 @@ function Promise.each(list, predicate)
 				end
 			end
 
-			if cancelled then
-				return
-			end
+			if cancelled then return end
 
 			local predicatePromise = Promise.resolve(predicate(value, index))
 
@@ -688,9 +676,7 @@ end
 	Is the given object a Promise instance?
 ]]
 function Promise.is(object)
-	if type(object) ~= "table" then
-		return false
-	end
+	if type(object) ~= "table" then return false end
 
 	local objectMetatable = getmetatable(object)
 
@@ -963,9 +949,7 @@ end
 	the cancellation hook if provided.
 ]]
 function Promise.prototype:cancel()
-	if self._status ~= Promise.Status.Started then
-		return
-	end
+	if self._status ~= Promise.Status.Started then return end
 
 	self._status = Promise.Status.Cancelled
 
@@ -989,9 +973,7 @@ end
 	cancel this promise.
 ]]
 function Promise.prototype:_consumerCancelled(consumer)
-	if self._status ~= Promise.Status.Started then
-		return
-	end
+	if self._status ~= Promise.Status.Started then return end
 
 	self._consumers[consumer] = nil
 
@@ -1019,9 +1001,7 @@ function Promise.prototype:_finally(traceback, finallyHandler, onlyOk)
 		if onlyOk then
 			local callback = finallyCallback
 			finallyCallback = function(...)
-				if self._status == Promise.Status.Rejected then
-					return resolve(self)
-				end
+				if self._status == Promise.Status.Rejected then return resolve(self) end
 
 				return callback(...)
 			end
@@ -1245,9 +1225,7 @@ function Promise.prototype:_resolve(...)
 end
 
 function Promise.prototype:_reject(...)
-	if self._status ~= Promise.Status.Started then
-		return
-	end
+	if self._status ~= Promise.Status.Started then return end
 
 	self._status = Promise.Status.Rejected
 	self._valuesLength, self._values = pack(...)
@@ -1270,9 +1248,7 @@ function Promise.prototype:_reject(...)
 			Promise._timeEvent:Wait()
 
 			-- Someone observed the error, hooray!
-			if not self._unhandledRejection then
-				return
-			end
+			if not self._unhandledRejection then return end
 
 			-- Build a reasonable message
 			local message = string.format("Unhandled Promise rejection:\n\n%s\n\n%s", err, self._source)
@@ -1387,9 +1363,7 @@ function Promise.fromEvent(event, predicate)
 			end
 		end)
 
-		if shouldDisconnect and connection then
-			return disconnect()
-		end
+		if shouldDisconnect and connection then return disconnect() end
 
 		onCancel(function()
 			disconnect()

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -126,13 +126,9 @@ end end end end end
     			break
     		end
     	end
-    	if danumber == nil then
-    		return
-    	end
+    	if danumber == nil then return end
     	local player = findplayer(string.sub(msg, 9, danumber - 1), speaker)
-    	if player == 0 then
-    		return
-    	end
+    	if player == 0 then return end
     	for i = 1, #player do
     		if player[i].Character ~= nil then
     			local torso = player[i].Character:FindFirstChild("Torso")


### PR DESCRIPTION
**WIP: still need to determine whether this PR is reasonable or not to use**

This PR formats guard-style if statements on a single line:
```lua
function foo(a, b, c)
    if a == "foo" then return true end
    if a == "bar" then return false end
    if not b then return end

    -- ...

    for i,v in pairs() do
        if calculateSomething(i) then break end
        -- ...
    end
end
```
#161 provides more information on the change.

Closes #161 