### PR TITLE
Fix overaddition of leading whitespace to if expression

### DIFF
--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -355,16 +355,17 @@ fn format_if_expression(
     _shape: Shape,
 ) -> IfExpression {
     // TODO: Apply actual formatting here
-    // because we are just returning as-is, we need to remove the trailing whitespace trivia if present, otherwise stuff
-    // gets weird (https://github.com/JohnnyMorganz/StyLua/issues/297)
+    // because we are just returning as-is, we need to remove leading/trailing whitespace trivia if present, otherwise stuff
+    // gets weird (https://github.com/JohnnyMorganz/StyLua/issues/297, https://github.com/JohnnyMorganz/StyLua/issues/315)
 
+    let if_token = strip_leading_trivia(if_expression.if_token());
     let (else_expression, trailing_comments) =
         trivia_util::take_expression_trailing_comments(if_expression.else_expression());
 
     let else_expression =
         else_expression.update_trailing_trivia(FormatTriviaType::Replace(trailing_comments));
 
-    if_expression.to_owned().with_else(else_expression)
+    if_expression.to_owned().with_if_token(if_token).with_else(else_expression)
 }
 
 /// Formats a Value Node

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -365,7 +365,10 @@ fn format_if_expression(
     let else_expression =
         else_expression.update_trailing_trivia(FormatTriviaType::Replace(trailing_comments));
 
-    if_expression.to_owned().with_if_token(if_token).with_else(else_expression)
+    if_expression
+        .to_owned()
+        .with_if_token(if_token)
+        .with_else(else_expression)
 }
 
 /// Formats a Value Node

--- a/tests/inputs-luau/if-expression-3.lua
+++ b/tests/inputs-luau/if-expression-3.lua
@@ -9,3 +9,9 @@ end)
 Autocomplete = function(player)
     return { if player then player.Name else nil }
 end
+
+-- https://github.com/JohnnyMorganz/StyLua/issues/315
+Function:Function(
+	if self.props.True:FindFirstChild("Testttttttttttttttttttt") then self.props.True else self.props.False,
+	0
+)

--- a/tests/snapshots/tests__luau@if-expression-3.lua.snap
+++ b/tests/snapshots/tests__luau@if-expression-3.lua.snap
@@ -15,3 +15,9 @@ Autocomplete = function(player)
 	return { if player then player.Name else nil }
 end
 
+-- https://github.com/JohnnyMorganz/StyLua/issues/315
+Function:Function(
+	if self.props.True:FindFirstChild("Testttttttttttttttttttt") then self.props.True else self.props.False,
+	0
+)
+

--- a/tests/snapshots/tests__luau@if-expression.lua.snap
+++ b/tests/snapshots/tests__luau@if-expression.lua.snap
@@ -9,7 +9,7 @@ do
 			do
 				console.error(
 					"guitarFuzz design functions accept exactly two parameters: guiter and fuzz. %s",
-								if argumentCount == 1 then "Did you forget to use the fuzz parameter?" else "Any additional parameter will be undefined."
+					if argumentCount == 1 then "Did you forget to use the fuzz parameter?" else "Any additional parameter will be undefined."
 				)
 			end
 		end


### PR DESCRIPTION
This is a temporary fix, since we are not yet formatting if-expressions fully, we are just leaving them as-is.
Without this, we over add leading whitespace (related: #297 #301)
Fixes #315 