### PR TITLE
Luau: force type tables multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- In Luau type tables, a newline after the opening brace will now force the type table multiline. This is the same procedure as standard tables. ([#226](https://github.com/JohnnyMorganz/StyLua/issues/226))
+
 
 ## [0.10.1] - 2021-08-08
 ### Fixed

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         trivia_util::{
             contains_comments, token_trivia_contains_comments, trivia_is_comment,
-            type_info_trailing_trivia,
+            trivia_is_newline, type_info_trailing_trivia,
         },
     },
     shape::Shape,
@@ -232,7 +232,15 @@ pub fn format_type_info(ctx: &Context, type_info: &TypeInfo, shape: Shape) -> Ty
 
                     match singleline_shape.over_budget() {
                         true => TableType::MultiLine,
-                        false => TableType::SingleLine,
+                        false => {
+                            // Determine if there was a new line at the end of the start brace
+                            // If so, then we should always be multiline
+                            if start_brace.trailing_trivia().any(trivia_is_newline) {
+                                TableType::MultiLine
+                            } else {
+                                TableType::SingleLine
+                            }
+                        }
                     }
                 }
 

--- a/tests/inputs-luau/type_tables.lua
+++ b/tests/inputs-luau/type_tables.lua
@@ -8,3 +8,6 @@ type PromptSettings = {
     lineOfSight: boolean,
     offset: Vector2,
 }
+
+export type Sprite = {
+	Image: string, ImageRectOffset: Vector2, ImageRectSize: Vector2 }

--- a/tests/snapshots/tests__luau@type_tables.lua.snap
+++ b/tests/snapshots/tests__luau@type_tables.lua.snap
@@ -14,3 +14,9 @@ type PromptSettings = {
 	offset: Vector2,
 }
 
+export type Sprite = {
+	Image: string,
+	ImageRectOffset: Vector2,
+	ImageRectSize: Vector2,
+}
+


### PR DESCRIPTION
If a newline is found after the opening brace of a luau type table, the table will be formatted multiline.
```lua
export type Sprite = {
	Image: string, ImageRectOffset: Vector2, ImageRectSize: Vector2 }
```
... turns into ...
```lua
export type Sprite = {
	Image: string,
	ImageRectOffset: Vector2,
	ImageRectSize: Vector2,
}
```

This is the same process as standard tables.

Closes #226 