### PR TITLE
Fix unstable formatting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed config locations (`$XDG_CONFIG_HOME` and `$HOME/.config`) not being looked into correctly on macOS when `--search-parent-directories` is used. ([#260](https://github.com/JohnnyMorganz/StyLua/issues/260))
 - Fixed incorrect indentation of multiline type specifiers for function parameters under the `luau` feature flag. ([#256](https://github.com/JohnnyMorganz/StyLua/issues/256))
 - Fixed unstable formatting caused by a singleline table which just reaches the column width. ([#261](https://github.com/JohnnyMorganz/StyLua/issues/261))
+- Fixed misformatting of a binop expression as precedence of the RHS expression was not taken into account. ([#257](https://github.com/JohnnyMorganz/StyLua/issues/257), [#261](https://github.com/JohnnyMorganz/StyLua/issues/261)) 
 
 ## [0.10.1] - 2021-08-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ignore file present in cwd not taken into account if cwd not included in file paths to format. ([#249](https://github.com/JohnnyMorganz/StyLua/issues/249))
 - Fixed config locations (`$XDG_CONFIG_HOME` and `$HOME/.config`) not being looked into correctly on macOS when `--search-parent-directories` is used. ([#260](https://github.com/JohnnyMorganz/StyLua/issues/260))
 - Fixed incorrect indentation of multiline type specifiers for function parameters under the `luau` feature flag. ([#256](https://github.com/JohnnyMorganz/StyLua/issues/256))
+- Fixed unstable formatting caused by a singleline table which just reaches the column width. ([#261](https://github.com/JohnnyMorganz/StyLua/issues/261))
 
 ## [0.10.1] - 2021-08-08
 ### Fixed

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -360,7 +360,7 @@ pub fn format_table_constructor(
                 start_brace.token().end_position().bytes(),
                 end_brace.token().start_position().bytes(),
             );
-            let singleline_shape = shape + (braces_range.1 - braces_range.0);
+            let singleline_shape = shape + (braces_range.1 - braces_range.0) + 4; // 4 = two braces + single space before/after them
 
             match singleline_shape.over_budget() {
                 true => TableType::MultiLine,

--- a/tests/inputs/hang-binop-rhs-precendence.lua
+++ b/tests/inputs/hang-binop-rhs-precendence.lua
@@ -1,0 +1,46 @@
+local function findMoney()
+	for _, existingObject in pairs(workspace:GetChildren()) do
+		if
+			existingObject:GetAttribute("MoneyID") == targetCash.id
+			and existingObject.Name == targetName .. ".money"
+		then
+			break
+		end
+	end
+end
+
+do
+	do
+		do
+			do
+				do
+					do
+						do
+							function Venue:inspectElectrics(inspectElectricParams)
+								local id, pedal, fendererID =
+									inspectElectricParams.id,
+									inspectElectricParams.pedal,
+									inspectElectricParams.rendererID
+								local fenderer = self._fendererInterfaces[fendererID]
+
+								if fenderer == nil then
+									logger.warn(('Invalid fenderer id "%s" for Electric "%s"'):format(fendererID, id))
+								else
+									self._chorus:send("inspectedElectric", renderer.inspectElectric(id, pedal))
+
+									-- When rocker selects an Electric, stop trying to frobnikate the pyramids,
+									-- and instead recall the present songs for the next venue.
+									if
+										self._nexusstedSelectionBatch == nil or self._nexusstedSelectionBatch.id
+											~= id
+									then
+									end
+							  end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/tests/inputs/table-4.lua
+++ b/tests/inputs/table-4.lua
@@ -1,0 +1,1 @@
+local thisisathing = {this_is_one = "one", this_is_two = "two", this_is_three = "three", this_is_four = "four", f = "b"}

--- a/tests/snapshots/tests__standard@hang-binop-rhs-precendence.lua.snap
+++ b/tests/snapshots/tests__standard@hang-binop-rhs-precendence.lua.snap
@@ -1,0 +1,52 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+local function findMoney()
+	for _, existingObject in pairs(workspace:GetChildren()) do
+		if
+			existingObject:GetAttribute("MoneyID") == targetCash.id
+			and existingObject.Name == targetName .. ".money"
+		then
+			break
+		end
+	end
+end
+
+do
+	do
+		do
+			do
+				do
+					do
+						do
+							function Venue:inspectElectrics(inspectElectricParams)
+								local id, pedal, fendererID =
+									inspectElectricParams.id,
+									inspectElectricParams.pedal,
+									inspectElectricParams.rendererID
+								local fenderer = self._fendererInterfaces[fendererID]
+
+								if fenderer == nil then
+									logger.warn(('Invalid fenderer id "%s" for Electric "%s"'):format(fendererID, id))
+								else
+									self._chorus:send("inspectedElectric", renderer.inspectElectric(id, pedal))
+
+									-- When rocker selects an Electric, stop trying to frobnikate the pyramids,
+									-- and instead recall the present songs for the next venue.
+									if
+										self._nexusstedSelectionBatch == nil
+										or self._nexusstedSelectionBatch.id ~= id
+									then
+									end
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end
+

--- a/tests/snapshots/tests__standard@table-4.lua.snap
+++ b/tests/snapshots/tests__standard@table-4.lua.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+local thisisathing =
+	{
+		this_is_one = "one",
+		this_is_two = "two",
+		this_is_three = "three",
+		this_is_four = "four",
+		f = "b",
+	}
+

--- a/tests/snapshots/tests__standard@table-4.lua.snap
+++ b/tests/snapshots/tests__standard@table-4.lua.snap
@@ -3,12 +3,11 @@ source: tests/tests.rs
 expression: format(&contents)
 
 ---
-local thisisathing =
-	{
-		this_is_one = "one",
-		this_is_two = "two",
-		this_is_three = "three",
-		this_is_four = "four",
-		f = "b",
-	}
+local thisisathing = {
+	this_is_one = "one",
+	this_is_two = "two",
+	this_is_three = "three",
+	this_is_four = "four",
+	f = "b",
+}
 


### PR DESCRIPTION
Fixes #261 (OP) - caused by a singleline table just hitting the column width, with initially no spaces between braces. We did not correctly calculate the column width in this case.

Fixes #257 - for the top-level binop expression, we did not take into account whether we hung the RHS of the expression and its precedence level. This led to an asymmetric formatting, which did not look as nice. This was also presented as a comment in #261 leading to unstable formatting.