### PR TITLE
Migrate to clap v3 with new help messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Migrate internal dependency for CLI arguments handling, with improved help messages.
+
+
 ## [0.12.5] - 2022-03-08
 ### Fixed
 - Fixed crashed due to unhandled generic type packs under the `luau` feature flag. ([#403](https://github.com/JohnnyMorganz/StyLua/issues/403))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,13 +99,39 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -146,7 +163,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools",
@@ -353,12 +370,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -509,6 +523,15 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "paste"
@@ -849,33 +872,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "stylua"
@@ -883,6 +882,7 @@ version = "0.12.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "clap 3.1.6",
  "console",
  "criterion",
  "crossbeam-channel",
@@ -897,7 +897,6 @@ dependencies = [
  "regex",
  "serde",
  "similar",
- "structopt",
  "threadpool",
  "toml",
 ]
@@ -911,6 +910,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -937,6 +945,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"
@@ -982,12 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,12 +1006,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lua52 = ["full_moon/lua52"]
 
 [dependencies]
 anyhow = "1.0.53"
+clap = { version = "3.1.6", features = ["derive"] }
 console = "0.15.0"
 crossbeam-channel = "0.5.2"
 env_logger = { version = "0.9.0", default-features = false }
@@ -38,7 +39,6 @@ num_cpus = "1.13.1"
 regex = "1.5.4"
 serde = "1.0.136"
 similar = { version = "2.1.0", features = ["text", "inline"] }
-structopt = "0.3.26"
 threadpool = "1.8.1"
 toml = "0.5.8"
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -167,12 +167,12 @@ pub fn load_overrides(config: Config, opt: &Opt) -> Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use structopt::StructOpt;
+    use clap::StructOpt;
     use stylua_lib::{CallParenType, IndentType, LineEndings, QuoteStyle};
 
     #[test]
     fn test_override_column_width() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--column-width", "80"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--column-width", "80"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.column_width(), 80);
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_override_line_endings() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--line-endings", "Windows"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--line-endings", "Windows"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.line_endings(), LineEndings::Windows);
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_override_indent_type() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--indent-type", "Spaces"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--indent-type", "Spaces"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.indent_type(), IndentType::Spaces);
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_override_indent_width() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--indent-width", "2"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--indent-width", "2"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.indent_width(), 2);
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_override_quote_style() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--quote-style", "ForceSingle"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--quote-style", "ForceSingle"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.quote_style(), QuoteStyle::ForceSingle);
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_override_call_parentheses() {
-        let override_opt = Opt::from_iter(vec!["BINARY_NAME", "--call-parentheses", "None"]);
+        let override_opt = Opt::parse_from(vec!["BINARY_NAME", "--call-parentheses", "None"]);
         let default_config = Config::new();
         let config = load_overrides(default_config, &override_opt);
         assert_eq!(config.call_parentheses(), CallParenType::None);

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use clap::StructOpt;
 use console::style;
 use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use log::{LevelFilter, *};
@@ -8,7 +9,6 @@ use std::path::Path;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use structopt::StructOpt;
 use threadpool::ThreadPool;
 
 use stylua_lib::{format_code, Config, OutputVerification, Range};
@@ -282,7 +282,7 @@ fn format(opt: opt::Opt) -> Result<i32> {
 }
 
 fn main() {
-    let opt = opt::Opt::from_args();
+    let opt = opt::Opt::parse();
     let should_use_color = opt.color.should_use_color_stderr();
     let level_filter = if opt.verbose {
         LevelFilter::Debug

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -15,38 +15,43 @@ pub struct Opt {
 
     /// Specify the location of the file that is being passed into stdin.
     /// Ignored if not taking in input from stdin.
+    ///
     /// This option is only used to help determine where to find the configuration file.
     #[structopt(long = "stdin-filepath", parse(from_os_str))]
     pub stdin_filepath: Option<PathBuf>,
 
     /// Search parent directories for stylua.toml, if not found in current directory.
     /// Ignored if config_path is provided.
+    ///
     /// Keeps searching recursively up the parent directory tree, until the root directory is reached.
     /// If not found, looks in $XDG_CONFIG_HOME or $XDG_CONFIG_HOME/stylua.
     #[structopt(short, long)]
     pub search_parent_directories: bool,
 
     /// Runs in 'check' mode.
+    ///
     /// Exits with 0 if all formatting is OK,
     /// Exits with 1 if the formatting is incorrect.
     /// Any files input will not be overwritten.
     #[structopt(short, long)]
     pub check: bool,
 
-    /// Verify the output after formatting.
+    /// Verifies the output after formatting.
+    ///
     /// Checks the generated AST with the original AST to detect if code correctness has changed.
     #[structopt(long)]
     pub verify: bool,
 
-    /// Whether to print out verbose output
+    /// Enables verbose output
     #[structopt(short, long)]
     pub verbose: bool,
 
-    // Whether the output should include terminal colour or not
+    /// Whether the output should include terminal colour or not
     #[structopt(long, possible_values = &Color::variants(), case_insensitive = true, default_value = "auto")]
     pub color: Color,
 
     /// Any glob patterns to test against which files to check.
+    ///
     /// To ignore a specific glob pattern, begin the glob pattern with `!`
     #[structopt(short, long)]
     pub glob: Option<Vec<String>>,


### PR DESCRIPTION
Structopt has been deprecated, migrating to clap v3.
Main features:
- help output now has colours
- help output is better spaced to be easier to read
- formatting options are now in a separate subheading in the help output

<details>
<summary>Old help message</summary>

```
stylua 0.12.5
A utility to format Lua code

USAGE:
    stylua.exe [FLAGS] [OPTIONS] [--] [files]...

FLAGS:
    -c, --check                        Runs in 'check' mode. Exits with 0 if all formatting is OK, Exits with 1 if the
                                       formatting is incorrect. Any files input will not be overwritten
    -h, --help                         Prints help information
    -s, --search-parent-directories    Search parent directories for stylua.toml, if not found in current directory.
                                       Ignored if config_path is provided. Keeps searching recursively up the parent
                                       directory tree, until the root directory is reached. If not found, looks in
                                       $XDG_CONFIG_HOME or $XDG_CONFIG_HOME/stylua
    -V, --version                      Prints version information
    -v, --verbose                      Whether to print out verbose output
        --verify                       Verify the output after formatting. Checks the generated AST with the original
                                       AST to detect if code correctness has changed

OPTIONS:
        --call-parentheses <call-parentheses>
            Specify whether to apply parentheses on function calls with signle string or table arg [possible values:
            Always, NoSingleString, NoSingleTable, None]
        --color <color>                           [default: auto]  [possible values: Always, Auto, Never]
        --column-width <column-width>            The column width to use to attempt to wrap lines
    -f, --config-path <config-path>              Specify path to stylua.toml configuration file
    -g, --glob <glob>...
            Any glob patterns to test against which files to check. To ignore a specific glob pattern, begin the glob
            pattern with `!`
        --indent-type <indent-type>              The type of indents to use [possible values: Tabs, Spaces]
        --indent-width <indent-width>            The width of a single indentation level
        --line-endings <line-endings>            The type of line endings to use [possible values: Unix, Windows]
        --num-threads <num-threads>
            The number of threads to use to format files in parallel. Defaults to the number of logical cores on your
            system [default: 12]
        --quote-style <quote-style>
            The style of quotes to use in string literals [possible values: AutoPreferDouble, AutoPreferSingle,
            ForceDouble, ForceSingle]
        --range-end <range-end>
            An ending range to format files, given as a byte offset from the beginning of the file. Any content after
            this value will be ignored
        --range-start <range-start>
            A starting range to format files, given as a byte offset from the beginning of the file. Any content before
            this value will be ignored
        --stdin-filepath <stdin-filepath>
            Specify the location of the file that is being passed into stdin. Ignored if not taking in input from stdin.
            This option is only used to help determine where to find the configuration file

ARGS:
    <files>...    A list of files to format

```
</details>

<details>
<summary>New help message</summary>

```
stylua 0.12.5
A utility to format Lua code

USAGE:
    stylua.exe [OPTIONS] [FILES]...

ARGS:
    <FILES>...
            A list of files to format

OPTIONS:
    -c, --check
            Runs in 'check' mode.
            
            Compares a diff between all input files to determine if they are formatted. Exits with 0
            if all formatting is OK, Exits with 1 if any formatting is incorrect, outputting file
            diffs. Any files input will not be overwritten.

        --color <COLOR>
            Use colored output
            
            [default: Auto]
            [possible values: Always, Auto, Never]

    -f, --config-path <CONFIG_PATH>
            Specify path to stylua.toml configuration file.
            
            If not provided, defaults to looking in the current directory for a configuration file.

    -g, --glob <GLOB>
            Glob patterns to test against which files to check.
            
            To ignore a specific glob pattern, begin the glob pattern with `!`

    -h, --help
            Print help information

        --num-threads <NUM_THREADS>
            The number of threads to use to format files in parallel.
            
            Defaults to the number of logical cores on your system.
            
            [default: 12]

        --range-end <RANGE_END>
            An ending range to format files, given as a byte offset from the beginning of the file.
            
            Any content after this value will be ignored.

        --range-start <RANGE_START>
            A starting range to format files, given as a byte offset from the beginning of the file.
            
            Any content before this value will be ignored.

    -s, --search-parent-directories
            Search parent directories for stylua.toml, if not found in current directory. Ignored if
            config_path is provided.
            
            Keeps searching recursively up the parent directory tree, until the root directory is
            reached. If not found, looks in $XDG_CONFIG_HOME or $XDG_CONFIG_HOME/stylua.

        --stdin-filepath <STDIN_FILEPATH>
            Specify the location of the file that is being passed into stdin. Ignored if not taking
            in input from stdin.
            
            This option is only used to help determine where to find the configuration file.

    -v, --verbose
            Enables verbose output

    -V, --version
            Print version information

        --verify
            Verifies the output correctness after formatting.
            
            Checks the generated AST with the original AST to detect if code correctness has
            changed.

FORMATTING OPTIONS:
        --call-parentheses <CALL_PARENTHESES>
            Specify whether to apply parentheses on function calls with signle string or table arg
            
            [possible values: Always, NoSingleString, NoSingleTable, None]

        --column-width <COLUMN_WIDTH>
            The column width to use to attempt to wrap lines

        --indent-type <INDENT_TYPE>
            The type of indents to use
            
            [possible values: Tabs, Spaces]

        --indent-width <INDENT_WIDTH>
            The width of a single indentation level

        --line-endings <LINE_ENDINGS>
            The type of line endings to use
            
            [possible values: Unix, Windows]

        --quote-style <QUOTE_STYLE>
            The style of quotes to use in string literals
            
            [possible values: AutoPreferDouble, AutoPreferSingle, ForceDouble, ForceSingle]
```
</details>