### PR TITLE
Extension GitHub authentication

### DIFF
--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -37,6 +37,11 @@
         "command": "stylua.reinstall",
         "title": "Reinstall StyLua",
         "category": "StyLua"
+      },
+      {
+        "command": "stylua.authenticate",
+        "title": "Authorize StyLua to use GitHub API",
+        "category": "StyLua"
       }
     ],
     "configuration": {

--- a/stylua-vscode/src/download.ts
+++ b/stylua-vscode/src/download.ts
@@ -1,0 +1,142 @@
+import * as vscode from "vscode";
+import * as unzip from "unzipper";
+import * as util from "./util";
+import fetch from "node-fetch";
+import { createWriteStream } from "fs";
+import { executeStylua } from "./stylua";
+import { GitHub, GitHubRelease } from "./github";
+
+export class StyluaDownloader {
+  constructor(
+    private readonly storageDirectory: vscode.Uri,
+    private readonly github: GitHub
+  ) {}
+
+  public async ensureStyluaExists(): Promise<string | undefined> {
+    const path = await this.getStyluaPath();
+
+    if (path === undefined) {
+      await vscode.workspace.fs.createDirectory(this.storageDirectory);
+      await this.downloadStyLuaVisual();
+      return await this.getStyluaPath();
+    } else {
+      if (!(await util.fileExists(path))) {
+        vscode.window.showErrorMessage(
+          `The path given for StyLua (${path}) does not exist`
+        );
+        return;
+      }
+
+      try {
+        const currentVersion = (
+          await executeStylua(path, ["--version"])
+        )?.trim();
+        const desiredVersion = util.getDesiredVersion();
+        const release = await this.github.getRelease(desiredVersion);
+        if (
+          currentVersion !==
+          `stylua ${
+            release.tagName.startsWith("v")
+              ? release.tagName.substr(1)
+              : release.tagName
+          }`
+        ) {
+          this.openUpdatePrompt(release);
+        }
+      } catch (err) {
+        vscode.window.showWarningMessage(
+          `Error checking the selected StyLua version, falling back to the currently installed version:\n${err}`
+        );
+      }
+
+      return path;
+    }
+  }
+
+  public downloadStyLuaVisual(): Thenable<void> {
+    return vscode.window.withProgress(
+      {
+        cancellable: false,
+        location: vscode.ProgressLocation.Notification,
+        title: "Downloading StyLua",
+      },
+      () => this.downloadStylua()
+    );
+  }
+
+  private async downloadStylua(): Promise<void> {
+    const version = util.getDesiredVersion();
+    const release = await this.github.getRelease(version);
+    const assetFilename = util.getAssetFilenamePattern();
+    const outputFilename = util.getDownloadOutputFilename();
+
+    for (const asset of release.assets) {
+      if (assetFilename.test(asset.name)) {
+        const file = createWriteStream(
+          vscode.Uri.joinPath(this.storageDirectory, outputFilename).fsPath,
+          {
+            mode: 0o755,
+          }
+        );
+
+        return new Promise(async (resolve, reject) => {
+          fetch(asset.downloadUrl, {
+            headers: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              "User-Agent": "stylua-vscode",
+            },
+          })
+            .then((res) => res.body.pipe(unzip.Parse()))
+            .then((stream) => {
+              stream.on("entry", (entry: unzip.Entry) => {
+                if (entry.path !== outputFilename) {
+                  entry.autodrain();
+                  return;
+                }
+
+                entry.pipe(file).on("finish", resolve).on("error", reject);
+              });
+            });
+        });
+      }
+    }
+  }
+
+  private openUpdatePrompt(release: GitHubRelease) {
+    vscode.window
+      .showInformationMessage(
+        `StyLua ${release.tagName} is available to install.`,
+        "Install",
+        "Later",
+        "Release Notes"
+      )
+      .then((option) => {
+        switch (option) {
+          case "Install":
+            this.downloadStyLuaVisual();
+            break;
+          case "Release Notes":
+            vscode.env.openExternal(vscode.Uri.parse(release.htmlUrl));
+            this.openUpdatePrompt(release);
+            break;
+        }
+      });
+  }
+
+  public async getStyluaPath(): Promise<string | undefined> {
+    const settingPath = vscode.workspace
+      .getConfiguration("stylua")
+      .get<string | null>("styluaPath");
+    if (settingPath) {
+      return settingPath;
+    }
+
+    const downloadPath = vscode.Uri.joinPath(
+      this.storageDirectory,
+      util.getDownloadOutputFilename()
+    );
+    if (await util.fileExists(downloadPath)) {
+      return downloadPath.fsPath;
+    }
+  }
+}

--- a/stylua-vscode/src/download.ts
+++ b/stylua-vscode/src/download.ts
@@ -47,6 +47,18 @@ export class StyluaDownloader {
         vscode.window.showWarningMessage(
           `Error checking the selected StyLua version, falling back to the currently installed version:\n${err}`
         );
+        if (!this.github.authenticated) {
+          const option = await vscode.window.showInformationMessage(
+            "Authenticating with GitHub can fix rate limits.",
+            "Authenticate with GitHub"
+          );
+          switch (option) {
+            case "Authenticate with GitHub":
+              if (await this.github.authenticate()) {
+                return this.ensureStyluaExists();
+              }
+          }
+        }
       }
 
       return path;

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -32,10 +32,23 @@ export async function activate(context: vscode.ExtensionContext) {
 
   let styluaBinaryPath: string | undefined =
     await downloader.ensureStyluaExists();
+
   context.subscriptions.push(
     vscode.commands.registerCommand("stylua.reinstall", async () => {
       await downloader.downloadStyLuaVisual();
       styluaBinaryPath = await downloader.getStyluaPath();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("stylua.authenticate", async () => {
+      try {
+        await github.authenticate();
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `Failed to authenticate with GitHub: ${error}`
+        );
+      }
     })
   );
 

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -42,13 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("stylua.authenticate", async () => {
-      try {
-        await github.authenticate();
-      } catch (error) {
-        vscode.window.showErrorMessage(
-          `Failed to authenticate with GitHub: ${error}`
-        );
-      }
+      await github.authenticate();
     })
   );
 

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as util from "./util";
 import { formatCode, checkIgnored } from "./stylua";
+import { GitHub } from "./github";
 
 /**
  * Convert a Position within a Document to a byte offset.
@@ -22,6 +23,9 @@ const byteOffset = (
 
 export async function activate(context: vscode.ExtensionContext) {
   console.log("stylua activated");
+
+  const github = new GitHub();
+  context.subscriptions.push(github);
 
   let styluaBinaryPath: string | undefined = await util.ensureStyluaExists(
     context.globalStorageUri

--- a/stylua-vscode/src/github.ts
+++ b/stylua-vscode/src/github.ts
@@ -3,6 +3,7 @@ import {
   Disposable,
   AuthenticationSession,
   AuthenticationSessionsChangeEvent,
+  window,
 } from "vscode";
 import fetch, { Headers } from "node-fetch";
 
@@ -126,7 +127,7 @@ export class GitHub implements Disposable {
         this.credential.set();
         return false;
       } else {
-        throw e;
+        window.showErrorMessage(`Failed to authenticate with GitHub: ${e}`);
       }
     }
     return this.credential.authenticated;

--- a/stylua-vscode/src/github.ts
+++ b/stylua-vscode/src/github.ts
@@ -19,13 +19,25 @@ async function fetchJson(url: string): Promise<any> {
 }
 
 function releaseFromJson(json: any): GithubRelease {
+  if (typeof json !== "object") {
+    return {
+      assets: [],
+      tagName: "",
+      htmlUrl: "",
+    };
+  }
   return {
-    assets: json.assets.map((asset: any) => ({
-      downloadUrl: asset.browser_download_url,
-      name: asset.name,
-    })),
-    tagName: json.tag_name,
-    htmlUrl: json.html_url,
+    assets: Array.isArray(json.assets)
+      ? json.assets.map((asset: any) => ({
+          downloadUrl:
+            typeof asset.browser_download_url === "string"
+              ? asset.browser_download_url
+              : "",
+          name: typeof asset.name === "string" ? asset.name : "",
+        }))
+      : [],
+    tagName: typeof json.tag_name === "string" ? json.tag_name : "",
+    htmlUrl: typeof json.html_url === "string" ? json.html_url : "",
   };
 }
 
@@ -37,9 +49,9 @@ export const getRelease = async (version: string): Promise<GithubRelease> => {
 
   version = version.startsWith("v") ? version : "v" + version;
   const json = await fetchJson(RELEASES_URL);
-  const releases: GithubRelease[] = json.map((release: any) =>
-    releaseFromJson(release)
-  );
+  const releases: GithubRelease[] = Array.isArray(json)
+    ? json.map(releaseFromJson)
+    : [];
   for (const release of releases) {
     if (release.tagName.startsWith(version)) {
       return release;

--- a/stylua-vscode/src/github.ts
+++ b/stylua-vscode/src/github.ts
@@ -1,0 +1,50 @@
+import fetch from "node-fetch";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/JohnnyMorganz/StyLua/releases";
+const RELEASES_URL_LATEST = RELEASES_URL + "/latest";
+
+export interface GithubRelease {
+  assets: {
+    downloadUrl: string;
+    name: string;
+  }[];
+  tagName: string;
+  htmlUrl: string;
+}
+
+async function fetchJson(url: string): Promise<any> {
+  const response = await fetch(url);
+  return response.json();
+}
+
+function releaseFromJson(json: any): GithubRelease {
+  return {
+    assets: json.assets.map((asset: any) => ({
+      downloadUrl: asset.browser_download_url,
+      name: asset.name,
+    })),
+    tagName: json.tag_name,
+    htmlUrl: json.html_url,
+  };
+}
+
+export const getRelease = async (version: string): Promise<GithubRelease> => {
+  if (version === "latest") {
+    const json = await fetchJson(RELEASES_URL_LATEST);
+    return releaseFromJson(json);
+  }
+
+  version = version.startsWith("v") ? version : "v" + version;
+  const json = await fetchJson(RELEASES_URL);
+  const releases: GithubRelease[] = json.map((release: any) =>
+    releaseFromJson(release)
+  );
+  for (const release of releases) {
+    if (release.tagName.startsWith(version)) {
+      return release;
+    }
+  }
+
+  throw new Error(`No release version matches ${version}.`);
+};

--- a/stylua-vscode/src/github.ts
+++ b/stylua-vscode/src/github.ts
@@ -93,14 +93,23 @@ export class GitHub implements Disposable {
   constructor() {
     this.disposables.push(
       authentication.onDidChangeSessions(
-        (event: AuthenticationSessionsChangeEvent) =>
-          this.authenticate(this.credential.authenticated)
+        (event: AuthenticationSessionsChangeEvent) => {
+          if (event.provider.id === "github") {
+            this.credential.set();
+            this.authenticate(false);
+          }
+        }
       )
     );
+    this.authenticate(false);
   }
 
   dispose() {
     this.disposables.forEach((d) => d.dispose());
+  }
+
+  public get authenticated(): boolean {
+    return this.credential.authenticated;
   }
 
   public async authenticate(create: boolean = true): Promise<boolean> {

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import * as unzip from "unzipper";
 import fetch from "node-fetch";
 import { executeStylua } from "./stylua";
-import { GithubRelease, getRelease } from "./github";
+import { GitHubRelease } from "./github";
 
 const getDownloadOutputFilename = () => {
   switch (os.platform()) {
@@ -159,7 +159,7 @@ export const ensureStyluaExists = async (
   }
 };
 
-function openUpdatePrompt(directory: vscode.Uri, release: GithubRelease) {
+function openUpdatePrompt(directory: vscode.Uri, release: GitHubRelease) {
   vscode.window
     .showInformationMessage(
       `StyLua ${release.tagName} is available to install.`,

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -2,13 +2,8 @@
 // Licensed under https://github.com/Kampfkarren/selene/blob/master/LICENSE.md
 import * as vscode from "vscode";
 import * as os from "os";
-import * as fs from "fs";
-import * as unzip from "unzipper";
-import fetch from "node-fetch";
-import { executeStylua } from "./stylua";
-import { GitHubRelease } from "./github";
 
-const getDownloadOutputFilename = () => {
+export const getDownloadOutputFilename = () => {
   switch (os.platform()) {
     case "win32":
       return "stylua.exe";
@@ -20,7 +15,7 @@ const getDownloadOutputFilename = () => {
   }
 };
 
-const getAssetFilenamePattern = () => {
+export const getAssetFilenamePattern = () => {
   switch (os.platform()) {
     case "win32":
       return /stylua-[\d\w\-\.]+-win64.zip/;
@@ -33,7 +28,7 @@ const getAssetFilenamePattern = () => {
   }
 };
 
-const getDesiredVersion = (): string => {
+export const getDesiredVersion = (): string => {
   const config = vscode.workspace.getConfiguration("stylua");
   const targetVersion = config.get<string>("targetReleaseVersion", "").trim();
   if (targetVersion.length === 0) {
@@ -49,133 +44,3 @@ export const fileExists = (path: vscode.Uri | string): Thenable<boolean> => {
     () => false
   );
 };
-
-const downloadStylua = async (outputDirectory: vscode.Uri) => {
-  const version = getDesiredVersion();
-  const release = await getRelease(version);
-  const assetFilename = getAssetFilenamePattern();
-  const outputFilename = getDownloadOutputFilename();
-
-  for (const asset of release.assets) {
-    if (assetFilename.test(asset.name)) {
-      const file = fs.createWriteStream(
-        vscode.Uri.joinPath(outputDirectory, outputFilename).fsPath,
-        {
-          mode: 0o755,
-        }
-      );
-
-      return new Promise(async (resolve, reject) => {
-        fetch(asset.downloadUrl, {
-          headers: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            "User-Agent": "stylua-vscode",
-          },
-        })
-          .then((res) => res.body.pipe(unzip.Parse()))
-          .then((stream) => {
-            stream.on("entry", (entry: unzip.Entry) => {
-              if (entry.path !== outputFilename) {
-                entry.autodrain();
-                return;
-              }
-
-              entry.pipe(file).on("finish", resolve).on("error", reject);
-            });
-          });
-      });
-    }
-  }
-};
-
-export const downloadStyLuaVisual = (outputDirectory: vscode.Uri) => {
-  return vscode.window.withProgress(
-    {
-      cancellable: false,
-      location: vscode.ProgressLocation.Notification,
-      title: "Downloading StyLua",
-    },
-    () => downloadStylua(outputDirectory)
-  );
-};
-
-export const getStyluaPath = async (
-  storageDirectory: vscode.Uri
-): Promise<string | undefined> => {
-  const settingPath = vscode.workspace
-    .getConfiguration("stylua")
-    .get<string | null>("styluaPath");
-  if (settingPath) {
-    return settingPath;
-  }
-
-  const downloadPath = vscode.Uri.joinPath(
-    storageDirectory,
-    getDownloadOutputFilename()
-  );
-  if (await fileExists(downloadPath)) {
-    return downloadPath.fsPath;
-  }
-};
-
-export const ensureStyluaExists = async (
-  storageDirectory: vscode.Uri
-): Promise<string | undefined> => {
-  const path = await getStyluaPath(storageDirectory);
-
-  if (path === undefined) {
-    await vscode.workspace.fs.createDirectory(storageDirectory);
-    await downloadStyLuaVisual(storageDirectory);
-    return await getStyluaPath(storageDirectory);
-  } else {
-    if (!(await fileExists(path))) {
-      vscode.window.showErrorMessage(
-        `The path given for StyLua (${path}) does not exist`
-      );
-      return;
-    }
-
-    try {
-      const currentVersion = (await executeStylua(path, ["--version"]))?.trim();
-      const desiredVersion = getDesiredVersion();
-      const release = await getRelease(desiredVersion);
-      if (
-        currentVersion !==
-        `stylua ${
-          release.tagName.startsWith("v")
-            ? release.tagName.substr(1)
-            : release.tagName
-        }`
-      ) {
-        openUpdatePrompt(storageDirectory, release);
-      }
-    } catch (err) {
-      vscode.window.showWarningMessage(
-        `Error checking the selected StyLua version, falling back to the currently installed version:\n${err}`
-      );
-    }
-
-    return path;
-  }
-};
-
-function openUpdatePrompt(directory: vscode.Uri, release: GitHubRelease) {
-  vscode.window
-    .showInformationMessage(
-      `StyLua ${release.tagName} is available to install.`,
-      "Install",
-      "Later",
-      "Release Notes"
-    )
-    .then((option) => {
-      switch (option) {
-        case "Install":
-          downloadStyLuaVisual(directory);
-          break;
-        case "Release Notes":
-          vscode.env.openExternal(vscode.Uri.parse(release.htmlUrl));
-          openUpdatePrompt(directory, release);
-          break;
-      }
-    });
-}


### PR DESCRIPTION
Extension users will be able to authenticate with github through vscode and will be prompted to when hitting the rate limit. No special scopes/permissions are needed as the extension only accesses public data.

This resolves #218 and allows proper usage of changes in #207 by allowing users to avoid REST API limits.

This change isn't that complicated, as vscode provides a nice interface for authentication providers and provides a built in github authentication provider. However, doing this nicely, and for future maintenance sanity, does require a fair bit of code reorganization.

- [x] Separate github interface into its own file
- [x] Separate downloading interface into its own file
- [x] Add authentication functionality
- [x] Prompt for authentication