### PR TITLE
Update pyproject to support installing on M1 machines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ build-backend = "pseudo_builder"
 
 [tool.release-gitter]
 extract-files = ["stylua"]
-format = "stylua-{system}.zip"
+format = "stylua-{system}{arch}.zip"
 exec = "chmod +x stylua"
+[tool.release-gitter.map-arch]
+x86_64 = ""
+arm64 = "-aarch64"
 [tool.release-gitter.map-system]
 Darwin = "macos"
 Windows = "win64"


### PR DESCRIPTION
The format is a bit different for macOS arm64 from the others in that
it's the only one specifying an arch. As a result, any x86_64 archs are
mapped to an empty string and the arm64 one has a prefixed `-` to
separate it from the system.