### PR TITLE
Fix whitespace causing overhanging on first pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed indentation of type callback specifier parameters when parameters have leading comment trivia. ([#278](https://github.com/JohnnyMorganz/StyLua/issues/278))
 - Fixed trailing comma not being taken into account when determining the width of a field in a multiline table. ([#282](https://github.com/JohnnyMorganz/StyLua/issues/282))
 - Fixed `--num-threads 1` causing a deadlock. ([#281](https://github.com/JohnnyMorganz/StyLua/issues/281))
+- Fixed whitespace around parts of a binary expression causing it to over-hang in first pass, leading to unstable formatting. ([#287](https://github.com/JohnnyMorganz/StyLua/issues/287))
 
 ## [0.11.0] - 2021-09-16
 ### Changed

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -420,17 +420,17 @@ fn binop_expression_length(expression: &Expression, top_binop: &BinOp) -> usize 
                 if binop.is_right_associative() {
                     binop_expression_length(rhs, top_binop)
                         + strip_trivia(binop).to_string().len() + 2 // 2 = space before and after binop
-                        + lhs.to_string().len()
+                        + strip_trivia(&**lhs).to_string().len()
                 } else {
                     binop_expression_length(lhs, top_binop)
                         + strip_trivia(binop).to_string().len() + 2 // 2 = space before and after binop
-                        + rhs.to_string().len()
+                        + strip_trivia(&**rhs).to_string().len()
                 }
             } else {
                 0
             }
         }
-        _ => expression.to_string().len(),
+        _ => strip_trivia(expression).to_string().len(),
     }
 }
 

--- a/tests/inputs/multiline-expressions-5.lua
+++ b/tests/inputs/multiline-expressions-5.lua
@@ -1,0 +1,9 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/287: whitespace around tokens causes inconsistency
+local foo = {
+	getTileProps = function(tile)
+		local result = {
+			adId = not GetFFlagLuaAppAddUniverseIdToGameImpress()         and           (tile.props.entry and tile.props.entry.adId)
+				or nil,
+		}
+	end,
+}

--- a/tests/snapshots/tests__standard@multiline-expressions-5.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-expressions-5.lua.snap
@@ -1,0 +1,15 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/287: whitespace around tokens causes inconsistency
+local foo = {
+	getTileProps = function(tile)
+		local result = {
+			adId = not GetFFlagLuaAppAddUniverseIdToGameImpress() and (tile.props.entry and tile.props.entry.adId)
+				or nil,
+		}
+	end,
+}
+


### PR DESCRIPTION
Large portions of whitespace around expressions in a BinaryExpression caused an initial formatting pass to overhang the multiline expression. Running a second pass would then reduce the hanging - this meant 2 passes to get a stable formatting.

This PR strips trivia before calculating lengths to determine whether to hang. This means in the first pass we will immediately get the final, stable, formatting.

Fixes #287 