### PR TITLE
Switch pre-commit language to Rust so pre-commit can build StyLua from source

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
   name: StyLua
   description: An opinionated Lua code formatter
   entry: stylua
-  language: system
+  language: rust
   types:
     - lua


### PR DESCRIPTION
The previous pre-commit config required having StyLua already installed. With this patch, pre-commit is responsible for building its own StyLua.