### PR TITLE
Allow alternative way to compute large scale diffs

### DIFF
--- a/.github/run_comparisons.py
+++ b/.github/run_comparisons.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import subprocess
-from typing import List
+from typing import List, Literal
 
 REPOS = {
     "roact": {
@@ -38,9 +38,8 @@ REPOS = {
     # }
 }
 
-# Get paths to downloaded executables
-# main_tool = sys.argv[1]
-# latest_tool = sys.argv[2]
+# Get formatting type
+formattingType: Literal["diffAfterMainFormat", "diffMainVsChangeFormat"] = sys.argv[1] or "diffAfterMainFormat"  # type: ignore
 
 os.chmod("./stylua-main", 0o700)
 os.chmod("./stylua-latest", 0o700)
@@ -99,6 +98,15 @@ for repo, data in REPOS.items():
         continue
 
     print(f"Main changes committed", file=sys.stderr)
+
+    # If we are diffing main vs change formatting, then reset to original code
+    if formattingType == "diffMainVsChangeFormat":
+        restoreProcess = subprocess.Popen(["git", "commit", "-a", "--allow-empty", "--no-verify", "-m", "base"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        restoreProcessStderr = restoreProcess.communicate()[1].decode()
+        if restoreProcess.wait() != 0:
+            print(f"**Error when restoring original changes on `{repo}`**:")
+            printCodeblock(restoreProcessStderr or "<no output>", "")
+            continue
 
     # Run the latest tool on the repository
     runLatestProcess = executeTool("../stylua-latest", data["command"])

--- a/.github/run_comparisons.py
+++ b/.github/run_comparisons.py
@@ -104,7 +104,7 @@ for repo, data in REPOS.items():
     # If we are diffing main vs change formatting, then reset to original code
     if formattingType == "diffMainVsChangeFormat":
         print(f"Restoring original code", file=sys.stderr)
-        restoreProcess = subprocess.Popen(["git", "commit", "-a", "--allow-empty", "--no-verify", "-m", "base"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        restoreProcess = subprocess.Popen(["git", "checkout", "HEAD~1", "."], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         restoreProcessStderr = restoreProcess.communicate()[1].decode()
         if restoreProcess.wait() != 0:
             print(f"**Error when restoring original changes on `{repo}`**:")
@@ -119,6 +119,16 @@ for repo, data in REPOS.items():
         printCodeblock(runLatestStderr, "")
 
     print(f"Latest tool executed", file=sys.stderr)
+
+    # If we are diffing main vs change formatting, we need to stage the changes
+    if formattingType == "diffMainVsChangeFormat":
+        print(f"Stage latest changes", file=sys.stderr)
+        stageProcess = subprocess.Popen(["git", "add", "--all"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stageProcessStderr = stageProcess.communicate()[1].decode()
+        if stageProcess.wait() != 0:
+            print(f"**Error when staging new changes on `{repo}`**:")
+            printCodeblock(stageProcessStderr or "<no output>", "")
+            continue
 
     # Compute the diff
     diffProcess = subprocess.Popen(['git', 'diff', f"--src-prefix=ORI/{repo}/", f"--dst-prefix=ALT/{repo}/"], stdout=subprocess.PIPE)

--- a/.github/run_comparisons.py
+++ b/.github/run_comparisons.py
@@ -111,6 +111,14 @@ for repo, data in REPOS.items():
             printCodeblock(restoreProcessStderr or "<no output>", "")
             continue
 
+        print(f"Unstaging original code", file=sys.stderr)
+        unstageProcess = subprocess.Popen(["git", "reset"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        unstageProcessStderr = unstageProcess.communicate()[1].decode()
+        if unstageProcess.wait() != 0:
+            print(f"**Error when restoring original changes on `{repo}`**:")
+            printCodeblock(unstageProcessStderr or "<no output>", "")
+            continue
+
     # Run the latest tool on the repository
     runLatestProcess = executeTool("../stylua-latest", data["command"])
     runLatestStderr = runLatestProcess.communicate()[1].decode()
@@ -119,16 +127,6 @@ for repo, data in REPOS.items():
         printCodeblock(runLatestStderr, "")
 
     print(f"Latest tool executed", file=sys.stderr)
-
-    # If we are diffing main vs change formatting, we need to stage the changes
-    if formattingType == "diffMainVsChangeFormat":
-        print(f"Stage latest changes", file=sys.stderr)
-        stageProcess = subprocess.Popen(["git", "add", "--all"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stageProcessStderr = stageProcess.communicate()[1].decode()
-        if stageProcess.wait() != 0:
-            print(f"**Error when staging new changes on `{repo}`**:")
-            printCodeblock(stageProcessStderr or "<no output>", "")
-            continue
 
     # Compute the diff
     diffProcess = subprocess.Popen(['git', 'diff', f"--src-prefix=ORI/{repo}/", f"--dst-prefix=ALT/{repo}/"], stdout=subprocess.PIPE)

--- a/.github/run_comparisons.py
+++ b/.github/run_comparisons.py
@@ -41,6 +41,8 @@ REPOS = {
 # Get formatting type
 formattingType: Literal["diffAfterMainFormat", "diffMainVsChangeFormat"] = sys.argv[1] or "diffAfterMainFormat"  # type: ignore
 
+print(f"RUNNING MODE: {formattingType}", file=sys.stderr)
+
 os.chmod("./stylua-main", 0o700)
 os.chmod("./stylua-latest", 0o700)
 os.system('git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"')
@@ -101,6 +103,7 @@ for repo, data in REPOS.items():
 
     # If we are diffing main vs change formatting, then reset to original code
     if formattingType == "diffMainVsChangeFormat":
+        print(f"Restoring original code", file=sys.stderr)
         restoreProcess = subprocess.Popen(["git", "commit", "-a", "--allow-empty", "--no-verify", "-m", "base"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         restoreProcessStderr = restoreProcess.communicate()[1].decode()
         if restoreProcess.wait() != 0:

--- a/.github/workflows/large-scale-test.yml
+++ b/.github/workflows/large-scale-test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-latest:
     name: Build Pull Request (#${{ github.event.inputs.prId }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -38,7 +38,7 @@ jobs:
 
   build-main:
     name: Build Main
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/large-scale-test.yml
+++ b/.github/workflows/large-scale-test.yml
@@ -6,6 +6,14 @@ on:
         description: "PR #"
         required: true
         type: number
+      type:
+        description: "Diff computation type"
+        required: true
+        default: "diffAfterMainFormat"
+        type: choice
+        options:
+          - diffAfterMainFormat # format using main branch first, then apply PR changes ontop of that
+          - diffMainVsChangeFormat # format using main branch, store. Reset to original then format using PR branch. Compute differences
 
 jobs:
   build-latest:
@@ -64,7 +72,7 @@ jobs:
       - name: Run comparison tool
         id: run_comparison
         run: |
-          body="$(python ./.github/run_comparisons.py ./stylua-main ./stylua-latest)"
+          body="$(python ./.github/run_comparisons.py ${{ github.event.inputs.type }})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"


### PR DESCRIPTION
Currently, we compute large scale diffs using the following steps:
- Clone repo
- Run stylua main on repo
- Commit main changes
- Run stylua PR on repo again (but this is based of already-formatted code from main)
- Compute diff

Since we run stylua PR on the already-formatted code, the diff computed isn't necessarily correct.

This adds in a new method:
- Clone repo
- Run stylua main on repo
- Commit main changes
- **Restore repo to original**
- Run stylua PR on repo again (based on original)
- Compute diff between main changes and current

This provides more accurate diffs.