### PR TITLE
Adds a new version of the hook to download releases

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,8 +15,8 @@
   types:
     - lua
 
-- id: stylua-release
-  name: StyLua Release
+- id: stylua-github
+  name: StyLua (Github)
   description: An opinionated Lua code formatter. Downloads Github release
   entry: stylua
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,3 +14,11 @@
   language: system
   types:
     - lua
+
+- id: stylua-release
+  name: StyLua Release
+  description: An opinionated Lua code formatter. Downloads Github release
+  entry: stylua
+  language: python
+  types:
+    - lua

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["release-gitter[builder]"]
+build-backend = "pseudo_builder"
+
+[tool.release-gitter]
+extract-files = [ "stylua" ]
+format = "stylua-{version}-{system}.zip"
+exec = "chmod +x stylua"
+[tool.release-gitter.map-system]
+    Darwin = "macos"
+    Windows = "win64"
+    Linux = "linux"


### PR DESCRIPTION
This version will auto download the current release from Github and then
run that instead of looking at system or compiling with cargo. It should
be fast and transparent for users.

I've found myself wanting to do thing similar to this more than once with pre-commit as well as generally wanting to automate downloading of releases from Github or Gitea in other scripts, so I wrote something to make this happen. The Python package [`release-gitter`](https://git.iamthefij.com/iamthefij/release-gitter) allows downloading releases based on a file template and detecting the current os and arch.

What this looks like in a project like `StyLua` is a `pyproject.toml` file that tells `pip` (the installer that pre-commit uses) that this repo is a Python package. It uses a custom package builder that calls `release-gitter` to, instead of bundling a bunch of Python files, downloads the specified `StyLua` release from Github and bundles that instead.

The `pyproject.toml` is where `release-gitter` is configured.

At the top, `[build-system]` is the part where we tell it to use `release-gitter` and the `pseudo_builder`.

In `[tool.release-gitter]` we specify the arguments to be passed to `release-gitter`. For `StyLua` these are pretty simple. We list the file to extract from the zip, the format template for identifying the zip we weant, an exec command to make `stylua` executable once downloaded, and then a map that maps `platform.system()` names to the system names used in the `StyLua` assets.

It gets everything else from either `git remote` or `Cargo.toml`.