### PR TITLE
Preserve trailing comments when removing parens in function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed misformatting of conditions in if-expression syntax leading to spurious whitespace under the `luau` feature flag. ([#349](https://github.com/JohnnyMorganz/StyLua/issues/349))
 - Fixed incorrect shape calculation in if-expression syntax: if-expression will now go multiline when only slightly over column width (`luau` feature flag).
 - Fixed incorrect handling of comments at the end of a callback type's arguments under the `luau` feature flag. ([#352](https://github.com/JohnnyMorganz/StyLua/issues/352))
+- Fixed trailing comments of a function call being lost as parentheses are removed around a single argument when `call_parentheses` is set to not `Always`. ([#356](https://github.com/JohnnyMorganz/StyLua/issues/356))
 
 ## [0.12.0] - 2022-01-31
 ### Added

--- a/tests/test_call_parentheses.rs
+++ b/tests/test_call_parentheses.rs
@@ -296,3 +296,17 @@ local opt = my_function({
     "###
     );
 }
+
+#[test]
+#[cfg_attr(feature = "luau", ignore)]
+fn test_call_parens_comments() {
+    insta::assert_snapshot!(
+        format(CallParenType::None,
+            r###"
+foo("hello") -- comment
+"###
+        ),
+        @r###"foo "hello" -- comment
+"###
+    );
+}

--- a/tests/test_call_parentheses.rs
+++ b/tests/test_call_parentheses.rs
@@ -307,6 +307,6 @@ foo("hello") -- comment
 "###
         ),
         @r###"foo "hello" -- comment
-"###
+    "###
     );
 }


### PR DESCRIPTION
Fixes #356 