### PR TITLE
Improve CLI error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - In Luau type tables, a newline after the opening brace will now force the type table multiline. This is the same procedure as standard tables. ([#226](https://github.com/JohnnyMorganz/StyLua/issues/226))
 - In Luau, type specifiers for function parameters will now force the parameters to be formatted multiline if a specifier is multiline (and there is more than one parameter).
+- Improved error messages to make them easier to understand.
 
 ### Fixed
 - Fixed range formatting no longer working when setting the range to statements inside nested blocks. ([#239](https://github.com/JohnnyMorganz/StyLua/issues/239))

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, format_err, Context, Result};
+use anyhow::{bail, Context, Result};
 use console::style;
 use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use std::fs;
@@ -185,16 +185,7 @@ fn format(opt: opt::Opt) -> Result<i32> {
             // Build overriders with any patterns given
             let mut overrides = OverrideBuilder::new(cwd);
             for pattern in globs {
-                match overrides.add(pattern) {
-                    Ok(_) => continue,
-                    Err(err) => {
-                        return Err(format_err!(
-                            "cannot parse glob pattern {}: {}",
-                            pattern,
-                            err
-                        ));
-                    }
-                }
+                overrides.add(pattern)?;
             }
             let overrides = overrides.build()?;
             walker_builder.overrides(overrides);

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -217,7 +217,10 @@ fn format(opt: opt::Opt) -> Result<i32> {
                         match handle.write_all(&output) {
                             Ok(_) => (),
                             Err(err) => {
-                                error!(read_error_code, 2, "Could not output to stdout: {:#}", err)
+                                error!(
+                                    read_error_code,
+                                    2, "error: could not output to stdout: {:#}", err
+                                )
                             }
                         };
                     }

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -83,6 +83,20 @@ structopt::clap::arg_enum! {
     }
 }
 
+impl Color {
+    pub fn should_use_color(&self) -> bool {
+        match self {
+            Color::Always => true,
+            Color::Never => false,
+            Color::Auto => {
+                let terminal = console::Term::stdout();
+                let features = terminal.features();
+                features.is_attended() && features.colors_supported()
+            }
+        }
+    }
+}
+
 #[derive(StructOpt, Debug)]
 pub struct FormatOpts {
     /// The column width to use to attempt to wrap lines.

--- a/src/cli/output_diff.rs
+++ b/src/cli/output_diff.rs
@@ -36,15 +36,7 @@ pub fn output_diff(
 
     let mut buffer = Vec::new();
 
-    let should_use_color = match color {
-        opt::Color::Always => true,
-        opt::Color::Never => false,
-        opt::Color::Auto => {
-            let terminal = Term::stdout();
-            let features = terminal.features();
-            features.is_attended() && features.colors_supported()
-        }
-    };
+    let should_use_color = color.should_use_color();
 
     // Print out the header title
     writeln!(&mut buffer, "{}", title)?;

--- a/src/cli/output_diff.rs
+++ b/src/cli/output_diff.rs
@@ -2,7 +2,7 @@
 // Licensed under https://github.com/mitsuhiko/similar/blob/main/LICENSE
 use crate::opt;
 use anyhow::Result;
-use console::{style, Style, Term};
+use console::{style, Style};
 use similar::{ChangeTag, TextDiff};
 use std::fmt;
 use std::io::Write;


### PR DESCRIPTION
- Library errors are now moved into a custom enum, allowing us to access specific information from the binary.
- Improve error reporting for "no file or directory found", to make it easier to read.
Old: `error: could not walk: foobar: IO error for operation on foobar: The system cannot find the file specified. (os error 2)`
New: `error: no file or directory found matching 'foobar'`
- Reduced verbosity of parsing errors
- Added colour to error output

TODO maybe:
- Look into making other errors easier to read
- Maybe using codespan diagnostics for syntax error reporting - need to make sure this is still machine readable.
- JSON error output? good for extensions etc.

