### PR TITLE
Create JSON-compatible errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `--output-format=json` now outputs all (error) messages in JSON format ([#453](https://github.com/JohnnyMorganz/StyLua/issues/453))
+
 ### Fixed
 - [**Luau**] Fixed spacing lost before a comment within a type generic ([#446](https://github.com/JohnnyMorganz/StyLua/issues/446))
 - [**Luau**] Removed unnecessary expansion of a type generic with a single table as the parameter ([#442](https://github.com/JohnnyMorganz/StyLua/issues/442))


### PR DESCRIPTION
`--output-format=json` will now output all messages in JSON format.
Structure:
```json5
{
    "type": "error", // or "warn"/"info"/"debug" etc. and "parse_error"
    "message": "XYZ"
}
```
and if `type == "parse_error"` we also have a `filename` and `location` field like
```json5
{
    "type": "parse_error",
    "message": "XYZ",
    "filename": "src/test.lua",
    "location": {
        "start": 0, // byte offset from start of file
        "start_line": 0,
        "start_column": 0,
        "end": 0, // byte offsets from start of file
        "end_line": 0,
        "end_column": 0,
    }
}
```
Closes #453 