### PR TITLE
Sort requires codemod

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 mod context;
 mod formatters;
 mod shape;
+mod sort_requires;
 mod verify_ast;
 
 /// The type of indents to use when indenting
@@ -283,6 +284,13 @@ pub fn format_code(
         Some(input_ast.to_owned())
     } else {
         None
+    };
+
+    // If we want to sort requires, we should firstly apply this on the input ast
+    // TODO: connect to option
+    let input_ast = match true {
+        true => sort_requires::sort_requires(input_ast),
+        false => input_ast,
     };
 
     let code_formatter = formatters::CodeFormatter::new(config, range);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub struct Config {
     /// if call_parentheses is set to [`CallParenType::None`] call parentheses is omitted when
     /// function is called with only one table or string argument (same as no_call_parentheses).
     call_parentheses: CallParenType,
+
+    sort_requires: bool, // TODO: probably separate this out into a different section entirely? so toml looks like [sort_requires] enabled = true
 }
 
 impl Config {
@@ -159,6 +161,10 @@ impl Config {
     /// Returns the current configured call parentheses style
     pub fn call_parentheses(&self) -> CallParenType {
         self.call_parentheses
+    }
+
+    pub fn sort_requires(&self) -> bool {
+        self.sort_requires
     }
 
     /// Returns a new config with the given column width
@@ -215,6 +221,13 @@ impl Config {
             ..self
         }
     }
+
+    pub fn with_sort_requires(self, sort_requires: bool) -> Self {
+        Self {
+            sort_requires,
+            ..self
+        }
+    }
 }
 
 impl Default for Config {
@@ -227,6 +240,7 @@ impl Default for Config {
             quote_style: QuoteStyle::default(),
             no_call_parentheses: false,
             call_parentheses: CallParenType::default(),
+            sort_requires: false,
         }
     }
 }
@@ -288,7 +302,7 @@ pub fn format_code(
 
     // If we want to sort requires, we should firstly apply this on the input ast
     // TODO: connect to option
-    let input_ast = match true {
+    let input_ast = match config.sort_requires {
         true => sort_requires::sort_requires(input_ast),
         false => input_ast,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 mod context;
 mod formatters;
 mod shape;
-mod sort_requires;
+pub mod sort_requires;
 mod verify_ast;
 
 /// The type of indents to use when indenting

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@ pub struct Config {
     /// function is called with only one table or string argument (same as no_call_parentheses).
     call_parentheses: CallParenType,
 
-    sort_requires: bool, // TODO: probably separate this out into a different section entirely? so toml looks like [sort_requires] enabled = true
+    /// Configuration for the sort requires codemod
+    sort_requires: sort_requires::SortRequiresConfig,
 }
 
 impl Config {
@@ -163,7 +164,8 @@ impl Config {
         self.call_parentheses
     }
 
-    pub fn sort_requires(&self) -> bool {
+    /// Returns the current sort requires codemod configuration
+    pub fn sort_requires(&self) -> sort_requires::SortRequiresConfig {
         self.sort_requires
     }
 
@@ -222,7 +224,8 @@ impl Config {
         }
     }
 
-    pub fn with_sort_requires(self, sort_requires: bool) -> Self {
+    /// Returns a new config with the given sort requires configuration
+    pub fn with_sort_requires(self, sort_requires: sort_requires::SortRequiresConfig) -> Self {
         Self {
             sort_requires,
             ..self
@@ -240,7 +243,7 @@ impl Default for Config {
             quote_style: QuoteStyle::default(),
             no_call_parentheses: false,
             call_parentheses: CallParenType::default(),
-            sort_requires: false,
+            sort_requires: sort_requires::SortRequiresConfig::default(),
         }
     }
 }
@@ -302,7 +305,7 @@ pub fn format_code(
 
     // If we want to sort requires, we should firstly apply this on the input ast
     // TODO: connect to option
-    let input_ast = match config.sort_requires {
+    let input_ast = match config.sort_requires.enabled() {
         true => sort_requires::sort_requires(input_ast),
         false => input_ast,
     };

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -13,7 +13,7 @@
 //!     - We then leave one line gap, and include all the requires (in a sorted order)
 //!     - Requires are sectioned by the variables that they rely on
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use full_moon::{
     ast::{
@@ -125,40 +125,66 @@ fn is_require_assignment(assignment: &LocalAssignment) -> bool {
         && parse_require_function(extract_assignment_expression(assignment)).is_some()
 }
 
-fn find_dependency_names(requires: &[&StmtSemicolon]) -> HashSet<String> {
-    let mut set = HashSet::new();
+fn create_map_from_assignments(block: &Block) -> HashMap<String, &StmtSemicolon> {
+    let mut map = HashMap::new();
 
-    for (require, _) in requires {
-        let expression = extract_assignment_expression(extract_local_assignment(require));
-        let argument = match parse_require_function(expression) {
-            Some(FunctionArgs::String(_)) => continue, // A string require cannot have any dependencies
-            Some(FunctionArgs::TableConstructor(_)) => todo!("require of a table"),
-            Some(FunctionArgs::Parentheses { arguments, .. }) => arguments.iter().next().unwrap(),
-            _ => unreachable!(),
-        };
-
-        let dependency = match argument {
-            Expression::Value { value, .. } => {
-                match &**value {
-                    Value::String(_) => continue, // A string require cannot have any dependencies
-                    Value::Var(var) => match var {
-                        Var::Name(token) => name_from_token(token.token_type()),
-                        Var::Expression(var_expression) => match var_expression.prefix() {
-                            Prefix::Name(token) => name_from_token(token.token_type()),
-                            _ => todo!("non-standard require expression"),
-                        },
-                        other => unreachable!("unknown node: {:?}", other),
-                    },
-                    _ => todo!("non-standard require expression"),
+    for stmt_semicolon in block.stmts_with_semicolon() {
+        match &stmt_semicolon.0 {
+            Stmt::LocalAssignment(assignment) => {
+                // TODO: should we map multi assignments?
+                for name in assignment.names() {
+                    map.insert(name_from_token(name.token_type()), stmt_semicolon);
                 }
             }
-            _ => todo!("non-standard require expression"),
-        };
-
-        set.insert(dependency);
+            _ => continue,
+        }
     }
 
-    set
+    map
+}
+
+fn find_dependency_name(stmt: &StmtSemicolon) -> Option<String> {
+    match &stmt.0 {
+        Stmt::LocalAssignment(assignment) => {
+            // TODO: handle multi expression?
+            if let Some(expression) = assignment.expressions().iter().next() {
+                // Handle if its a require function
+                let expression = match parse_require_function(expression) {
+                    Some(FunctionArgs::String(_)) => return None, // A string require cannot have any dependencies
+                    Some(FunctionArgs::TableConstructor(_)) => todo!("require of a table"),
+                    Some(FunctionArgs::Parentheses { arguments, .. }) => {
+                        arguments.iter().next().unwrap()
+                    }
+                    Some(other) => unreachable!("unknown node: {:?}", other),
+                    None => expression,
+                };
+
+                let dependency = match expression {
+                    Expression::Value { value, .. } => {
+                        match &**value {
+                            Value::String(_) => return None, // A string require cannot have any dependencies
+                            Value::Var(var) => match var {
+                                Var::Name(token) => name_from_token(token.token_type()),
+                                Var::Expression(var_expression) => match var_expression.prefix() {
+                                    Prefix::Name(token) => name_from_token(token.token_type()),
+                                    _ => todo!("non-standard dependency"),
+                                },
+                                other => unreachable!("unknown node: {:?}", other),
+                            },
+                            _ => todo!("non-standard dependency"),
+                        }
+                    }
+                    _ => todo!("non-standard dependency"),
+                };
+
+                Some(dependency)
+            } else {
+                None
+            }
+        }
+
+        _ => todo!("non-local assignment dependency"),
+    }
 }
 
 fn is_dependency(stmt: &Stmt, dependency_names: &HashSet<String>) -> bool {
@@ -179,10 +205,30 @@ fn find_requires(
     Vec<&StmtSemicolon>,
     Vec<&StmtSemicolon>,
 ) {
+    let assignment_map = create_map_from_assignments(block);
+
+    // Partition into require statements and the remaining statements
     let (requires, remainders): (Vec<_>, _) = block.stmts_with_semicolon().partition(|stmt| matches!(&stmt.0, Stmt::LocalAssignment(assignment) if is_require_assignment(assignment)));
 
+    // Find all the dependency variables from the list of remaining statements
+    // We need to continuously search the list to find all the statements (i.e., local a = __, local b = a.x, local c = require(b.y) : both a and b are dependencies)
+    let mut dependency_names = HashSet::new();
+    let mut search_stack = requires.clone();
+    while let Some(element) = search_stack.pop() {
+        let dependency_name = find_dependency_name(element);
+        if let Some(dependency_name) = dependency_name {
+            dependency_names.insert(dependency_name.clone());
+
+            // Climb up to look for any more dependencies
+            // TODO: we should structure this so that we can topo-sort
+            let dependency_stmt = assignment_map.get(&dependency_name);
+            if let Some(dependency_stmt) = dependency_stmt {
+                search_stack.push(dependency_stmt);
+            }
+        }
+    }
+
     // From the remaining statements, find all the assignments which a require is dependent on
-    let dependency_names = find_dependency_names(requires.as_slice());
     let (dependencies, remainders) = remainders
         .iter()
         .partition(|stmt| is_dependency(&stmt.0, &dependency_names));

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -1,0 +1,120 @@
+//! Sort Requires CodeMod
+//! This is an optional extension which will firstly sort all requires within a file before formatting the file
+//!
+//! The following assumptions are made when using this codemod:
+//! - All requires are pure and have no side effects: resorting the requires is not an issue
+//! - Only requires at the top level block are to be sorted
+//! - Requires are of the form `local NAME = require(REQUIRE)`, with only a single require per local assignment
+//!
+//! Particular cases to consider:
+//! - Requires based on other variables (e.g., `require(ReplicatedStorage.Module)`)
+//!     - We firstly find all variables that have an impact on the require
+//!     - We then list all these variables beforehand, in a sorted order
+//!     - We then leave one line gap, and include all the requires (in a sorted order)
+//!     - Requires are sectioned by the variables that they rely on
+
+use full_moon::{
+    ast::{
+        Ast, Block, Call, Expression, FunctionArgs, LocalAssignment, Prefix, Stmt, Suffix, Value,
+    },
+    tokenizer::{TokenReference, TokenType},
+};
+
+type StmtSemicolon = (Stmt, Option<TokenReference>);
+
+/// Takes in an input AST, and applies the sort requires codemod to output a new AST
+pub fn sort_requires(input_ast: Ast) -> Ast {
+    let block = input_ast.nodes();
+
+    // Find all the requires in the code
+    let mut requires = find_requires(block);
+
+    // Exit early if no requires present
+    if requires.0.is_empty() {
+        return input_ast;
+    }
+
+    // TODO: find dependents and place them in a section beforehand
+
+    // Sort all requires
+    requires.0.sort_by_key(|assignment| {
+        name_from_token(
+            extract_local_assignment(&assignment.0)
+                .names()
+                .iter()
+                .next()
+                .expect("local assignment with no names")
+                .token_type(),
+        )
+    });
+
+    // Rewrite the requires into the AST, at the beginning of the block
+    let new_stmts = rewrite_requires(requires.0, requires.1);
+    let new_block = block.to_owned().with_stmts(new_stmts);
+
+    input_ast.with_nodes(new_block)
+}
+
+/// Extracts a name from an identifier.
+/// Errors if a non identifier is provided
+fn name_from_token(token: &TokenType) -> String {
+    match token {
+        TokenType::Identifier { identifier } => identifier.to_string(),
+        _ => unreachable!("attempted to get a name from non-identifier token"),
+    }
+}
+
+/// Extracts a [`LocalAssignment`] from a [`Stmt`].
+/// Errors if a provided [`Stmt`] is not a [`LocalAssignment`]
+fn extract_local_assignment(stmt: &Stmt) -> &LocalAssignment {
+    match stmt {
+        Stmt::LocalAssignment(assignment) => assignment,
+        _ => unreachable!("attempt to extract non-localassignment from stmt"),
+    }
+}
+
+/// Verifies whether the provided [`Expression`] is in require form (i.e. `require(arg)`).
+/// Returns the `arg` part of the require expression.
+fn parse_require_function(expression: &Expression) -> Option<&FunctionArgs> {
+    if let Expression::Value { value, .. } = expression {
+        if let Value::FunctionCall(function_call) = &**value {
+            if let Prefix::Name(name) = function_call.prefix() {
+                if name.to_string() == "require" {
+                    if let Some(Suffix::Call(Call::AnonymousCall(function_args))) =
+                        function_call.suffixes().next()
+                    {
+                        if function_call.suffixes().count() == 1 {
+                            return Some(function_args);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Determines whether the provided [`LocalAssignment`] is a require assignment.
+/// i.e., of the form `local NAME = require(ARG)`
+fn is_require_assignment(assignment: &LocalAssignment) -> bool {
+    let expressions = assignment.expressions();
+    expressions.len() == 1 && parse_require_function(expressions.iter().next().unwrap()).is_some()
+}
+
+/// Partitions all the statements within a block into requires and remainder statements
+fn find_requires(block: &Block) -> (Vec<&StmtSemicolon>, Vec<&StmtSemicolon>) {
+    block.stmts_with_semicolon().partition(|stmt| matches!(&stmt.0, Stmt::LocalAssignment(assignment) if is_require_assignment(assignment)))
+}
+
+/// Constructs a new set of Stmts from a sorted list of requires and any remainder statements
+fn rewrite_requires(
+    sorted_requires: Vec<&StmtSemicolon>,
+    remainder_stmts: Vec<&StmtSemicolon>,
+) -> Vec<StmtSemicolon> {
+    sorted_requires
+        .into_iter()
+        .chain(remainder_stmts.into_iter())
+        .cloned()
+        .collect()
+}

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -167,14 +167,24 @@ fn find_dependency_name(stmt: &StmtSemicolon) -> Option<String> {
                                 Var::Name(token) => name_from_token(token.token_type()),
                                 Var::Expression(var_expression) => match var_expression.prefix() {
                                     Prefix::Name(token) => name_from_token(token.token_type()),
-                                    _ => todo!("non-standard dependency"),
+                                    _ => todo!(
+                                        "non-standard dependency [PREFIX]: {}",
+                                        var_expression.to_string()
+                                    ),
                                 },
                                 other => unreachable!("unknown node: {:?}", other),
                             },
-                            _ => todo!("non-standard dependency"),
+                            Value::FunctionCall(function_call) => match function_call.prefix() {
+                                Prefix::Name(token) => name_from_token(token.token_type()),
+                                _ => todo!(
+                                    "non-standard dependency [PREFIX]: {}",
+                                    function_call.to_string()
+                                ),
+                            },
+                            _ => todo!("non-standard dependency [VALUE]: {}", value.to_string()),
                         }
                     }
-                    _ => todo!("non-standard dependency"),
+                    _ => todo!("non-standard dependency [EXPR]: {}", expression.to_string()),
                 };
 
                 Some(dependency)

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -44,7 +44,7 @@ impl SortRequiresConfig {
 }
 
 /// Takes in an input AST, and applies the sort requires codemod to output a new AST
-pub fn sort_requires(input_ast: Ast) -> Ast {
+pub(crate) fn sort_requires(input_ast: Ast) -> Ast {
     let block = input_ast.nodes();
 
     // Find all the requires in the code

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -13,9 +13,12 @@
 //!     - We then leave one line gap, and include all the requires (in a sorted order)
 //!     - Requires are sectioned by the variables that they rely on
 
+use std::collections::HashSet;
+
 use full_moon::{
     ast::{
         Ast, Block, Call, Expression, FunctionArgs, LocalAssignment, Prefix, Stmt, Suffix, Value,
+        Var,
     },
     tokenizer::{TokenReference, TokenType},
 };
@@ -27,17 +30,18 @@ pub fn sort_requires(input_ast: Ast) -> Ast {
     let block = input_ast.nodes();
 
     // Find all the requires in the code
-    let mut requires = find_requires(block);
+    let (mut dependencies, mut requires, remainders) = find_requires(block);
 
     // Exit early if no requires present
-    if requires.0.is_empty() {
+    if requires.is_empty() {
         return input_ast;
     }
 
     // TODO: find dependents and place them in a section beforehand
+    // TODO: perform a topo sort on the requires
 
     // Sort all requires
-    requires.0.sort_by_key(|assignment| {
+    requires.sort_by_key(|assignment| {
         name_from_token(
             extract_local_assignment(&assignment.0)
                 .names()
@@ -48,8 +52,11 @@ pub fn sort_requires(input_ast: Ast) -> Ast {
         )
     });
 
+    // TODO: this is wrong
+    dependencies.extend(requires);
+
     // Rewrite the requires into the AST, at the beginning of the block
-    let new_stmts = rewrite_requires(requires.0, requires.1);
+    let new_stmts = rewrite_requires(dependencies, remainders);
     let new_block = block.to_owned().with_stmts(new_stmts);
 
     input_ast.with_nodes(new_block)
@@ -84,7 +91,16 @@ fn parse_require_function(expression: &Expression) -> Option<&FunctionArgs> {
                         function_call.suffixes().next()
                     {
                         if function_call.suffixes().count() == 1 {
-                            return Some(function_args);
+                            match function_args {
+                                FunctionArgs::String(_) => return Some(function_args),
+                                FunctionArgs::Parentheses { arguments, .. }
+                                    if arguments.len() == 1 =>
+                                {
+                                    return Some(function_args);
+                                }
+                                // TODO: require of a table? is this possible?
+                                _ => (),
+                            }
                         }
                     }
                 }
@@ -95,16 +111,83 @@ fn parse_require_function(expression: &Expression) -> Option<&FunctionArgs> {
     None
 }
 
+/// Extracts the [`Expression`] inside a require assignment.
+/// NOTE: this function EXPECTS only one expression in the local assignemnt
+fn extract_assignment_expression(assignment: &LocalAssignment) -> &Expression {
+    assert!(assignment.expressions().len() == 1);
+    assignment.expressions().iter().next().unwrap()
+}
+
 /// Determines whether the provided [`LocalAssignment`] is a require assignment.
 /// i.e., of the form `local NAME = require(ARG)`
 fn is_require_assignment(assignment: &LocalAssignment) -> bool {
-    let expressions = assignment.expressions();
-    expressions.len() == 1 && parse_require_function(expressions.iter().next().unwrap()).is_some()
+    assignment.expressions().len() == 1
+        && parse_require_function(extract_assignment_expression(assignment)).is_some()
+}
+
+fn find_dependency_names(requires: &[&StmtSemicolon]) -> HashSet<String> {
+    let mut set = HashSet::new();
+
+    for (require, _) in requires {
+        let expression = extract_assignment_expression(extract_local_assignment(require));
+        let argument = match parse_require_function(expression) {
+            Some(FunctionArgs::String(_)) => continue, // A string require cannot have any dependencies
+            Some(FunctionArgs::TableConstructor(_)) => todo!("require of a table"),
+            Some(FunctionArgs::Parentheses { arguments, .. }) => arguments.iter().next().unwrap(),
+            _ => unreachable!(),
+        };
+
+        let dependency = match argument {
+            Expression::Value { value, .. } => {
+                match &**value {
+                    Value::String(_) => continue, // A string require cannot have any dependencies
+                    Value::Var(var) => match var {
+                        Var::Name(token) => name_from_token(token.token_type()),
+                        Var::Expression(var_expression) => match var_expression.prefix() {
+                            Prefix::Name(token) => name_from_token(token.token_type()),
+                            _ => todo!("non-standard require expression"),
+                        },
+                        other => unreachable!("unknown node: {:?}", other),
+                    },
+                    _ => todo!("non-standard require expression"),
+                }
+            }
+            _ => todo!("non-standard require expression"),
+        };
+
+        set.insert(dependency);
+    }
+
+    set
+}
+
+fn is_dependency(stmt: &Stmt, dependency_names: &HashSet<String>) -> bool {
+    match stmt {
+        Stmt::LocalAssignment(local_assignment) => local_assignment
+            .names()
+            .iter()
+            .any(|name| dependency_names.contains(&name_from_token(name.token_type()))),
+        _ => false,
+    }
 }
 
 /// Partitions all the statements within a block into requires and remainder statements
-fn find_requires(block: &Block) -> (Vec<&StmtSemicolon>, Vec<&StmtSemicolon>) {
-    block.stmts_with_semicolon().partition(|stmt| matches!(&stmt.0, Stmt::LocalAssignment(assignment) if is_require_assignment(assignment)))
+fn find_requires(
+    block: &Block,
+) -> (
+    Vec<&StmtSemicolon>,
+    Vec<&StmtSemicolon>,
+    Vec<&StmtSemicolon>,
+) {
+    let (requires, remainders): (Vec<_>, _) = block.stmts_with_semicolon().partition(|stmt| matches!(&stmt.0, Stmt::LocalAssignment(assignment) if is_require_assignment(assignment)));
+
+    // From the remaining statements, find all the assignments which a require is dependent on
+    let dependency_names = find_dependency_names(requires.as_slice());
+    let (dependencies, remainders) = remainders
+        .iter()
+        .partition(|stmt| is_dependency(&stmt.0, &dependency_names));
+
+    (dependencies, requires, remainders)
 }
 
 /// Constructs a new set of Stmts from a sorted list of requires and any remainder statements
@@ -112,6 +195,8 @@ fn rewrite_requires(
     sorted_requires: Vec<&StmtSemicolon>,
     remainder_stmts: Vec<&StmtSemicolon>,
 ) -> Vec<StmtSemicolon> {
+    // TODO: place a single newline between the sorted requires and the remainder statements
+
     sorted_requires
         .into_iter()
         .chain(remainder_stmts.into_iter())

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -22,8 +22,26 @@ use full_moon::{
     },
     tokenizer::{TokenReference, TokenType},
 };
+use serde::Deserialize;
 
 type StmtSemicolon = (Stmt, Option<TokenReference>);
+
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SortRequiresConfig {
+    /// Whether the sort requires codemod is enabled.
+    enabled: bool,
+}
+
+impl SortRequiresConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn set_enabled(&self, enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
 
 /// Takes in an input AST, and applies the sort requires codemod to output a new AST
 pub fn sort_requires(input_ast: Ast) -> Ast {
@@ -251,6 +269,7 @@ fn rewrite_requires(
     sorted_requires: Vec<&StmtSemicolon>,
     remainder_stmts: Vec<&StmtSemicolon>,
 ) -> Vec<StmtSemicolon> {
+    // TODO: remove any excessive newlines at the end of requires (in case they were removed)
     // TODO: place a single newline between the sorted requires and the remainder statements
 
     sorted_requires

--- a/tests/inputs-sort-requires/basic.lua
+++ b/tests/inputs-sort-requires/basic.lua
@@ -1,0 +1,4 @@
+local bee = require("b")
+local ah = require("a")
+
+print("hello world")

--- a/tests/inputs-sort-requires/chained-dependencies.lua
+++ b/tests/inputs-sort-requires/chained-dependencies.lua
@@ -1,0 +1,6 @@
+local holder = script.Parent
+local modules = holder.Modules
+local cee = require(modules.Script)
+local bee = require(modules.BeeMovie)
+local aa = require(modules.Test)
+print("hello!")

--- a/tests/inputs-sort-requires/dependency.lua
+++ b/tests/inputs-sort-requires/dependency.lua
@@ -1,0 +1,7 @@
+local parent = script.Parent
+local x = foo()
+local bee = require("aaa")
+local cee = require(parent.Cee)
+local aaa = require(parent.Script)
+
+print("hello world")

--- a/tests/snapshots/tests__sort_requires@basic.lua.snap
+++ b/tests/snapshots/tests__sort_requires@basic.lua.snap
@@ -1,0 +1,11 @@
+---
+source: tests/tests.rs
+assertion_line: 56
+expression: format(&contents)
+
+---
+local ah = require("a")
+local bee = require("b")
+
+print("hello world")
+

--- a/tests/snapshots/tests__sort_requires@chained-dependencies.lua.snap
+++ b/tests/snapshots/tests__sort_requires@chained-dependencies.lua.snap
@@ -1,0 +1,13 @@
+---
+source: tests/tests.rs
+assertion_line: 56
+expression: "format_code(&contents, Config::default().with_sort_requires(true), None,\n            OutputVerification::None).unwrap()"
+
+---
+local holder = script.Parent
+local modules = holder.Modules
+local aa = require(modules.Test)
+local bee = require(modules.BeeMovie)
+local cee = require(modules.Script)
+print("hello!")
+

--- a/tests/snapshots/tests__sort_requires@dependency.lua.snap
+++ b/tests/snapshots/tests__sort_requires@dependency.lua.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests.rs
+assertion_line: 56
+expression: format(&contents)
+
+---
+local parent = script.Parent
+local aaa = require(parent.Script)
+local bee = require("aaa")
+local cee = require(parent.Cee)
+local x = foo()
+
+print("hello world")
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-use stylua_lib::{format_code, Config, OutputVerification};
+use stylua_lib::{format_code, sort_requires::SortRequiresConfig, Config, OutputVerification};
 
 fn format(input: &str) -> String {
     format_code(input, Config::default(), None, OutputVerification::None).unwrap()
@@ -55,7 +55,7 @@ fn test_sort_requires() {
         let contents = std::fs::read_to_string(path).unwrap();
         insta::assert_snapshot!(format_code(
             &contents,
-            Config::default().with_sort_requires(true),
+            Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),
             None,
             OutputVerification::None
         )

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -48,3 +48,11 @@ fn test_lua52() {
         insta::assert_snapshot!(format(&contents));
     })
 }
+
+#[test]
+fn test_sort_requires() {
+    insta::glob!("inputs-sort-requires/*.lua", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_snapshot!(format(&contents));
+    })
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,6 +53,12 @@ fn test_lua52() {
 fn test_sort_requires() {
     insta::glob!("inputs-sort-requires/*.lua", |path| {
         let contents = std::fs::read_to_string(path).unwrap();
-        insta::assert_snapshot!(format(&contents));
+        insta::assert_snapshot!(format_code(
+            &contents,
+            Config::default().with_sort_requires(true),
+            None,
+            OutputVerification::None
+        )
+        .unwrap());
     })
 }


### PR DESCRIPTION
An implementation of the sort requires codemod

Enabling sort requires functionality will make stylua sort requires in the top level block of a file accordingly.
All requires will move to the top, and will be ordered alphabetically.
Any dependencies used within requires (e.g. `ReplicatedStorage` in `require(ReplicatedStorage.Module)`) will also be moved so that they are sorted above requires.

Assumptions:
- We only touch requires in the form `local NAME = require(EXPRESSION)`. Other types of requires are left alone
- We only touch requires in the top level of a file. We don't touch requires in nested blocks.
- Requires have no side-effects, reorganising requires is safe

TODO:
- Topologically sort dependencies and requires so that dependencies are correctly structured. E.g. `local c = script.Parent; local a = child.Module`, we need to enforce `c` goes before `a`.
- Add ability to structure requires (and other variables) into sections. This should open up functionality to sort `game:GetService()` calls at the top, before requires.
- Add sections ordering.
- Put newlines in appropriate positions
- More tests!

What the configuration file will look like when this is implemented:
```toml
column_width = 120
line_endings = "Unix"
indent_type = "Tabs"
indent_width = 4
quote_style = "AutoPreferDouble"
call_parentheses = "Always"

[sort_requires]
enabled = true
sections_order = ["services", "packages", "shared", "requires"] # The order to apply sections in. "requires" is the default section when no other section matches

[sort_requires.sections]
# A map between section names and a list of regex's to match against values
services = ["game:GetService(.)"]
packages = ["require(ReplicatedStorage.Packages.([%w.]+))"]
shared = ["require(ReplicatedStorage.Shared.([%w.]+))"]
```

Closes #364 