### PR TITLE
Fix aarch64 linux builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,6 @@ rustflags = [
     "-C",
     "link-args=/NODEFAULTLIB:libucrt.lib /NODEFAULTLIB:libucrtd.lib /NODEFAULTLIB:ucrtd.lib",
 ]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           override: true
           profile: minimal
 
+      - name: Install aarch64 c toolchain
+        run: apt-get install -y --force-yes --no-install-recommends gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+        if: ${{ matrix.cargo-target == "aarch64-unknown-linux-gnu" }}
+
       - name: Build Binary (All features)
         run: cargo build --verbose --locked --release --all-features --target ${{ matrix.cargo-target }}
         env:


### PR DESCRIPTION
Add c toolchain and instruct cargo to use the right linker for aarch64-linux

Apparently these are required for this target only. I'm not sure how to test a gh release but I think this will work. It worked on my local Ubuntu Jammy environment.