### PR TITLE
Add v0.10 release version to extension

### DIFF
--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -47,6 +47,7 @@
           "default": "latest",
           "enum": [
             "latest",
+            "v0.10",
             "v0.9",
             "v0.8",
             "v0.7",


### PR DESCRIPTION
Updates the release version setting to include v0.10 releases.