### PR TITLE
Statically link linux build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,3 @@ rustflags = [
     "-C",
     "link-args=/NODEFAULTLIB:libucrt.lib /NODEFAULTLIB:libucrtd.lib /NODEFAULTLIB:ucrtd.lib",
 ]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,6 @@ rustflags = [
     "-C",
     "link-args=/NODEFAULTLIB:libucrt.lib /NODEFAULTLIB:libucrtd.lib /NODEFAULTLIB:ucrtd.lib",
 ]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
         submodules: true
 
     - name: Build (All features)
-      run: cargo build --locked --verbose --release --all-features
+      run: cargo build --locked --verbose --release --all-features --target x86_64-unknown-linux-gnu
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: stylua-linux
-        path: target/release/stylua
+        path: target/x86_64-unknown-linux-gnu/release/stylua
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         submodules: true
 
     - name: Build (All features)
-      run: cargo build --locked --verbose --release --all-features --target x86_64-unknown-linux-gnu
+      run: RUSTFLAGS='-C target-feature=+crt-static' cargo build --locked --verbose --release --all-features --target x86_64-unknown-linux-gnu
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
stylua's linux build fails to run on Ubuntu 18:
```
./stylua: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by ./stylua)
```

One oddity was that `--target` must be passed explicitly, as documented by this [blog post](https://msfjarvis.dev/posts/building-static-rust-binaries-for-linux/)
