### PR TITLE
Fix comment indentation on elseif/else token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - We now attempt to first hang the equals token in an assignment before expanding the RHS expression ([#292](https://github.com/JohnnyMorganz/StyLua/issues/292))
+- Comments preceding an `elseif`/`else` token in an if statement will now be inlined with the token if the previous block contains contents. This should resolve issues where the comment was meant to be on the elseif condition. If the previous block is empty, the comment will be indented ([#254](https://github.com/JohnnyMorganz/StyLua/issues/254))
 
 ### Fixed
 - [**Luau**] Fixed spacing lost before a comment within a type generic ([#446](https://github.com/JohnnyMorganz/StyLua/issues/446))

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -312,7 +312,7 @@ pub fn format_index(ctx: &Context, index: &Index, shape: Shape) -> Index {
                             create_indent_trivia(ctx, indent_shape),
                         ]),
                     ),
-                    format_end_token(ctx, end_bracket, EndTokenType::ClosingBrace, shape)
+                    format_end_token(ctx, end_bracket, EndTokenType::IndentComments, shape)
                         .update_leading_trivia(FormatTriviaType::Append(vec![
                             create_indent_trivia(ctx, shape),
                         ])),

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -721,7 +721,7 @@ pub fn format_function_body(
     let end_token = format_end_token(
         ctx,
         function_body.end_token(),
-        EndTokenType::BlockEnd,
+        EndTokenType::IndentComments,
         shape,
     )
     .update_trivia(end_token_leading_trivia, end_token_trailing_trivia);

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -71,8 +71,13 @@ pub fn format_do_block(ctx: &Context, do_block: &Do, shape: Shape) -> Do {
         .update_trivia(leading_trivia.to_owned(), trailing_trivia.to_owned());
     let block_shape = shape.reset().increment_block_indent();
     let block = format_block(ctx, do_block.block(), block_shape);
-    let end_token = format_end_token(ctx, do_block.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trivia(leading_trivia, trailing_trivia);
+    let end_token = format_end_token(
+        ctx,
+        do_block.end_token(),
+        EndTokenType::IndentComments,
+        shape,
+    )
+    .update_trivia(leading_trivia, trailing_trivia);
 
     do_block
         .to_owned()
@@ -264,11 +269,16 @@ pub fn format_generic_for(ctx: &Context, generic_for: &GenericFor, shape: Shape)
     let block_shape = shape.reset().increment_block_indent();
     let block = format_block(ctx, generic_for.block(), block_shape);
 
-    let end_token = format_end_token(ctx, generic_for.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trivia(
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(vec![create_newline_trivia(ctx)]), // trailing_trivia was emptied when it was appended to names_comment_buf
-        );
+    let end_token = format_end_token(
+        ctx,
+        generic_for.end_token(),
+        EndTokenType::IndentComments,
+        shape,
+    )
+    .update_trivia(
+        FormatTriviaType::Append(leading_trivia),
+        FormatTriviaType::Append(vec![create_newline_trivia(ctx)]), // trailing_trivia was emptied when it was appended to names_comment_buf
+    );
 
     let generic_for = generic_for.to_owned();
     #[cfg(feature = "luau")]
@@ -284,7 +294,12 @@ pub fn format_generic_for(ctx: &Context, generic_for: &GenericFor, shape: Shape)
 }
 
 /// Formats an ElseIf node - This must always reside within format_if
-fn format_else_if(ctx: &Context, else_if_node: &ElseIf, shape: Shape) -> ElseIf {
+fn format_else_if(
+    ctx: &Context,
+    else_if_node: &ElseIf,
+    shape: Shape,
+    last_block_empty: bool,
+) -> ElseIf {
     // Calculate trivia
     let shape = shape.reset();
     let leading_trivia = vec![create_indent_trivia(ctx, shape)];
@@ -296,7 +311,11 @@ fn format_else_if(ctx: &Context, else_if_node: &ElseIf, shape: Shape) -> ElseIf 
     let elseif_token = format_end_token(
         ctx,
         else_if_node.else_if_token(),
-        EndTokenType::BlockEnd,
+        if last_block_empty {
+            EndTokenType::IndentComments
+        } else {
+            EndTokenType::InlineComments
+        },
         shape,
     );
     let singleline_condition = format_expression(ctx, &condition, shape + 7);
@@ -332,7 +351,7 @@ fn format_else_if(ctx: &Context, else_if_node: &ElseIf, shape: Shape) -> ElseIf 
         true => format_end_token(
             ctx,
             else_if_node.then_token(),
-            EndTokenType::BlockEnd,
+            EndTokenType::IndentComments,
             shape,
         )
         .update_leading_trivia(FormatTriviaType::Append(leading_trivia)),
@@ -389,8 +408,13 @@ pub fn format_if(ctx: &Context, if_node: &If, shape: Shape) -> If {
     };
 
     let then_token = match require_multiline_expression {
-        true => format_end_token(ctx, if_node.then_token(), EndTokenType::BlockEnd, shape)
-            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned())),
+        true => format_end_token(
+            ctx,
+            if_node.then_token(),
+            EndTokenType::IndentComments,
+            shape,
+        )
+        .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned())),
         false => singleline_then_token,
     }
     .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
@@ -398,26 +422,45 @@ pub fn format_if(ctx: &Context, if_node: &If, shape: Shape) -> If {
     let block_shape = shape.reset().increment_block_indent();
     let block = format_block(ctx, if_node.block(), block_shape);
 
-    let end_token = format_end_token(ctx, if_node.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trivia(
-            FormatTriviaType::Append(leading_trivia.to_owned()),
-            FormatTriviaType::Append(trailing_trivia.to_owned()),
-        );
+    let end_token = format_end_token(
+        ctx,
+        if_node.end_token(),
+        EndTokenType::IndentComments,
+        shape,
+    )
+    .update_trivia(
+        FormatTriviaType::Append(leading_trivia.to_owned()),
+        FormatTriviaType::Append(trailing_trivia.to_owned()),
+    );
 
-    let else_if = if_node.else_if().map(|else_if| {
-        else_if
-            .iter()
-            .map(|else_if| format_else_if(ctx, else_if, shape))
-            .collect()
+    // Determine how to format the leading trivia on the `elseif` / `else` tokens
+    // If the last block was empty, then the comment inside the previous block should be indented,
+    let mut last_block_empty = trivia_util::is_block_empty(if_node.block());
+    let else_if = if_node.else_if().map(|else_ifs| {
+        let mut new_else_ifs = Vec::with_capacity(else_ifs.len());
+        for else_if in else_ifs {
+            new_else_ifs.push(format_else_if(ctx, else_if, shape, last_block_empty));
+            last_block_empty = trivia_util::is_block_empty(else_if.block())
+        }
+        new_else_ifs
     });
 
     let (else_token, else_block) = match (if_node.else_token(), if_node.else_block()) {
         (Some(else_token), Some(else_block)) => {
-            let else_token = format_end_token(ctx, else_token, EndTokenType::BlockEnd, shape)
-                .update_trivia(
-                    FormatTriviaType::Append(leading_trivia),
-                    FormatTriviaType::Append(trailing_trivia),
-                );
+            let else_token = format_end_token(
+                ctx,
+                else_token,
+                if last_block_empty {
+                    EndTokenType::IndentComments
+                } else {
+                    EndTokenType::InlineComments
+                },
+                shape,
+            )
+            .update_trivia(
+                FormatTriviaType::Append(leading_trivia),
+                FormatTriviaType::Append(trailing_trivia),
+            );
             let else_block_shape = shape.reset().increment_block_indent();
             let else_block = format_block(ctx, else_block, else_block_shape);
 
@@ -473,11 +516,16 @@ pub fn format_numeric_for(ctx: &Context, numeric_for: &NumericFor, shape: Shape)
         .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
     let block_shape = shape.reset().increment_block_indent();
     let block = format_block(ctx, numeric_for.block(), block_shape);
-    let end_token = format_end_token(ctx, numeric_for.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trivia(
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(trailing_trivia),
-        );
+    let end_token = format_end_token(
+        ctx,
+        numeric_for.end_token(),
+        EndTokenType::IndentComments,
+        shape,
+    )
+    .update_trivia(
+        FormatTriviaType::Append(leading_trivia),
+        FormatTriviaType::Append(trailing_trivia),
+    );
 
     let numeric_for = numeric_for.to_owned();
     #[cfg(feature = "luau")]
@@ -577,8 +625,13 @@ pub fn format_while_block(ctx: &Context, while_block: &While, shape: Shape) -> W
     };
 
     let do_token = match require_multiline_expression {
-        true => format_end_token(ctx, while_block.do_token(), EndTokenType::BlockEnd, shape)
-            .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned())),
+        true => format_end_token(
+            ctx,
+            while_block.do_token(),
+            EndTokenType::IndentComments,
+            shape,
+        )
+        .update_leading_trivia(FormatTriviaType::Append(leading_trivia.to_owned())),
         false => singleline_do_token,
     }
     .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.to_owned()));
@@ -586,11 +639,16 @@ pub fn format_while_block(ctx: &Context, while_block: &While, shape: Shape) -> W
     let block_shape = shape.reset().increment_block_indent();
     let block = format_block(ctx, while_block.block(), block_shape);
 
-    let end_token = format_end_token(ctx, while_block.end_token(), EndTokenType::BlockEnd, shape)
-        .update_trivia(
-            FormatTriviaType::Append(leading_trivia),
-            FormatTriviaType::Append(trailing_trivia),
-        );
+    let end_token = format_end_token(
+        ctx,
+        while_block.end_token(),
+        EndTokenType::IndentComments,
+        shape,
+    )
+    .update_trivia(
+        FormatTriviaType::Append(leading_trivia),
+        FormatTriviaType::Append(trailing_trivia),
+    );
 
     while_block
         .to_owned()

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -222,7 +222,7 @@ pub fn create_table_braces(
                 .update_trailing_trivia(FormatTriviaType::Append(vec![create_newline_trivia(ctx)]));
 
             let end_brace_token =
-                format_end_token(ctx, end_brace, EndTokenType::ClosingBrace, shape)
+                format_end_token(ctx, end_brace, EndTokenType::IndentComments, shape)
                     .update_leading_trivia(FormatTriviaType::Append(end_brace_leading_trivia));
 
             ContainedSpan::new(start_brace_token, end_brace_token)

--- a/tests/inputs/if-comments-2.lua
+++ b/tests/inputs/if-comments-2.lua
@@ -1,0 +1,14 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/254
+if condition1 then
+	print("Do something")
+
+--[[
+	my multiline comment
+]]
+elseif condition2 then
+	print("Do something else")
+
+-- my single line comment
+elseif condition3 then
+	print("Do some final thing")
+end

--- a/tests/snapshots/tests__standard@if-comments-2.lua.snap
+++ b/tests/snapshots/tests__standard@if-comments-2.lua.snap
@@ -1,0 +1,19 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/254
+if condition1 then
+	print("Do something")
+
+--[[
+	my multiline comment
+]]
+elseif condition2 then
+	print("Do something else")
+
+-- my single line comment
+elseif condition3 then
+	print("Do some final thing")
+end
+


### PR DESCRIPTION
If the previous block contains contents, the comment on the elseif/else token should be inlined with the token - as it most likely represents content at the level.

If the block was empty, then the comment will be indented, like originally.

Closes #254 