### PR TITLE
Hug generic for when expression is function call with single table arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Migrate internal dependency for CLI arguments handling, with improved help messages.
 - Type declarations consisting of unions/intersections where an inner type has a multiline comment will now force hanging
+- Generic fors will no longer expand onto multiple lines if the expression looping over is a function call with a single table argument (e.g., `ipairs({ ... })`) ([#405](https://github.com/JohnnyMorganz/StyLua/issues/405))
 
 ## [0.12.5] - 2022-03-08
 ### Fixed

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -104,7 +104,6 @@ fn hug_generic_for(expressions: &Punctuated<Expression>) -> bool {
                 // Ensure is function call
                 Value::FunctionCall(function_call) => {
                     let mut suffixes = function_call.suffixes();
-
                     match suffixes.next() {
                         // Ensure atleast one suffix
                         Some(suffix) => match suffixes.next() {

--- a/tests/inputs/generic-for-hug.lua
+++ b/tests/inputs/generic-for-hug.lua
@@ -25,6 +25,39 @@ end
 
 -- These cases should not hug:
 do
+	for _,v in ipairs({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) -- comment
+	do
+	end
+end
+
+do
+	for _,v in ipairs(foo and {
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	} or bar)
+	do
+	end
+end
+
+do
+	for _,v in call(function()
+		return { test, another }
+	end) do
+	end
+end
+
+do
 	for _,v in call({
 		Kind.SELECTION_sET,
 		Kind.DIRECTIVE,

--- a/tests/inputs/generic-for-hug.lua
+++ b/tests/inputs/generic-for-hug.lua
@@ -1,0 +1,12 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/405
+do
+	for _,v in ipairs({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) do
+	end
+end

--- a/tests/inputs/generic-for-hug.lua
+++ b/tests/inputs/generic-for-hug.lua
@@ -10,3 +10,93 @@ do
 	}) do
 	end
 end
+
+do
+	for _,v in ipairs {
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	} do
+	end
+end
+
+-- These cases should not hug:
+do
+	for _,v in call({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}), anotherThing do
+	end
+end
+
+do
+	for _,v in call({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}, "failure case") do
+	end
+end
+
+do
+	for _,v in call({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	})(true) do
+	end
+end
+
+do
+	for _,v in x.y.z.call({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) do
+	end
+end
+
+do
+	for _,v in foo and call({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) or otherCall() do
+	end
+end
+
+do
+	for _,v in (foo({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) or true) do
+	end
+end
+
+do
+	for _,v in "thissssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" do
+	end
+end

--- a/tests/snapshots/tests__standard@generic-for-hug.lua.snap
+++ b/tests/snapshots/tests__standard@generic-for-hug.lua.snap
@@ -17,3 +17,108 @@ do
 	end
 end
 
+do
+	for _, v in ipairs({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) do
+	end
+end
+
+-- These cases should not hug:
+do
+	for _, v in
+		call({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		}),
+		anotherThing
+	do
+	end
+end
+
+do
+	for _, v in
+		call({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		}, "failure case")
+	do
+	end
+end
+
+do
+	for _, v in
+		call({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		})(true)
+	do
+	end
+end
+
+do
+	for _, v in
+		x.y.z.call({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		})
+	do
+	end
+end
+
+do
+	for _, v in
+		foo and call({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		}) or otherCall()
+	do
+	end
+end
+
+do
+	for _, v in
+		(foo({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		}) or true)
+	do
+	end
+end
+
+do
+	for _, v in
+		"thissssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss"
+	do
+	end
+end
+

--- a/tests/snapshots/tests__standard@generic-for-hug.lua.snap
+++ b/tests/snapshots/tests__standard@generic-for-hug.lua.snap
@@ -32,6 +32,43 @@ end
 -- These cases should not hug:
 do
 	for _, v in
+		ipairs({
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		}) -- comment
+	do
+	end
+end
+
+do
+	for _, v in
+		ipairs(foo and {
+			Kind.SELECTION_sET,
+			Kind.DIRECTIVE,
+			Kind.OEPRATION_DEFINITION,
+			Kind.INLINE_FRAGMENT,
+			Kind.FRAGMENT_DEFINITION,
+			Kind.ARGUMENT,
+		} or bar)
+	do
+	end
+end
+
+do
+	for _, v in
+		call(function()
+			return { test, another }
+		end)
+	do
+	end
+end
+
+do
+	for _, v in
 		call({
 			Kind.SELECTION_sET,
 			Kind.DIRECTIVE,

--- a/tests/snapshots/tests__standard@generic-for-hug.lua.snap
+++ b/tests/snapshots/tests__standard@generic-for-hug.lua.snap
@@ -1,0 +1,19 @@
+---
+source: tests/tests.rs
+assertion_line: 12
+expression: format(&contents)
+
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/405
+do
+	for _, v in ipairs({
+		Kind.SELECTION_sET,
+		Kind.DIRECTIVE,
+		Kind.OEPRATION_DEFINITION,
+		Kind.INLINE_FRAGMENT,
+		Kind.FRAGMENT_DEFINITION,
+		Kind.ARGUMENT,
+	}) do
+	end
+end
+


### PR DESCRIPTION
Attempts to handle the common case of
```lua
for _, x in ipairs({
    a,
    b,
}) do
end
```

Closes #405