### PR TITLE
Automate test case retrieval

### DIFF
--- a/.github/retrieve_test_cases.py
+++ b/.github/retrieve_test_cases.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+
+FULL_MOON_CLONE = "git clone https://github.com/Kampfkarren/full-moon.git"
+FULL_MOON_LUA_TESTS_DIRS = "./full-moon/full-moon/tests/cases/pass"
+FULL_MOON_LUAU_TESTS_DIR = "./full-moon/full-moon/tests/roblox_cases/pass"
+
+FULL_MOON_LUA_OUTPUT = "./tests/inputs-full_moon"
+FULL_MOON_LUAU_OUTPUT = "./tests/inputs-luau-full_moon"
+
+# Clone the relevant repositories
+os.system(FULL_MOON_CLONE)
+
+# Create test outputs if not present
+os.makedirs(FULL_MOON_LUA_OUTPUT, exist_ok=True)
+os.makedirs(FULL_MOON_LUAU_OUTPUT, exist_ok=True)
+
+# Clear old tests
+def delete_children(directory):
+    for root, dirs, files in os.walk(directory):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))
+
+delete_children(FULL_MOON_LUA_OUTPUT)
+delete_children(FULL_MOON_LUAU_OUTPUT)
+
+# Copy new tests
+def copy_test_files(input, output):
+    for test in os.listdir(input):
+        source_file = os.path.join(input, test, "source.lua")
+        shutil.copyfile(source_file, os.path.join(output, f"{test}.lua"))
+
+copy_test_files(FULL_MOON_LUA_TESTS_DIRS, FULL_MOON_LUA_OUTPUT)
+copy_test_files(FULL_MOON_LUAU_TESTS_DIR, FULL_MOON_LUAU_OUTPUT)
+
+# Cleanup the cloned repositories
+shutil.rmtree("./full-moon", ignore_errors=True)

--- a/.github/workflows/test-cases.yml
+++ b/.github/workflows/test-cases.yml
@@ -1,0 +1,26 @@
+name: Pull Latest Test Cases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "10 0 * * *" # Runs at 00:10 UTC every day
+
+jobs:
+  retrieve_cases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Pull latest tests
+        run: python ./.github/retrieve_test_cases.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3.12.1
+        with:
+          title: Update external test cases
+          body: |
+            Pulls in new changes from external repositories for test cases
+            - This pull request is **auto-generated**
+            - Note: **snapshots have not been updated**. You must manually update snapshots for the updated test cases
+          branch: auto/update-external-test-cases
+          commit-message: Update external test cases
+          base: main


### PR DESCRIPTION
This PR adds automated test case updating from external sources.
It can be triggered through a workflow dispatch event, or every day at 00:20 UTC.

Currently, it pulls in latest test cases from full-moon.
Hopefully, this will improve our test suite and help catch any errors.