### PR TITLE
extension: Ignore version in asset name matching

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To view the changelog of the StyLua binary, see [here](https://github.com/JohnnyMorganz/StyLua/blob/master/CHANGELOG.md)
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 
 - Updated release version setting to include v0.12.
+- Changed the pattern match for downloading a stylua binary to ignore a version present in the name - in future stylua releases the version may no longer be included in the name.
 
 ## [1.3.1] - 2021-11-19
 

--- a/stylua-vscode/src/test/suite/util.test.ts
+++ b/stylua-vscode/src/test/suite/util.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "assert";
+import { getAssetFilenamePatternForPlatform } from "../../util";
+
+suite("Utilities testing", () => {
+  test("asset filename pattern matches name with version", () => {
+    const pattern = getAssetFilenamePatternForPlatform("win32");
+    assert(pattern.test("stylua-0.12.2-win64.zip"));
+  });
+
+  test("asset filename pattern matches name without version", () => {
+    const pattern = getAssetFilenamePatternForPlatform("win32");
+    assert(pattern.test("stylua-win64.zip"));
+  });
+
+  test("asset filename pattern does not match for wrong platform", () => {
+    const pattern = getAssetFilenamePatternForPlatform("win32");
+    assert.strictEqual(pattern.test("stylua-linux.zip"), false);
+  });
+});

--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -15,17 +15,23 @@ export const getDownloadOutputFilename = () => {
   }
 };
 
-export const getAssetFilenamePattern = () => {
-  switch (os.platform()) {
+export const getAssetFilenamePatternForPlatform = (
+  platform: NodeJS.Platform
+) => {
+  switch (platform) {
     case "win32":
-      return /stylua-[\d\w\-\.]+-win64.zip/;
+      return /stylua(-[\d\w\-\.]+)?-win64.zip/;
     case "linux":
-      return /stylua-[\d\w\-\.]+-linux.zip/;
+      return /stylua(-[\d\w\-\.]+)?-linux.zip/;
     case "darwin":
-      return /stylua-[\d\w\-\.]+-macos.zip/;
+      return /stylua(-[\d\w\-\.]+)?-macos.zip/;
     default:
       throw new Error("Platform not supported");
   }
+};
+
+export const getAssetFilenamePattern = () => {
+  return getAssetFilenamePatternForPlatform(os.platform());
 };
 
 export const getDesiredVersion = (): string => {


### PR DESCRIPTION
Ignores the version specified in an asset name. This will be important when we no longer include versions in names for #343 