### PR TITLE
Enforce locked on cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           override: true
 
       - name: Publish to cargo
-        run: cargo publish --token ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --verbose --locked --token ${{ secrets.CARGO_TOKEN }}
 
   release_npm_wasm:
     name: Publish wasm to npm


### PR DESCRIPTION
We accidently published with outdated lock file
Enforce locked so this doesn't happen again
#556 