### PR TITLE
Simplify "simple heuristics" even further

### DIFF
--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -182,18 +182,18 @@ fn function_args_multiline_heuristic(
         return false;
     }
 
+    if shape.using_simple_heuristics() {
+        return false;
+    }
+
     // Format all the arguments on an infinite width, so that we can prepare them and check to see whether they
     // need expanding. We will ignore punctuation for now
     let first_iter_formatted_arguments = arguments.iter().map(|argument| {
-        if shape.using_simple_heuristics() {
-            argument.to_owned()
-        } else {
-            format_expression(
-                ctx,
-                argument,
-                shape.with_simple_heuristics().with_infinite_width(),
-            )
-        }
+        format_expression(
+            ctx,
+            argument,
+            shape.with_simple_heuristics().with_infinite_width(),
+        )
     });
 
     // Apply some heuristics to determine whether we should expand the function call


### PR DESCRIPTION
The change in #478 causes issues seen in #490, because we don't format enough so the call to `argument.to_owned()` relies on input formatting.

This fixes that to simplify it even further, where we automatically go single-line

Fixes #490 