### PR TITLE
Fix range formatting for nested blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed range formatting no longer working when setting the range to statements inside nested blocks. ([#239](https://github.com/JohnnyMorganz/StyLua/issues/239))
 
 ## [0.10.1] - 2021-08-08
 ### Fixed

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -148,7 +148,7 @@ fn format_last_stmt_block(ctx: &Context, last_stmt: &LastStmt, shape: Shape) -> 
                 .map(|pair| {
                     pair.to_owned().map(|expression| {
                         let shape = shape.reset().increment_block_indent();
-                        super::stmt::format_expression_block(ctx, &expression, shape)
+                        super::stmt::stmt_block::format_expression_block(ctx, &expression, shape)
                     })
                 })
                 .collect();

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -574,7 +574,7 @@ fn format_function_call_block(
 }
 
 /// Only formats a block within an expression
-fn format_expression_block(ctx: &Context, expression: &Expression, shape: Shape) -> Expression {
+pub fn format_expression_block(ctx: &Context, expression: &Expression, shape: Shape) -> Expression {
     match expression {
         Expression::BinaryOperator { lhs, binop, rhs } => Expression::BinaryOperator {
             lhs: Box::new(format_expression_block(ctx, lhs, shape)),

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -480,14 +480,14 @@ fn format_table_constructor_block(
                     equal,
                     value,
                 } => Field::ExpressionKey {
-                    brackets: brackets.to_owned(),
+                    brackets,
                     key: format_expression_block(ctx, &key, shape),
-                    equal: equal.to_owned(),
+                    equal,
                     value: format_expression_block(ctx, &value, shape),
                 },
                 Field::NameKey { key, equal, value } => Field::NameKey {
-                    key: key.to_owned(),
-                    equal: equal.to_owned(),
+                    key,
+                    equal,
                     value: format_expression_block(ctx, &value, shape),
                 },
                 Field::NoKey(expression) => {
@@ -603,13 +603,13 @@ fn format_expression_block(ctx: &Context, expression: &Expression, shape: Shape)
                     Value::Function((function_token.to_owned(), body.to_owned().with_block(block)))
                 }
                 Value::FunctionCall(function_call) => {
-                    Value::FunctionCall(format_function_call_block(ctx, &function_call, shape))
+                    Value::FunctionCall(format_function_call_block(ctx, function_call, shape))
                 }
                 Value::TableConstructor(table_constructor) => Value::TableConstructor(
-                    format_table_constructor_block(ctx, &table_constructor, shape),
+                    format_table_constructor_block(ctx, table_constructor, shape),
                 ),
                 Value::ParenthesesExpression(expression) => {
-                    Value::ParenthesesExpression(format_expression_block(ctx, &expression, shape))
+                    Value::ParenthesesExpression(format_expression_block(ctx, expression, shape))
                 }
                 // TODO: var?
                 value => value.to_owned(),

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -24,8 +24,7 @@ use crate::{
     shape::Shape,
 };
 use full_moon::ast::{
-    Call, Do, ElseIf, Expression, Field, FunctionArgs, FunctionCall, GenericFor, If, Index,
-    NumericFor, Prefix, Repeat, Stmt, Suffix, TableConstructor, Value, While,
+    Do, ElseIf, Expression, FunctionCall, GenericFor, If, NumericFor, Repeat, Stmt, Value, While,
 };
 use full_moon::tokenizer::{Token, TokenReference, TokenType};
 
@@ -464,273 +463,299 @@ pub fn format_function_call_stmt(
     )
 }
 
-fn format_table_constructor_block(
-    ctx: &Context,
-    table_constructor: &TableConstructor,
-    shape: Shape,
-) -> TableConstructor {
-    let fields = table_constructor
-        .fields()
-        .pairs()
-        .map(|pair| {
-            pair.to_owned().map(|field| match field {
-                Field::ExpressionKey {
-                    brackets,
-                    key,
-                    equal,
-                    value,
-                } => Field::ExpressionKey {
-                    brackets,
-                    key: format_expression_block(ctx, &key, shape),
-                    equal,
-                    value: format_expression_block(ctx, &value, shape),
-                },
-                Field::NameKey { key, equal, value } => Field::NameKey {
-                    key,
-                    equal,
-                    value: format_expression_block(ctx, &value, shape),
-                },
-                Field::NoKey(expression) => {
-                    Field::NoKey(format_expression_block(ctx, &expression, shape))
-                }
-                other => panic!("unknown node {:?}", other),
-            })
-        })
-        .collect();
-
-    table_constructor.to_owned().with_fields(fields)
-}
-
-fn format_function_args_block(
-    ctx: &Context,
-    function_args: &FunctionArgs,
-    shape: Shape,
-) -> FunctionArgs {
-    match function_args {
-        FunctionArgs::Parentheses {
-            parentheses,
-            arguments,
-        } => FunctionArgs::Parentheses {
-            parentheses: parentheses.to_owned(),
-            arguments: arguments
-                .pairs()
-                .map(|pair| {
-                    pair.to_owned()
-                        .map(|expression| format_expression_block(ctx, &expression, shape))
-                })
-                .collect(),
-        },
-        FunctionArgs::TableConstructor(table_constructor) => FunctionArgs::TableConstructor(
-            format_table_constructor_block(ctx, table_constructor, shape),
-        ),
-        _ => function_args.to_owned(),
-    }
-}
-
-fn format_function_call_block(
-    ctx: &Context,
-    function_call: &FunctionCall,
-    shape: Shape,
-) -> FunctionCall {
-    let prefix = match function_call.prefix() {
-        Prefix::Expression(expression) => {
-            Prefix::Expression(format_expression_block(ctx, expression, shape))
-        }
-        Prefix::Name(name) => Prefix::Name(name.to_owned()),
-        other => panic!("unknown node {:?}", other),
+/// Functions which are used to only format a block within a statement
+/// These are used for range formatting
+pub(crate) mod stmt_block {
+    #[cfg(feature = "lua52")]
+    use crate::formatters::lua52::{format_goto, format_label};
+    #[cfg(feature = "luau")]
+    use crate::formatters::luau::{
+        format_compound_assignment, format_exported_type_declaration, format_type_declaration_stmt,
+        format_type_specifier,
+    };
+    use crate::{context::Context, formatters::block::format_block, shape::Shape};
+    use full_moon::ast::{
+        Call, Expression, Field, FunctionArgs, FunctionCall, Index, Prefix, Stmt, Suffix,
+        TableConstructor, Value,
     };
 
-    let suffixes = function_call
-        .suffixes()
-        .map(|suffix| match suffix {
-            Suffix::Call(call) => Suffix::Call(match call {
-                Call::AnonymousCall(function_args) => {
-                    Call::AnonymousCall(format_function_args_block(ctx, function_args, shape))
-                }
-                Call::MethodCall(method_call) => {
-                    let args = format_function_args_block(ctx, method_call.args(), shape);
-                    Call::MethodCall(method_call.to_owned().with_args(args))
-                }
-                other => panic!("unknown node {:?}", other),
-            }),
-            Suffix::Index(index) => Suffix::Index(match index {
-                Index::Brackets {
-                    brackets,
-                    expression,
-                } => Index::Brackets {
-                    brackets: brackets.to_owned(),
-                    expression: format_expression_block(ctx, expression, shape),
-                },
-                _ => index.to_owned(),
-            }),
-            other => panic!("unknown node {:?}", other),
-        })
-        .collect();
+    fn format_table_constructor_block(
+        ctx: &Context,
+        table_constructor: &TableConstructor,
+        shape: Shape,
+    ) -> TableConstructor {
+        let fields = table_constructor
+            .fields()
+            .pairs()
+            .map(|pair| {
+                pair.to_owned().map(|field| match field {
+                    Field::ExpressionKey {
+                        brackets,
+                        key,
+                        equal,
+                        value,
+                    } => Field::ExpressionKey {
+                        brackets,
+                        key: format_expression_block(ctx, &key, shape),
+                        equal,
+                        value: format_expression_block(ctx, &value, shape),
+                    },
+                    Field::NameKey { key, equal, value } => Field::NameKey {
+                        key,
+                        equal,
+                        value: format_expression_block(ctx, &value, shape),
+                    },
+                    Field::NoKey(expression) => {
+                        Field::NoKey(format_expression_block(ctx, &expression, shape))
+                    }
+                    other => panic!("unknown node {:?}", other),
+                })
+            })
+            .collect();
 
-    function_call
-        .to_owned()
-        .with_prefix(prefix)
-        .with_suffixes(suffixes)
-}
-
-/// Only formats a block within an expression
-pub fn format_expression_block(ctx: &Context, expression: &Expression, shape: Shape) -> Expression {
-    match expression {
-        Expression::BinaryOperator { lhs, binop, rhs } => Expression::BinaryOperator {
-            lhs: Box::new(format_expression_block(ctx, lhs, shape)),
-            binop: binop.to_owned(),
-            rhs: Box::new(format_expression_block(ctx, rhs, shape)),
-        },
-        Expression::Parentheses {
-            contained,
-            expression,
-        } => Expression::Parentheses {
-            contained: contained.to_owned(),
-            expression: Box::new(format_expression_block(ctx, expression, shape)),
-        },
-        Expression::UnaryOperator { unop, expression } => Expression::UnaryOperator {
-            unop: unop.to_owned(),
-            expression: Box::new(format_expression_block(ctx, expression, shape)),
-        },
-        Expression::Value {
-            value,
-            #[cfg(feature = "luau")]
-            type_assertion,
-        } => Expression::Value {
-            value: Box::new(match &**value {
-                Value::Function((function_token, body)) => {
-                    let block = format_block(ctx, body.block(), shape);
-                    Value::Function((function_token.to_owned(), body.to_owned().with_block(block)))
-                }
-                Value::FunctionCall(function_call) => {
-                    Value::FunctionCall(format_function_call_block(ctx, function_call, shape))
-                }
-                Value::TableConstructor(table_constructor) => Value::TableConstructor(
-                    format_table_constructor_block(ctx, table_constructor, shape),
-                ),
-                Value::ParenthesesExpression(expression) => {
-                    Value::ParenthesesExpression(format_expression_block(ctx, expression, shape))
-                }
-                // TODO: var?
-                value => value.to_owned(),
-            }),
-            #[cfg(feature = "luau")]
-            type_assertion: type_assertion.to_owned(),
-        },
-        other => panic!("unknown node {:?}", other),
+        table_constructor.to_owned().with_fields(fields)
     }
-}
 
-/// Only formats a block within the statement
-fn format_stmt_block(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
-    let block_shape = shape.reset().increment_block_indent();
-
-    // TODO: Assignment, FunctionCall, LocalAssignment is funky
-    match stmt {
-        Stmt::Assignment(assignment) => {
-            // TODO: var?
-            let expressions = assignment
-                .expressions()
-                .pairs()
-                .map(|pair| {
-                    pair.to_owned()
-                        .map(|expression| format_expression_block(ctx, &expression, block_shape))
-                })
-                .collect();
-
-            Stmt::Assignment(assignment.to_owned().with_expressions(expressions))
-        }
-        Stmt::Do(do_block) => {
-            let block = format_block(ctx, do_block.block(), block_shape);
-            Stmt::Do(do_block.to_owned().with_block(block))
-        }
-        Stmt::FunctionCall(function_call) => {
-            Stmt::FunctionCall(format_function_call_block(ctx, function_call, block_shape))
-        }
-        Stmt::FunctionDeclaration(function_declaration) => {
-            let block = format_block(ctx, function_declaration.body().block(), block_shape);
-            let body = function_declaration.body().to_owned().with_block(block);
-            Stmt::FunctionDeclaration(function_declaration.to_owned().with_body(body))
-        }
-        Stmt::GenericFor(generic_for) => {
-            let block = format_block(ctx, generic_for.block(), block_shape);
-            Stmt::GenericFor(generic_for.to_owned().with_block(block))
-        }
-        Stmt::If(if_block) => {
-            let block = format_block(ctx, if_block.block(), block_shape);
-            let else_if = if_block.else_if().map(|else_ifs| {
-                else_ifs
-                    .iter()
-                    .map(|else_if| {
-                        else_if.to_owned().with_block(format_block(
-                            ctx,
-                            else_if.block(),
-                            block_shape,
-                        ))
+    fn format_function_args_block(
+        ctx: &Context,
+        function_args: &FunctionArgs,
+        shape: Shape,
+    ) -> FunctionArgs {
+        match function_args {
+            FunctionArgs::Parentheses {
+                parentheses,
+                arguments,
+            } => FunctionArgs::Parentheses {
+                parentheses: parentheses.to_owned(),
+                arguments: arguments
+                    .pairs()
+                    .map(|pair| {
+                        pair.to_owned()
+                            .map(|expression| format_expression_block(ctx, &expression, shape))
                     })
-                    .collect()
-            });
-            let else_block = if_block
-                .else_block()
-                .map(|block| format_block(ctx, block, block_shape));
+                    .collect(),
+            },
+            FunctionArgs::TableConstructor(table_constructor) => FunctionArgs::TableConstructor(
+                format_table_constructor_block(ctx, table_constructor, shape),
+            ),
+            _ => function_args.to_owned(),
+        }
+    }
 
-            Stmt::If(
-                if_block
-                    .to_owned()
-                    .with_block(block)
-                    .with_else_if(else_if)
-                    .with_else(else_block),
-            )
-        }
-        Stmt::LocalAssignment(assignment) => {
-            let expressions = assignment
-                .expressions()
-                .pairs()
-                .map(|pair| {
-                    pair.to_owned()
-                        .map(|expression| format_expression_block(ctx, &expression, block_shape))
-                })
-                .collect();
+    fn format_function_call_block(
+        ctx: &Context,
+        function_call: &FunctionCall,
+        shape: Shape,
+    ) -> FunctionCall {
+        let prefix = match function_call.prefix() {
+            Prefix::Expression(expression) => {
+                Prefix::Expression(format_expression_block(ctx, expression, shape))
+            }
+            Prefix::Name(name) => Prefix::Name(name.to_owned()),
+            other => panic!("unknown node {:?}", other),
+        };
 
-            Stmt::LocalAssignment(assignment.to_owned().with_expressions(expressions))
+        let suffixes = function_call
+            .suffixes()
+            .map(|suffix| match suffix {
+                Suffix::Call(call) => Suffix::Call(match call {
+                    Call::AnonymousCall(function_args) => {
+                        Call::AnonymousCall(format_function_args_block(ctx, function_args, shape))
+                    }
+                    Call::MethodCall(method_call) => {
+                        let args = format_function_args_block(ctx, method_call.args(), shape);
+                        Call::MethodCall(method_call.to_owned().with_args(args))
+                    }
+                    other => panic!("unknown node {:?}", other),
+                }),
+                Suffix::Index(index) => Suffix::Index(match index {
+                    Index::Brackets {
+                        brackets,
+                        expression,
+                    } => Index::Brackets {
+                        brackets: brackets.to_owned(),
+                        expression: format_expression_block(ctx, expression, shape),
+                    },
+                    _ => index.to_owned(),
+                }),
+                other => panic!("unknown node {:?}", other),
+            })
+            .collect();
+
+        function_call
+            .to_owned()
+            .with_prefix(prefix)
+            .with_suffixes(suffixes)
+    }
+
+    /// Only formats a block within an expression
+    pub fn format_expression_block(
+        ctx: &Context,
+        expression: &Expression,
+        shape: Shape,
+    ) -> Expression {
+        match expression {
+            Expression::BinaryOperator { lhs, binop, rhs } => Expression::BinaryOperator {
+                lhs: Box::new(format_expression_block(ctx, lhs, shape)),
+                binop: binop.to_owned(),
+                rhs: Box::new(format_expression_block(ctx, rhs, shape)),
+            },
+            Expression::Parentheses {
+                contained,
+                expression,
+            } => Expression::Parentheses {
+                contained: contained.to_owned(),
+                expression: Box::new(format_expression_block(ctx, expression, shape)),
+            },
+            Expression::UnaryOperator { unop, expression } => Expression::UnaryOperator {
+                unop: unop.to_owned(),
+                expression: Box::new(format_expression_block(ctx, expression, shape)),
+            },
+            Expression::Value {
+                value,
+                #[cfg(feature = "luau")]
+                type_assertion,
+            } => Expression::Value {
+                value: Box::new(match &**value {
+                    Value::Function((function_token, body)) => {
+                        let block = format_block(ctx, body.block(), shape);
+                        Value::Function((
+                            function_token.to_owned(),
+                            body.to_owned().with_block(block),
+                        ))
+                    }
+                    Value::FunctionCall(function_call) => {
+                        Value::FunctionCall(format_function_call_block(ctx, function_call, shape))
+                    }
+                    Value::TableConstructor(table_constructor) => Value::TableConstructor(
+                        format_table_constructor_block(ctx, table_constructor, shape),
+                    ),
+                    Value::ParenthesesExpression(expression) => Value::ParenthesesExpression(
+                        format_expression_block(ctx, expression, shape),
+                    ),
+                    // TODO: var?
+                    value => value.to_owned(),
+                }),
+                #[cfg(feature = "luau")]
+                type_assertion: type_assertion.to_owned(),
+            },
+            other => panic!("unknown node {:?}", other),
         }
-        Stmt::LocalFunction(local_function) => {
-            let block = format_block(ctx, local_function.body().block(), block_shape);
-            let body = local_function.body().to_owned().with_block(block);
-            Stmt::LocalFunction(local_function.to_owned().with_body(body))
+    }
+
+    /// Only formats a block within the statement
+    pub(crate) fn format_stmt_block(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
+        let block_shape = shape.reset().increment_block_indent();
+
+        // TODO: Assignment, FunctionCall, LocalAssignment is funky
+        match stmt {
+            Stmt::Assignment(assignment) => {
+                // TODO: var?
+                let expressions = assignment
+                    .expressions()
+                    .pairs()
+                    .map(|pair| {
+                        pair.to_owned().map(|expression| {
+                            format_expression_block(ctx, &expression, block_shape)
+                        })
+                    })
+                    .collect();
+
+                Stmt::Assignment(assignment.to_owned().with_expressions(expressions))
+            }
+            Stmt::Do(do_block) => {
+                let block = format_block(ctx, do_block.block(), block_shape);
+                Stmt::Do(do_block.to_owned().with_block(block))
+            }
+            Stmt::FunctionCall(function_call) => {
+                Stmt::FunctionCall(format_function_call_block(ctx, function_call, block_shape))
+            }
+            Stmt::FunctionDeclaration(function_declaration) => {
+                let block = format_block(ctx, function_declaration.body().block(), block_shape);
+                let body = function_declaration.body().to_owned().with_block(block);
+                Stmt::FunctionDeclaration(function_declaration.to_owned().with_body(body))
+            }
+            Stmt::GenericFor(generic_for) => {
+                let block = format_block(ctx, generic_for.block(), block_shape);
+                Stmt::GenericFor(generic_for.to_owned().with_block(block))
+            }
+            Stmt::If(if_block) => {
+                let block = format_block(ctx, if_block.block(), block_shape);
+                let else_if = if_block.else_if().map(|else_ifs| {
+                    else_ifs
+                        .iter()
+                        .map(|else_if| {
+                            else_if.to_owned().with_block(format_block(
+                                ctx,
+                                else_if.block(),
+                                block_shape,
+                            ))
+                        })
+                        .collect()
+                });
+                let else_block = if_block
+                    .else_block()
+                    .map(|block| format_block(ctx, block, block_shape));
+
+                Stmt::If(
+                    if_block
+                        .to_owned()
+                        .with_block(block)
+                        .with_else_if(else_if)
+                        .with_else(else_block),
+                )
+            }
+            Stmt::LocalAssignment(assignment) => {
+                let expressions = assignment
+                    .expressions()
+                    .pairs()
+                    .map(|pair| {
+                        pair.to_owned().map(|expression| {
+                            format_expression_block(ctx, &expression, block_shape)
+                        })
+                    })
+                    .collect();
+
+                Stmt::LocalAssignment(assignment.to_owned().with_expressions(expressions))
+            }
+            Stmt::LocalFunction(local_function) => {
+                let block = format_block(ctx, local_function.body().block(), block_shape);
+                let body = local_function.body().to_owned().with_block(block);
+                Stmt::LocalFunction(local_function.to_owned().with_body(body))
+            }
+            Stmt::NumericFor(numeric_for) => {
+                let block = format_block(ctx, numeric_for.block(), block_shape);
+                Stmt::NumericFor(numeric_for.to_owned().with_block(block))
+            }
+            Stmt::Repeat(repeat) => {
+                let block = format_block(ctx, repeat.block(), block_shape);
+                Stmt::Repeat(repeat.to_owned().with_block(block))
+            }
+            Stmt::While(while_block) => {
+                let block = format_block(ctx, while_block.block(), block_shape);
+                Stmt::While(while_block.to_owned().with_block(block))
+            }
+            #[cfg(feature = "luau")]
+            Stmt::CompoundAssignment(compound_assignment) => {
+                let rhs = format_expression_block(ctx, compound_assignment.rhs(), block_shape);
+                Stmt::CompoundAssignment(compound_assignment.to_owned().with_rhs(rhs))
+            }
+            #[cfg(feature = "luau")]
+            Stmt::ExportedTypeDeclaration(node) => Stmt::ExportedTypeDeclaration(node.to_owned()),
+            #[cfg(feature = "luau")]
+            Stmt::TypeDeclaration(node) => Stmt::TypeDeclaration(node.to_owned()),
+            #[cfg(feature = "lua52")]
+            Stmt::Goto(node) => Stmt::Goto(node.to_owned()),
+            #[cfg(feature = "lua52")]
+            Stmt::Label(node) => Stmt::Label(node.to_owned()),
+            other => panic!("unknown node {:?}", other),
         }
-        Stmt::NumericFor(numeric_for) => {
-            let block = format_block(ctx, numeric_for.block(), block_shape);
-            Stmt::NumericFor(numeric_for.to_owned().with_block(block))
-        }
-        Stmt::Repeat(repeat) => {
-            let block = format_block(ctx, repeat.block(), block_shape);
-            Stmt::Repeat(repeat.to_owned().with_block(block))
-        }
-        Stmt::While(while_block) => {
-            let block = format_block(ctx, while_block.block(), block_shape);
-            Stmt::While(while_block.to_owned().with_block(block))
-        }
-        #[cfg(feature = "luau")]
-        Stmt::CompoundAssignment(compound_assignment) => {
-            let rhs = format_expression_block(ctx, compound_assignment.rhs(), block_shape);
-            Stmt::CompoundAssignment(compound_assignment.to_owned().with_rhs(rhs))
-        }
-        #[cfg(feature = "luau")]
-        Stmt::ExportedTypeDeclaration(node) => Stmt::ExportedTypeDeclaration(node.to_owned()),
-        #[cfg(feature = "luau")]
-        Stmt::TypeDeclaration(node) => Stmt::TypeDeclaration(node.to_owned()),
-        #[cfg(feature = "lua52")]
-        Stmt::Goto(node) => Stmt::Goto(node.to_owned()),
-        #[cfg(feature = "lua52")]
-        Stmt::Label(node) => Stmt::Label(node.to_owned()),
-        other => panic!("unknown node {:?}", other),
     }
 }
 
 pub fn format_stmt(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
     if !ctx.should_format_node(stmt) {
-        return format_stmt_block(ctx, stmt, shape);
+        return stmt_block::format_stmt_block(ctx, stmt, shape);
     }
 
     fmt_stmt!(ctx, stmt, shape, {

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -466,13 +466,6 @@ pub fn format_function_call_stmt(
 /// Functions which are used to only format a block within a statement
 /// These are used for range formatting
 pub(crate) mod stmt_block {
-    #[cfg(feature = "lua52")]
-    use crate::formatters::lua52::{format_goto, format_label};
-    #[cfg(feature = "luau")]
-    use crate::formatters::luau::{
-        format_compound_assignment, format_exported_type_declaration, format_type_declaration_stmt,
-        format_type_specifier,
-    };
     use crate::{context::Context, formatters::block::format_block, shape::Shape};
     use full_moon::ast::{
         Call, Expression, Field, FunctionArgs, FunctionCall, Index, Prefix, Stmt, Suffix,

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -6,7 +6,6 @@ use crate::formatters::luau::{
     format_type_specifier,
 };
 use crate::{
-    check_should_format,
     context::{create_indent_trivia, create_newline_trivia, Context},
     fmt_symbol,
     formatters::{
@@ -25,7 +24,8 @@ use crate::{
     shape::Shape,
 };
 use full_moon::ast::{
-    Do, ElseIf, Expression, FunctionCall, GenericFor, If, NumericFor, Repeat, Stmt, Value, While,
+    Call, Do, ElseIf, Expression, Field, FunctionArgs, FunctionCall, GenericFor, If, Index,
+    NumericFor, Prefix, Repeat, Stmt, Suffix, TableConstructor, Value, While,
 };
 use full_moon::tokenizer::{Token, TokenReference, TokenType};
 
@@ -464,8 +464,255 @@ pub fn format_function_call_stmt(
     )
 }
 
+fn format_table_constructor_block(
+    ctx: &Context,
+    table_constructor: &TableConstructor,
+    shape: Shape,
+) -> TableConstructor {
+    let fields = table_constructor
+        .fields()
+        .pairs()
+        .map(|pair| {
+            pair.to_owned().map(|field| match field {
+                Field::ExpressionKey {
+                    brackets,
+                    key,
+                    equal,
+                    value,
+                } => Field::ExpressionKey {
+                    brackets: brackets.to_owned(),
+                    key: format_expression_block(ctx, &key, shape),
+                    equal: equal.to_owned(),
+                    value: format_expression_block(ctx, &value, shape),
+                },
+                Field::NameKey { key, equal, value } => Field::NameKey {
+                    key: key.to_owned(),
+                    equal: equal.to_owned(),
+                    value: format_expression_block(ctx, &value, shape),
+                },
+                Field::NoKey(expression) => {
+                    Field::NoKey(format_expression_block(ctx, &expression, shape))
+                }
+                other => panic!("unknown node {:?}", other),
+            })
+        })
+        .collect();
+
+    table_constructor.to_owned().with_fields(fields)
+}
+
+fn format_function_args_block(
+    ctx: &Context,
+    function_args: &FunctionArgs,
+    shape: Shape,
+) -> FunctionArgs {
+    match function_args {
+        FunctionArgs::Parentheses {
+            parentheses,
+            arguments,
+        } => FunctionArgs::Parentheses {
+            parentheses: parentheses.to_owned(),
+            arguments: arguments
+                .pairs()
+                .map(|pair| {
+                    pair.to_owned()
+                        .map(|expression| format_expression_block(ctx, &expression, shape))
+                })
+                .collect(),
+        },
+        FunctionArgs::TableConstructor(table_constructor) => FunctionArgs::TableConstructor(
+            format_table_constructor_block(ctx, table_constructor, shape),
+        ),
+        _ => function_args.to_owned(),
+    }
+}
+
+fn format_function_call_block(
+    ctx: &Context,
+    function_call: &FunctionCall,
+    shape: Shape,
+) -> FunctionCall {
+    let prefix = match function_call.prefix() {
+        Prefix::Expression(expression) => {
+            Prefix::Expression(format_expression_block(ctx, expression, shape))
+        }
+        Prefix::Name(name) => Prefix::Name(name.to_owned()),
+        other => panic!("unknown node {:?}", other),
+    };
+
+    let suffixes = function_call
+        .suffixes()
+        .map(|suffix| match suffix {
+            Suffix::Call(call) => Suffix::Call(match call {
+                Call::AnonymousCall(function_args) => {
+                    Call::AnonymousCall(format_function_args_block(ctx, function_args, shape))
+                }
+                Call::MethodCall(method_call) => {
+                    let args = format_function_args_block(ctx, method_call.args(), shape);
+                    Call::MethodCall(method_call.to_owned().with_args(args))
+                }
+                other => panic!("unknown node {:?}", other),
+            }),
+            Suffix::Index(index) => Suffix::Index(match index {
+                Index::Brackets {
+                    brackets,
+                    expression,
+                } => Index::Brackets {
+                    brackets: brackets.to_owned(),
+                    expression: format_expression_block(ctx, expression, shape),
+                },
+                _ => index.to_owned(),
+            }),
+            other => panic!("unknown node {:?}", other),
+        })
+        .collect();
+
+    function_call
+        .to_owned()
+        .with_prefix(prefix)
+        .with_suffixes(suffixes)
+}
+
+/// Only formats a block within an expression
+fn format_expression_block(ctx: &Context, expression: &Expression, shape: Shape) -> Expression {
+    match expression {
+        Expression::BinaryOperator { lhs, binop, rhs } => Expression::BinaryOperator {
+            lhs: Box::new(format_expression_block(ctx, lhs, shape)),
+            binop: binop.to_owned(),
+            rhs: Box::new(format_expression_block(ctx, rhs, shape)),
+        },
+        Expression::Parentheses {
+            contained,
+            expression,
+        } => Expression::Parentheses {
+            contained: contained.to_owned(),
+            expression: Box::new(format_expression_block(ctx, expression, shape)),
+        },
+        Expression::UnaryOperator { unop, expression } => Expression::UnaryOperator {
+            unop: unop.to_owned(),
+            expression: Box::new(format_expression_block(ctx, expression, shape)),
+        },
+        Expression::Value { value } => Expression::Value {
+            value: Box::new(match &**value {
+                Value::Function((function_token, body)) => {
+                    let block = format_block(ctx, body.block(), shape);
+                    Value::Function((function_token.to_owned(), body.to_owned().with_block(block)))
+                }
+                Value::FunctionCall(function_call) => {
+                    Value::FunctionCall(format_function_call_block(ctx, &function_call, shape))
+                }
+                Value::TableConstructor(table_constructor) => Value::TableConstructor(
+                    format_table_constructor_block(ctx, &table_constructor, shape),
+                ),
+                Value::ParenthesesExpression(expression) => {
+                    Value::ParenthesesExpression(format_expression_block(ctx, &expression, shape))
+                }
+                // TODO: var?
+                value => value.to_owned(),
+            }),
+        },
+        other => panic!("unknown node {:?}", other),
+    }
+}
+
+/// Only formats a block within the statement
+fn format_stmt_block(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
+    let block_shape = shape.reset().increment_block_indent();
+
+    // TODO: Assignment, FunctionCall, LocalAssignment is funky
+    match stmt {
+        Stmt::Assignment(assignment) => {
+            // TODO: var?
+            let expressions = assignment
+                .expressions()
+                .pairs()
+                .map(|pair| {
+                    pair.to_owned()
+                        .map(|expression| format_expression_block(ctx, &expression, block_shape))
+                })
+                .collect();
+
+            Stmt::Assignment(assignment.to_owned().with_expressions(expressions))
+        }
+        Stmt::Do(do_block) => {
+            let block = format_block(ctx, do_block.block(), block_shape);
+            Stmt::Do(do_block.to_owned().with_block(block))
+        }
+        Stmt::FunctionCall(function_call) => {
+            Stmt::FunctionCall(format_function_call_block(ctx, function_call, block_shape))
+        }
+        Stmt::FunctionDeclaration(function_declaration) => {
+            let block = format_block(ctx, function_declaration.body().block(), block_shape);
+            let body = function_declaration.body().to_owned().with_block(block);
+            Stmt::FunctionDeclaration(function_declaration.to_owned().with_body(body))
+        }
+        Stmt::GenericFor(generic_for) => {
+            let block = format_block(ctx, generic_for.block(), block_shape);
+            Stmt::GenericFor(generic_for.to_owned().with_block(block))
+        }
+        Stmt::If(if_block) => {
+            let block = format_block(ctx, if_block.block(), block_shape);
+            let else_if = if_block.else_if().map(|else_ifs| {
+                else_ifs
+                    .iter()
+                    .map(|else_if| {
+                        else_if.to_owned().with_block(format_block(
+                            ctx,
+                            else_if.block(),
+                            block_shape,
+                        ))
+                    })
+                    .collect()
+            });
+            let else_block = if_block
+                .else_block()
+                .map(|block| format_block(ctx, block, block_shape));
+
+            Stmt::If(
+                if_block
+                    .to_owned()
+                    .with_block(block)
+                    .with_else_if(else_if)
+                    .with_else(else_block),
+            )
+        }
+        Stmt::LocalAssignment(assignment) => {
+            let expressions = assignment
+                .expressions()
+                .pairs()
+                .map(|pair| {
+                    pair.to_owned()
+                        .map(|expression| format_expression_block(ctx, &expression, block_shape))
+                })
+                .collect();
+
+            Stmt::LocalAssignment(assignment.to_owned().with_expressions(expressions))
+        }
+        Stmt::LocalFunction(local_function) => {
+            let block = format_block(ctx, local_function.body().block(), block_shape);
+            let body = local_function.body().to_owned().with_block(block);
+            Stmt::LocalFunction(local_function.to_owned().with_body(body))
+        }
+        Stmt::NumericFor(numeric_for) => {
+            let block = format_block(ctx, numeric_for.block(), block_shape);
+            Stmt::NumericFor(numeric_for.to_owned().with_block(block))
+        }
+        Stmt::Repeat(repeat) => {
+            let block = format_block(ctx, repeat.block(), block_shape);
+            Stmt::Repeat(repeat.to_owned().with_block(block))
+        }
+        Stmt::While(while_block) => {
+            let block = format_block(ctx, while_block.block(), block_shape);
+            Stmt::While(while_block.to_owned().with_block(block))
+        }
+        other => panic!("unknown node {:?}", other),
+    }
+}
+
 pub fn format_stmt(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
-    check_should_format!(ctx, stmt);
+    if !ctx.should_format_node(stmt) {
+        return format_stmt_block(ctx, stmt, shape);
+    }
 
     fmt_stmt!(ctx, stmt, shape, {
         Assignment = format_assignment,

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -183,7 +183,7 @@ end
     @r###"
 
     local my_function  =  function()
-        local nested_statement    =  "foobar"
+    	local nested_statement = "foobar"
     end
     "###);
 }

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -16,15 +16,15 @@ fn test_default() {
     insta::assert_snapshot!(
         format(
             r###"
-local foo     =      bar      
-local bar   =     baz    
+local foo     =      bar
+local bar   =     baz
             "###,
             Range::from_values(Some(0), Some(30))
         ),
         @r###"
     local foo = bar
-    local bar   =     baz    
-                
+    local bar   =     baz
+
     "###
     );
 }
@@ -34,13 +34,13 @@ local bar   =     baz
 fn test_ignore_last_stmt() {
     insta::assert_snapshot!(
         format(
-            r###"function foo() 
+            r###"function foo()
     return bar
 end"###,
             Range::from_values(Some(0), Some(1))
         ),
     @r###"
-    function foo() 
+    function foo()
         return bar
     end
     "###);
@@ -52,8 +52,8 @@ fn test_dont_modify_eof() {
     insta::assert_snapshot!(
         format(
             r###"
-local foo     =      bar      
-local bar   =     baz    
+local foo     =      bar
+local bar   =     baz
 
 
 
@@ -63,12 +63,12 @@ local bar   =     baz
         ),
     @r###"
     local foo = bar
-    local bar   =     baz    
+    local bar   =     baz
 
 
 
 
-                
+
     "###);
 }
 
@@ -83,7 +83,7 @@ fn test_incomplete_range() {
     @r###"
 
     local    fooo =    bar
-                
+
     "###);
 }
 
@@ -106,7 +106,7 @@ bf.Parent = torso end local c2 = player[i].Character:GetChildren()
 for i = 1, #c2 do if c2[i].className == "Part" then
 torso.BF.force = torso.BF.force
 + Vector3.new(0, c2[i]:getMass() * -string.sub(msg, danumber + 1), 0)
-end end end end end end 
+end end end end end end
 
 if string.sub(msg, 1, 5) == "trip/" then local player = findplayer(string.sub(msg, 6), speaker)
 if player ~= 0 then for i = 1, #player do
@@ -164,6 +164,26 @@ end end end end end
     local torso = player[i].Character:FindFirstChild("Torso")
     if torso ~= nil then torso.CFrame = CFrame.new(torso.Position.x, torso.Position.y, torso.Position.z, 0, 0, 1, 0, -1, 0, 1, 0, 0) --math.random(),math.random(),math.random(),math.random(),math.random(),math.random(),math.random(),math.random(),math.random()) -- i like the people being upside down better.
     end end end end end
-                
+
+    "###);
+}
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_nested_range() {
+    insta::assert_snapshot!(
+        format(
+            r###"
+local my_function  =  function()
+    local nested_statement    =  "foobar"
+end
+"###,
+            Range::from_values(Some(33), Some(76))
+        ),
+    @r###"
+
+    local my_function  =  function()
+        local nested_statement    =  "foobar"
+    end
     "###);
 }

--- a/tests/test_ranges.rs
+++ b/tests/test_ranges.rs
@@ -173,8 +173,7 @@ end end end end end
 fn test_nested_range() {
     insta::assert_snapshot!(
         format(
-            r###"
-local my_function  =  function()
+            r###"local my_function  =  function()
     local nested_statement    =  "foobar"
 end
 "###,


### PR DESCRIPTION
This PR re-supports nested blocks when using range formatting.

Previously, we used to format this fine, but after changing from using visitors to formatting blocks within format functions, we stopped being able to format nested blocks if they fall within the range provided for range formatting.

This fixes this again, by changing around `format_stmt` and `format_last_stmt`, to run a `*_block` version if the original Stmt/LastStmt did not fit within the range. In the `*_block` versions, we only format a block if present within the nested range.

Fixes #239 