### PR TITLE
Add `serialize`, `fromstr` and `wasm-bindgen` features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt install ${{ matrix.linker }}
 
       - name: Build Binary (All features)
-        run: cargo build --verbose --locked --release --features lua53,lua53,lua54,luau --target ${{ matrix.cargo-target }}
+        run: cargo build --verbose --locked --release --features lua52,lua53,lua54,luau --target ${{ matrix.cargo-target }}
         env:
           CARGO_TARGET_DIR: output
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt install ${{ matrix.linker }}
 
       - name: Build Binary (All features)
-        run: cargo build --verbose --locked --release --all-features --target ${{ matrix.cargo-target }}
+        run: cargo build --verbose --locked --release --features lua53,lua53,lua54,luau --target ${{ matrix.cargo-target }}
         env:
           CARGO_TARGET_DIR: output
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +894,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "stylua"
 version = "0.15.1"
 dependencies = [
@@ -910,6 +938,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "strum",
  "thiserror",
  "threadpool",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/cli/main.rs"
 bench = false
 
 [features]
-default = []
+default = ["wasm-bindgen"]
 serialize = []
 fromstr = ["strum"]
 luau = ["full_moon/roblox"]
@@ -54,7 +54,7 @@ threadpool = "1.8.1"
 toml = "0.5.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.81"
+wasm-bindgen = { version = "0.2.81", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bench = false
 [features]
 default = []
 serialize = []
+fromstr = ["strum"]
 luau = ["full_moon/roblox"]
 lua52 = ["full_moon/lua52"]
 lua53 = ["lua52", "full_moon/lua53"]
@@ -47,6 +48,7 @@ regex = "1.5.4"
 serde = "1.0.136"
 serde_json = "1.0.79"
 similar = { version = "2.1.0", features = ["text", "inline", "serde"] }
+strum = { version = "0.24.1", features = ["derive"], optional = true }
 thiserror = "1.0.31"
 threadpool = "1.8.1"
 toml = "0.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bench = false
 
 [features]
 default = []
+serialize = []
 luau = ["full_moon/roblox"]
 lua52 = ["full_moon/lua52"]
 lua53 = ["lua52", "full_moon/lua53"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use full_moon::ast::Ast;
 use serde::Deserialize;
 use thiserror::Error;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
 #[macro_use]
@@ -12,7 +12,7 @@ mod verify_ast;
 
 /// The type of indents to use when indenting
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum IndentType {
@@ -30,7 +30,7 @@ impl Default for IndentType {
 
 /// The type of line endings to use at the end of a line
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum LineEndings {
@@ -49,7 +49,7 @@ impl Default for LineEndings {
 
 /// The style of quotes to use within string literals
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum QuoteStyle {
@@ -71,7 +71,7 @@ impl Default for QuoteStyle {
 
 /// When to use call parentheses
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum CallParenType {
@@ -93,7 +93,7 @@ impl Default for CallParenType {
 
 /// What mode to use if we want to collapse simple functions / guard statements
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum CollapseSimpleStatement {
@@ -117,13 +117,13 @@ impl Default for CollapseSimpleStatement {
 /// If provided, only content within these boundaries (inclusive) will be formatted.
 /// Both boundaries are optional, and are given as byte offsets from the beginning of the file.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 pub struct Range {
     start: Option<usize>,
     end: Option<usize>,
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 impl Range {
     /// Creates a new formatting range from the given start and end point.
     /// All content within these boundaries (inclusive) will be formatted.
@@ -135,7 +135,7 @@ impl Range {
 /// The configuration to use when formatting.
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Config {
     /// The approximate line length to use when printing the code.
@@ -170,7 +170,7 @@ pub struct Config {
     collapse_simple_statement: CollapseSimpleStatement,
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 impl Config {
     /// Creates a new Config with the default values
     pub fn new() -> Self {
@@ -294,7 +294,7 @@ impl Default for Config {
 
 /// The type of verification to perform to validate that the output AST is still correct.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
 pub enum OutputVerification {
     /// Reparse the generated output to detect any changes to code correctness.
     Full,
@@ -372,7 +372,7 @@ pub fn format_code(
     Ok(output)
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 #[wasm_bindgen(js_name = formatCode)]
 pub fn format_code_wasm(
     code: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod verify_ast;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum IndentType {
     /// Indent using tabs (`\t`)
     Tabs,
@@ -31,6 +32,7 @@ impl Default for IndentType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum LineEndings {
     // Auto,
     /// Unix Line Endings (LF) - `\n`
@@ -49,6 +51,7 @@ impl Default for LineEndings {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum QuoteStyle {
     /// Use double quotes where possible, but change to single quotes if it produces less escapes
     AutoPreferDouble,
@@ -70,6 +73,7 @@ impl Default for QuoteStyle {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum CallParenType {
     /// Use call parentheses all the time
     Always,
@@ -91,6 +95,7 @@ impl Default for CallParenType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "fromstr", derive(strum::EnumString))]
 pub enum CollapseSimpleStatement {
     /// Never collapse
     Never,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod verify_ast;
 /// The type of indents to use when indenting
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum IndentType {
     /// Indent using tabs (`\t`)
     Tabs,
@@ -29,6 +30,7 @@ impl Default for IndentType {
 /// The type of line endings to use at the end of a line
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum LineEndings {
     // Auto,
     /// Unix Line Endings (LF) - `\n`
@@ -46,6 +48,7 @@ impl Default for LineEndings {
 /// The style of quotes to use within string literals
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum QuoteStyle {
     /// Use double quotes where possible, but change to single quotes if it produces less escapes
     AutoPreferDouble,
@@ -66,6 +69,7 @@ impl Default for QuoteStyle {
 /// When to use call parentheses
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum CallParenType {
     /// Use call parentheses all the time
     Always,
@@ -86,6 +90,7 @@ impl Default for CallParenType {
 /// What mode to use if we want to collapse simple functions / guard statements
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum CollapseSimpleStatement {
     /// Never collapse
     Never,
@@ -126,6 +131,7 @@ impl Range {
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Config {
     /// The approximate line length to use when printing the code.
     /// This is used as a guide to determine when to wrap lines, but note


### PR DESCRIPTION
While working on creating a [dprint](https://dprint.dev/) plugin for integrating StyLua ([dprint-plugin-stylua](https://github.com/RubixDev/dprint-plugin-stylua)), I found few things were missing in StyLua to make the integration easier:

1. A `serde::Serialize` impl for the config types
2. A `FromStr` impl for the config enum types (using `strum::EnumString`)
3. Disabling the `wasm-bindgen` crate for correct compilation

I turned these three things into features and left the defaults just like they were before.