### PR TITLE
Add a system hook for people who don't have the rust toolchain

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,6 +11,6 @@
   name: StyLua (system)
   description: An opinionated Lua code formatter
   entry: stylua
-  language: rust
+  language: system
   types:
     - lua

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,14 @@
 ---
 - id: stylua
-  name: StyLua
+  name: StyLua (cargo)
+  description: An opinionated Lua code formatter
+  entry: stylua
+  language: rust
+  types:
+    - lua
+
+- id: stylua-system
+  name: StyLua (system)
   description: An opinionated Lua code formatter
   entry: stylua
   language: rust


### PR DESCRIPTION
This PR will add back the option for a `system` pre-commit hook. Otherwise every update will require cargo and the rust tool chain, which some Lua developers may not have and may prefer to install their own binary.

One downside to `system` hooks is that the version tag is really irrelevant as it won't update the checker.

Another option would be to do something like this: https://github.com/shellcheck-py/shellcheck-py and provide a wrapper. This example uses Python to manage the download and installation. Since this person has put this in it's own repo, they are hard coding the version and sha's.

I'm tempted to write a Python package that can accept a git repo as an argument and then it will download the release using repo metadata (reading `Cargo.toml`) and then execute that binary. This would be helpful, not just for StyLua, but any statically compiled checkers that have dependencies.