### PR TITLE
Fix comments preceding commas in function call/definition syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed comments preceding a comma within a function call or parameter list for a function definition being mistransformed leading to a syntax error. ([#307](https://github.com/JohnnyMorganz/StyLua/issues/307))
 
 ## [0.11.2] - 2021-11-15
 ### Fixed

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -398,18 +398,24 @@ pub fn format_function_args(
                         ctx, shape,
                     )]));
 
+                    // Take any trailing trivia (i.e. comments) from the argument, and append it to the end of the punctuation
+                    let (formatted_argument, mut trailing_comments) =
+                        trivia_util::take_expression_trailing_comments(&formatted_argument);
+
                     let punctuation = match argument.punctuation() {
                         Some(punctuation) => {
                             // Continue adding a comma and a new line for multiline function args
+                            // Also add any trailing comments we have taken from the expression
+                            trailing_comments.push(create_newline_trivia(ctx));
                             let symbol = fmt_symbol!(ctx, punctuation, ",", shape)
-                                .update_trailing_trivia(FormatTriviaType::Append(vec![
-                                    create_newline_trivia(ctx),
-                                ]));
+                                .update_trailing_trivia(FormatTriviaType::Append(
+                                    trailing_comments,
+                                ));
 
                             Some(symbol)
                         }
                         None => Some(TokenReference::new(
-                            vec![],
+                            trailing_comments,
                             create_newline_trivia(ctx),
                             vec![],
                         )),

--- a/tests/inputs/function-call-comments-2.lua
+++ b/tests/inputs/function-call-comments-2.lua
@@ -1,0 +1,5 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/307#issuecomment-980594322
+call(
+	param_a -- this is cool
+	, param_b
+)

--- a/tests/inputs/function-def-comments.lua
+++ b/tests/inputs/function-def-comments.lua
@@ -1,0 +1,4 @@
+function func(
+	param_a -- description of a
+	, param_b -- description of b
+) end

--- a/tests/snapshots/tests__standard@function-call-comments-2.lua.snap
+++ b/tests/snapshots/tests__standard@function-call-comments-2.lua.snap
@@ -1,0 +1,11 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/307#issuecomment-980594322
+call(
+	param_a, -- this is cool
+	param_b
+)
+

--- a/tests/snapshots/tests__standard@function-def-comments.lua.snap
+++ b/tests/snapshots/tests__standard@function-def-comments.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+
+---
+function func(
+	param_a, -- description of a
+	param_b -- description of b
+) end
+


### PR DESCRIPTION
This led to a syntax error

Fixes #307 