### PR TITLE
Add support for alternative diff outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for alternative diff outputs. You can now use `--output-format=unified` or `--output-format=json` to output a unified diff or json mismatches list respectively. A unified diff can be fed into other tools such as `patch` or `delta`, whilst a JSON diff provides a more machine readable format useful for extensions.
+
 ### Changed
 - Migrate internal dependency for CLI arguments handling, with improved help messages.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -441,6 +441,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -834,11 +840,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -860,6 +866,9 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smol_str"
@@ -896,6 +905,7 @@ dependencies = [
  "num_cpus",
  "regex",
  "serde",
+ "serde_json",
  "similar",
  "threadpool",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ log = "0.4.14"
 num_cpus = "1.13.1"
 regex = "1.5.4"
 serde = "1.0.136"
-similar = { version = "2.1.0", features = ["text", "inline"] }
+serde_json = "1.0.79"
+similar = { version = "2.1.0", features = ["text", "inline", "serde"] }
 threadpool = "1.8.1"
 toml = "0.5.8"
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -109,6 +109,11 @@ fn format(opt: opt::Opt) -> Result<i32> {
         bail!("no files provided");
     }
 
+    // Check for incompatible options
+    if !opt.check && !matches!(opt.output_format, opt::OutputFormat::Standard) {
+        bail!("--output-format can only be used when --check is enabled");
+    }
+
     // Load the configuration
     let config = config::load_config(&opt)?;
 

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -39,6 +39,12 @@ pub struct Opt {
     #[structopt(short, long)]
     pub check: bool,
 
+    /// Configures the diff output when using 'check' mode.
+    ///
+    /// This option is ignored if 'check' is not enabled.
+    #[structopt(long, arg_enum, ignore_case = true, default_value_t = OutputFormat::Standard)]
+    pub output_format: OutputFormat,
+
     /// Verifies the output correctness after formatting.
     ///
     /// Checks the generated AST with the original AST to detect if code correctness has changed.
@@ -121,6 +127,17 @@ impl Color {
             }
         }
     }
+}
+
+#[derive(ArgEnum, Clone, Copy, Debug)]
+#[clap(rename_all = "PascalCase")]
+pub enum OutputFormat {
+    /// Outputs using the standard inbuilt pretty-diff design
+    Standard,
+    /// Outputs using unified diff formatting
+    Unified,
+    /// Outputs in json
+    Json,
 }
 
 #[derive(StructOpt, Debug)]


### PR DESCRIPTION
This PR adds support for alternative diff outputs. Currently, it defaults to the "standard" output, which uses the current in-built prettier diff viewer.

The following support has been added:
- `--output-format=unified`. Unified diff output, useful to feed into tools like `patch` or `delta` (ref: #312)
- `--output-format=json`. Json mismatches list, useful for machine-readable usecases like extensions

Closes #230