### PR TITLE
Fix release build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           profile: minimal
 
       - name: Build Binary (All features)
-        run: cargo build --verbose --locked --release --all-features
+        run: cargo build --verbose --locked --release --all-features --target ${{ matrix.cargo-target }}
         env:
           CARGO_TARGET_DIR: output
 


### PR DESCRIPTION
We setup a target already, but cargo build only uses the default target.
We explicitly pass the cargo target so that it builds using the correct one

Fixes #567 