### PR TITLE
Handle looking in `$XDG_CONFIG_HOME` ourselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,26 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,17 +288,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -672,25 +641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
-dependencies = [
- "getrandom",
- "redox_syscall",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,7 +817,6 @@ dependencies = [
  "console",
  "criterion",
  "crossbeam-channel",
- "directories",
  "full_moon",
  "globset",
  "ignore",
@@ -1001,12 +950,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ lua52 = ["full_moon/lua52"]
 anyhow = "1.0.41"
 console = "0.14.1"
 crossbeam-channel = "0.5.1"
-directories = "3.0.2"
 full_moon = { version = "0.13.1" }
 globset = "0.4.8"
 ignore = "0.4.18"

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -85,8 +85,7 @@ fn search_config_locations(verbose: bool) -> Result<Option<Config>> {
         if home_config_path.exists() {
             verbose_println!(verbose, "config: looking in $HOME/.config");
 
-            if let Some(config) = find_config_file(home_config_path.to_path_buf(), false, verbose)?
-            {
+            if let Some(config) = find_config_file(home_config_path.to_owned(), false, verbose)? {
                 return Ok(Some(config));
             }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,7 +1,6 @@
 use crate::opt::Opt;
 use crate::verbose_println;
 use anyhow::{Context, Result};
-use directories::{ProjectDirs, UserDirs};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -28,20 +27,80 @@ fn find_toml_file(directory: &Path) -> Option<PathBuf> {
     None
 }
 
-fn find_config_file(mut directory: PathBuf, recursive: bool) -> Result<Option<Config>> {
+/// Looks for a configuration file in the directory provided (and its parent's recursively, if specified)
+fn find_config_file(
+    mut directory: PathBuf,
+    recursive: bool,
+    verbose: bool,
+) -> Result<Option<Config>> {
+    verbose_println!(
+        verbose,
+        "config: looking for config in {}",
+        directory.display()
+    );
     let config_file = find_toml_file(&directory);
     match config_file {
-        Some(file_path) => read_config_file(&file_path).map(Some),
+        Some(file_path) => {
+            verbose_println!(verbose, "config: found config at {}", file_path.display());
+            read_config_file(&file_path).map(Some)
+        }
         None => {
             // Both don't exist, search up the tree if necessary
             // directory.pop() mutates the path to get its parent, and returns false if no more parent
             if recursive && directory.pop() {
-                find_config_file(directory, recursive)
+                find_config_file(directory, recursive, verbose)
             } else {
                 Ok(None)
             }
         }
     }
+}
+
+/// Looks for a configuration file at either `$XDG_CONFIG_HOME`, `$XDG_CONFIG_HOME/stylua`, `$HOME/.config` or `$HOME/.config/stylua`
+fn search_config_locations(verbose: bool) -> Result<Option<Config>> {
+    // Look in `$XDG_CONFIG_HOME`
+    if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
+        let xdg_config_path = Path::new(&xdg_config);
+        if xdg_config_path.exists() {
+            verbose_println!(verbose, "config: looking in $XDG_CONFIG_HOME");
+
+            if let Some(config) = find_config_file(xdg_config_path.to_path_buf(), false, verbose)? {
+                return Ok(Some(config));
+            }
+
+            verbose_println!(verbose, "config: looking in $XDG_CONFIG_HOME/stylua");
+            let xdg_config_path = xdg_config_path.join("stylua");
+            if xdg_config_path.exists() {
+                if let Some(config) = find_config_file(xdg_config_path, false, verbose)? {
+                    return Ok(Some(config));
+                }
+            }
+        }
+    }
+
+    // Look in `$HOME/.config`
+    if let Ok(home) = std::env::var("HOME") {
+        let home_config_path = Path::new(&home).join(".config");
+
+        if home_config_path.exists() {
+            verbose_println!(verbose, "config: looking in $HOME/.config");
+
+            if let Some(config) = find_config_file(home_config_path.to_path_buf(), false, verbose)?
+            {
+                return Ok(Some(config));
+            }
+
+            verbose_println!(verbose, "config: looking in $HOME/.config/stylua");
+            let home_config_path = home_config_path.join("stylua");
+            if home_config_path.exists() {
+                if let Some(config) = find_config_file(home_config_path, false, verbose)? {
+                    return Ok(Some(config));
+                }
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 pub fn load_config(opt: &Opt) -> Result<Config> {
@@ -68,7 +127,7 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
                 current_dir.display(),
                 opt.search_parent_directories
             );
-            let config = find_config_file(current_dir, opt.search_parent_directories)?;
+            let config = find_config_file(current_dir, opt.search_parent_directories, opt.verbose)?;
             match config {
                 Some(config) => Ok(config),
                 None => {
@@ -76,24 +135,8 @@ pub fn load_config(opt: &Opt) -> Result<Config> {
 
                     // Search the configuration directory for a file, if necessary
                     if opt.search_parent_directories {
-                        // Look in `$HOME/.config/stylua`
-                        verbose_println!(opt.verbose, "config: looking in $HOME/.config/stylua");
-                        if let Some(project_dirs) = ProjectDirs::from("", "", "stylua") {
-                            if let Some(config) =
-                                find_config_file(project_dirs.config_dir().to_path_buf(), false)?
-                            {
-                                return Ok(config);
-                            }
-                        }
-
-                        // Look in `$HOME/.config`
-                        verbose_println!(opt.verbose, "config: looking in $HOME/.config");
-                        if let Some(user_dirs) = UserDirs::new() {
-                            if let Some(config) =
-                                find_config_file(user_dirs.home_dir().to_path_buf(), false)?
-                            {
-                                return Ok(config);
-                            }
+                        if let Some(config) = search_config_locations(opt.verbose)? {
+                            return Ok(config);
                         }
                     }
 


### PR DESCRIPTION
The directories crate doesn't handle it like we want it to (on macOS).
The crate isn't really needed anyways

Fixes #260