### PR TITLE
Reset RHS expression shape when hanging at binop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed leading trivia on semicolon lost when semicolon is removed ([#431](https://github.com/JohnnyMorganz/StyLua/issues/431))
+- Fixed shape calculation of the RHS of a binary expression not correctly reset when hanging, causing it to expand unnecessarily ([#432](https://github.com/JohnnyMorganz/StyLua/issues/432))
 
 ## [0.13.0] - 2022-03-31
 ### Added

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -978,6 +978,8 @@ fn hang_binop_expression(
     shape: Shape,
     lhs_range: Option<LeftmostRangeHang>,
 ) -> Expression {
+    const SPACE_LEN: usize = " ".len();
+
     let full_expression = expression.to_owned();
 
     match expression {
@@ -1018,7 +1020,8 @@ fn hang_binop_expression(
             let (lhs, rhs) = match should_hang {
                 true => {
                     let lhs_shape = shape;
-                    let rhs_shape = shape + strip_trivia(&new_binop).to_string().len() + 1;
+                    let rhs_shape =
+                        shape.reset() + strip_trivia(&new_binop).to_string().len() + SPACE_LEN;
 
                     let (lhs, rhs) = match side_to_hang {
                         ExpressionSide::Left => (

--- a/tests/inputs/multiline-expressions-6.lua
+++ b/tests/inputs/multiline-expressions-6.lua
@@ -1,0 +1,22 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/432: shape was not correctly reset for the new line of hanging expression
+local function test()
+	return "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. foo(long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa())
+end

--- a/tests/snapshots/tests__standard@multiline-expressions-6.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-expressions-6.lua.snap
@@ -1,0 +1,29 @@
+---
+source: tests/tests.rs
+assertion_line: 12
+expression: format(&contents)
+
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/432: shape was not correctly reset for the new line of hanging expression
+local function test()
+	return "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. "test"
+		.. foo(long_function_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa())
+end
+


### PR DESCRIPTION
It caused the calculation to be incorrect, with a ghost offset present inside the shape, causing the RHS expression to expand unnecessarily

Fixes #432 