### PR TITLE
Fix leading whitespace in singleline arguments preserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Fixed spaces around brackets string (`[[string]]`) used as an index or table key (i.e. `[ [[string]] ]`) being removed, leading to a syntax error. ([#293](https://github.com/JohnnyMorganz/StyLua/issues/293))
+- Fixed newlines before arguments in a function call which is later formatted on a single line being preserved, leading to inconsistent formatting. ([#290](https://github.com/JohnnyMorganz/StyLua/issues/290))
 
 ## [0.11.1] - 2021-11-08
 ### Changed

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -441,7 +441,7 @@ pub fn format_function_args(
                 // this can be removed.
                 for argument in arguments.pairs_mut() {
                     let expression = argument.value_mut();
-                    let trivia = trivia_util::get_expression_leading_trivia(&expression)
+                    let trivia = trivia_util::get_expression_leading_trivia(expression)
                         .iter()
                         .skip_while(|trivia| trivia_util::trivia_is_whitespace(trivia))
                         .map(|x| x.to_owned())

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -431,8 +431,24 @@ pub fn format_function_args(
                 let shape_increment = if hug_table_constructor { 2 } else { 1 };
 
                 let parentheses = format_contained_span(ctx, parentheses, shape);
-                let arguments =
+                let mut arguments =
                     format_punctuated(ctx, arguments, shape + shape_increment, format_expression);
+
+                // HACK: if there was more than one newline before each argument, then it will be incorrectly preserved
+                // leading to weird formatting (https://github.com/JohnnyMorganz/StyLua/issues/290#issuecomment-964428535)
+                // We get around this (badly) by reformatting each argument to remove leading newlines from them.
+                // TODO(#169): once a proper fix to https://github.com/JohnnyMorganz/StyLua/issues/169 is solved
+                // this can be removed.
+                for argument in arguments.pairs_mut() {
+                    let expression = argument.value_mut();
+                    let trivia = trivia_util::get_expression_leading_trivia(&expression)
+                        .iter()
+                        .skip_while(|trivia| trivia_util::trivia_is_whitespace(trivia))
+                        .map(|x| x.to_owned())
+                        .collect();
+                    *expression =
+                        expression.update_leading_trivia(FormatTriviaType::Replace(trivia));
+                }
 
                 FunctionArgs::Parentheses {
                     parentheses,

--- a/tests/inputs/function-call-argument-leading-trivia.lua
+++ b/tests/inputs/function-call-argument-leading-trivia.lua
@@ -1,0 +1,30 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/290
+local foo = foo(
+
+	foo,
+
+	bar
+)
+
+local foo = foo(
+	foo,
+
+	bar
+)
+
+return function()
+	call(function()
+		local abortSelfPromise = abortSelf(
+			function()
+				return Promise.resolve(true)
+			end,
+
+			function()
+				return Promise.new(function(newResolve)
+					resolve = newResolve
+				end)
+			end
+		)
+	end)
+end
+

--- a/tests/snapshots/tests__standard@function-call-argument-leading-trivia.lua.snap
+++ b/tests/snapshots/tests__standard@function-call-argument-leading-trivia.lua.snap
@@ -1,0 +1,22 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/290
+local foo = foo(foo, bar)
+
+local foo = foo(foo, bar)
+
+return function()
+	call(function()
+		local abortSelfPromise = abortSelf(function()
+			return Promise.resolve(true)
+		end, function()
+			return Promise.new(function(newResolve)
+				resolve = newResolve
+			end)
+		end)
+	end)
+end
+


### PR DESCRIPTION
Temporarily Fixes #290 
Note: #169 is the underlying cause - once this is fixed (which is quite hard), this hack can be removed.