### PR TITLE
Don't collapse when comment present in typeinfo tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix incorrect indentation level used for hanging expressions in if expression syntax ([#596](https://github.com/JohnnyMorganz/StyLua/issues/596))
+- Fixed Luau return type in parentheses containing a comment on the last item being collapsed causing a syntax error ([#608](https://github.com/JohnnyMorganz/StyLua/issues/608))
 
 ## [0.15.1] - 2022-09-22
 

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -407,9 +407,16 @@ pub fn format_type_info(ctx: &Context, type_info: &TypeInfo, shape: Shape) -> Ty
             let should_format_multiline =
                 trivia_contains_comments(start_brace.trailing_trivia(), CommentSearch::Single)
                     || trivia_contains_comments(end_brace.leading_trivia(), CommentSearch::Single)
-                    || types
-                        .pairs()
-                        .any(|pair| contains_comments(pair.punctuation()));
+                    || types.pairs().any(|pair| {
+                        pair.punctuation().map_or_else(
+                            || {
+                                type_info_trailing_trivia(pair.value())
+                                    .iter()
+                                    .any(trivia_is_comment)
+                            },
+                            contains_comments,
+                        )
+                    });
 
             let singleline_parentheses = format_contained_span(ctx, parentheses, shape);
             let singleline_types = format_punctuated(ctx, types, shape + 1, format_type_info); // 1 = "("

--- a/tests/inputs-luau/type-parentheses-comments.lua
+++ b/tests/inputs-luau/type-parentheses-comments.lua
@@ -1,0 +1,13 @@
+function foo(): (
+	nil -- Some comment
+)
+	return nil
+end
+
+type X = (
+	string,
+	number -- testing
+) -> (
+	number,
+	string -- testing
+)

--- a/tests/snapshots/tests__luau@type-parentheses-comments.lua.snap
+++ b/tests/snapshots/tests__luau@type-parentheses-comments.lua.snap
@@ -1,0 +1,18 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+---
+function foo(): (
+	nil -- Some comment
+)
+	return nil
+end
+
+type X = (
+	string,
+	number -- testing
+) -> (
+	number,
+	string -- testing
+)
+


### PR DESCRIPTION
We were not checking for comments on the typeinfo in the last `Pair::End` in the tuple

Fixes #608 