### PR TITLE
Sort requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for "sort requires", which sorts top-level statements of the form `local NAME = require(EXPR)` lexicographically on `NAME`.
+  We do this by treating a group of consecutive requires as a "block", and then sorting **only within** the block. Any other statement, or an empty line, between require statements will split the group into two separate blocks (and can be used to separate the sorting). A block of requires will not move around the file.
+  Roblox Luau statements of the form `local NAME = game:GetService(EXPR)` will also be sorted separately.
+
+This feature is disabled by default. To enable it, add the following to your `stylua.toml`:
+
+```toml
+[sort_requires]
+enabled = true
+```
+
+Note: we assume that all requires are **pure** with no side effects. It is not recommended to use this feature if the ordering of your requires matter.
+
 ## [0.16.1] - 2023-02-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ We only include requires of the form `local NAME = require(EXPR)`, and sort lexi
 Requires sorting is off by default. To enable it, add the following to your `stylua.toml`:
 
 ```toml
-[sort-requires]
+[sort_requires]
 enabled = true
 ```
 
@@ -247,6 +247,6 @@ quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
 collapse_simple_statement = "Never"
 
-[sort-requires]
+[sort_requires]
 enabled = false
 ```

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ StyLua has built-in support for sorting require statements. We group consecutive
 and then requires are sorted only within that block. Blocks of requires do not move around the file.
 
 We only include requires of the form `local NAME = require(EXPR)`, and sort lexicographically based on `NAME`.
+(We also sort Roblox services of the form `local NAME = game:GetService(EXPR)`)
 
 Requires sorting is off by default. To enable it, add the following to your `stylua.toml`:
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ If part of a statement falls outside the range, the statement will be ignored.
 
 In editors, `Format Selection` is supported.
 
+### Requires Sorting
+
+StyLua has built-in support for sorting require statements. We group consecutive require statements into a single "block",
+and then requires are sorted only within that block. Blocks of requires do not move around the file.
+
+We only include requires of the form `local NAME = require(EXPR)`, and sort lexicographically based on `NAME`.
+
+Requires sorting is off by default. To enable it, add the following to your `stylua.toml`:
+
+```toml
+[sort-requires]
+enabled = true
+```
+
 ## Configuration
 
 StyLua is **opinionated**, so only a few options are provided.
@@ -232,4 +246,7 @@ indent_width = 4
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
 collapse_simple_statement = "Never"
+
+[sort-requires]
+enabled = false
 ```

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -1,4 +1,4 @@
-use crate::{context::Context, shape::Shape, Config};
+use crate::{context::Context, shape::Shape};
 use full_moon::ast::Ast;
 
 pub mod assignment;
@@ -28,10 +28,8 @@ pub struct CodeFormatter {
 
 impl CodeFormatter {
     /// Creates a new CodeFormatter, with the given configuration
-    pub fn new(config: Config, range: Option<crate::Range>) -> Self {
-        CodeFormatter {
-            context: Context::new(config, range),
-        }
+    pub fn new(ctx: Context) -> Self {
+        CodeFormatter { context: ctx }
     }
 
     /// Runs the formatter over the given AST

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use full_moon::ast::Ast;
 use serde::Deserialize;
+use sort_requires::SortRequiresConfig;
 use thiserror::Error;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
@@ -8,6 +9,7 @@ use wasm_bindgen::prelude::*;
 mod context;
 mod formatters;
 mod shape;
+pub mod sort_requires;
 mod verify_ast;
 
 /// The type of indents to use when indenting
@@ -143,6 +145,8 @@ pub struct Config {
     /// if set to [`CollapseSimpleStatement::None`] structures are never collapsed.
     /// if set to [`CollapseSimpleStatement::FunctionOnly`] then simple functions (i.e., functions with a single laststmt) can be collapsed
     collapse_simple_statement: CollapseSimpleStatement,
+    /// Configuration for the sort requires codemod
+    sort_requires: SortRequiresConfig,
 }
 
 #[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
@@ -184,6 +188,11 @@ impl Config {
 
     pub fn collapse_simple_statement(&self) -> CollapseSimpleStatement {
         self.collapse_simple_statement
+    }
+
+    /// Returns the current sort requires codemod configuration
+    pub fn sort_requires(&self) -> SortRequiresConfig {
+        self.sort_requires
     }
 
     /// Returns a new config with the given column width
@@ -250,6 +259,14 @@ impl Config {
             ..self
         }
     }
+
+    /// Returns a new config with the given sort requires configuration
+    pub fn with_sort_requires(self, sort_requires: SortRequiresConfig) -> Self {
+        Self {
+            sort_requires,
+            ..self
+        }
+    }
 }
 
 impl Default for Config {
@@ -263,6 +280,7 @@ impl Default for Config {
             no_call_parentheses: false,
             call_parentheses: CallParenType::default(),
             collapse_simple_statement: CollapseSimpleStatement::default(),
+            sort_requires: SortRequiresConfig::default(),
         }
     }
 }
@@ -304,6 +322,12 @@ pub fn format_ast(
         Some(input_ast.to_owned())
     } else {
         None
+    };
+
+    // Perform require sorting beforehand if necessary
+    let input_ast = match config.sort_requires().enabled() {
+        true => sort_requires::sort_requires(input_ast),
+        false => input_ast,
     };
 
     let code_formatter = formatters::CodeFormatter::new(config, range);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use context::Context;
 use full_moon::ast::Ast;
 use serde::Deserialize;
 use thiserror::Error;
@@ -342,13 +343,15 @@ pub fn format_ast(
         None
     };
 
+    let ctx = Context::new(config, range);
+
     // Perform require sorting beforehand if necessary
     let input_ast = match config.sort_requires().enabled() {
-        true => sort_requires::sort_requires(input_ast),
+        true => sort_requires::sort_requires(&ctx, input_ast),
         false => input_ast,
     };
 
-    let code_formatter = formatters::CodeFormatter::new(config, range);
+    let code_formatter = formatters::CodeFormatter::new(ctx);
     let ast = code_formatter.format(input_ast);
 
     // If we are verifying, reparse the output then check it matches the original input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use full_moon::ast::Ast;
 use serde::Deserialize;
-use sort_requires::SortRequiresConfig;
 use thiserror::Error;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
@@ -106,6 +105,25 @@ impl Range {
     /// All content within these boundaries (inclusive) will be formatted.
     pub fn from_values(start: Option<usize>, end: Option<usize>) -> Self {
         Self { start, end }
+    }
+}
+
+/// Configuration for the Sort Requires codemod
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct SortRequiresConfig {
+    /// Whether the sort requires codemod is enabled
+    enabled: bool,
+}
+
+impl SortRequiresConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+    pub fn set_enabled(&self, enabled: bool) -> Self {
+        Self { enabled }
     }
 }
 

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -33,7 +33,6 @@ fn extract_identifier_from_token(token: &TokenReference) -> Option<String> {
 fn get_expression_kind(expression: &Expression) -> Option<GroupKind> {
     if let Expression::Value { value, .. } = expression {
         if let Value::FunctionCall(function_call) = &**value {
-            // Require
             if let Prefix::Name(token) = function_call.prefix() {
                 if let Some(name) = extract_identifier_from_token(token) {
                     if name == "require" {

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -20,24 +20,8 @@ use full_moon::{
     node::Node,
     tokenizer::{TokenReference, TokenType},
 };
-use serde::Deserialize;
 
 use crate::formatters::trivia::{FormatTriviaType, UpdateLeadingTrivia};
-
-#[derive(Copy, Clone, Debug, Default, Deserialize)]
-pub struct SortRequiresConfig {
-    /// Whether the sort requires codemod is enabled
-    enabled: bool,
-}
-
-impl SortRequiresConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-    pub fn set_enabled(&self, enabled: bool) -> Self {
-        Self { enabled }
-    }
-}
 
 fn extract_identifier_from_token(token: &TokenReference) -> Option<String> {
     match token.token_type() {

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -14,6 +14,14 @@
 //!   (if there is a local variable in between requires, it would split them into two separate blocks,
 //!   so a require will always be after any local variable it uses)
 //! - Blocks remain in-place in the file.
+
+use std::collections::BTreeMap;
+
+use full_moon::{
+    ast::{Ast, Block, Expression, Prefix, Stmt, Value},
+    node::Node,
+    tokenizer::{TokenReference, TokenType},
+};
 use serde::Deserialize;
 
 #[derive(Copy, Clone, Debug, Default, Deserialize)]
@@ -29,4 +37,127 @@ impl SortRequiresConfig {
     pub fn set_enabled(&self, enabled: bool) -> Self {
         Self { enabled }
     }
+}
+
+fn extract_identifier_from_token(token: &TokenReference) -> Option<String> {
+    match token.token_type() {
+        TokenType::Identifier { identifier } => Some(identifier.to_string()),
+        _ => None,
+    }
+}
+
+fn is_require_expression(expression: &Expression) -> bool {
+    if let Expression::Value { value, .. } = expression {
+        if let Value::FunctionCall(function_call) = &**value {
+            if let Prefix::Name(token) = function_call.prefix() {
+                if let Some(name) = extract_identifier_from_token(token) {
+                    if name == "require" {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+type StmtSemicolon = (Stmt, Option<TokenReference>);
+
+enum BlockPartition {
+    RequiresGroup(BTreeMap<String, StmtSemicolon>),
+    Other(Vec<StmtSemicolon>),
+}
+
+fn partition_nodes_into_groups(block: &Block) -> Vec<BlockPartition> {
+    let mut parts = Vec::new();
+
+    for stmt in block.stmts_with_semicolon() {
+        if let Stmt::LocalAssignment(node) = &stmt.0 {
+            if node.names().len() == 1 && node.expressions().len() == 1 {
+                let name = node.names().iter().next().unwrap();
+                let expression = node.expressions().iter().next().unwrap();
+
+                let current_line = name.start_position().unwrap().line();
+
+                if is_require_expression(expression) {
+                    let require_name = extract_identifier_from_token(name)
+                        .expect("require is stored as non-identifier");
+
+                    // Check if we need to start a new block:
+                    // Either, the parts list is empty, the last part was a BlockPartition::Other
+                    // or, there is > 1 line in between the previous require and this one
+                    let create_new_block = match parts.last() {
+                        None => true,
+                        Some(BlockPartition::Other(_)) => true,
+                        Some(BlockPartition::RequiresGroup(map)) => {
+                            // TODO: can we prevent having to search through this map?
+                            let mut previous_require_line = 0;
+                            for require_stmts in map.values() {
+                                if let Some(position) = require_stmts.0.end_position() {
+                                    previous_require_line =
+                                        previous_require_line.max(position.line())
+                                }
+                            }
+                            current_line - previous_require_line > 1
+                        }
+                    };
+
+                    if create_new_block {
+                        parts.push(BlockPartition::RequiresGroup(BTreeMap::new()))
+                    }
+
+                    match parts.last_mut() {
+                        Some(BlockPartition::RequiresGroup(map)) => {
+                            map.insert(require_name, stmt.clone())
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    continue;
+                }
+            }
+        }
+
+        // Handle as a non-require
+        if parts.is_empty() {
+            parts.push(BlockPartition::Other(Vec::new()))
+        } else if let Some(BlockPartition::RequiresGroup(_)) = parts.last() {
+            parts.push(BlockPartition::Other(Vec::new()))
+        }
+
+        match parts.last_mut() {
+            Some(BlockPartition::Other(list)) => list.push(stmt.clone()),
+            _ => unreachable!(),
+        }
+    }
+
+    parts
+}
+
+pub(crate) fn sort_requires(input_ast: Ast) -> Ast {
+    let block = input_ast.nodes();
+
+    // Find all `local NAME = require(EXPR)` lines
+    let parts = partition_nodes_into_groups(block);
+
+    // If there is only one non-require partition, or no partitions at all
+    // then just return the original AST
+    match parts.last() {
+        Some(BlockPartition::Other(_)) if parts.len() == 1 => return input_ast,
+        None => return input_ast,
+        _ => (),
+    };
+
+    // Reconstruct the AST with sorted require groups
+    let mut stmts: Vec<StmtSemicolon> = Vec::new();
+    for part in parts {
+        match part {
+            BlockPartition::RequiresGroup(map) => stmts.extend(map.values().cloned()),
+            BlockPartition::Other(mut list) => stmts.append(&mut list),
+        };
+    }
+
+    let block = block.clone().with_stmts(stmts);
+    input_ast.with_nodes(block).update_positions()
 }

--- a/src/sort_requires.rs
+++ b/src/sort_requires.rs
@@ -1,0 +1,32 @@
+//! Sort Requires CodeMod
+//! This is an optional extension which will firstly sort all requires within a file before formatting the file
+//!
+//! The following assumptions are made when using this codemod:
+//! - All requires are pure and have no side effects: resorting the requires is not an issue
+//! - Only requires at the top level block are to be sorted
+//! - Requires are of the form `local NAME = require(REQUIRE)`, with only a single require per local assignment
+//!
+//! Requires sorting works in the following way:
+//! - We group consecutive requires into a "block".
+//!   If we hit a line which is a non-require or empty, we close the old block and start a new one.
+//! - Requires are sorted only within their block.
+//!   This allows us to solve the assumption of depending on local variables
+//!   (if there is a local variable in between requires, it would split them into two separate blocks,
+//!   so a require will always be after any local variable it uses)
+//! - Blocks remain in-place in the file.
+use serde::Deserialize;
+
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
+pub struct SortRequiresConfig {
+    /// Whether the sort requires codemod is enabled
+    enabled: bool,
+}
+
+impl SortRequiresConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+    pub fn set_enabled(&self, enabled: bool) -> Self {
+        Self { enabled }
+    }
+}

--- a/tests/inputs-sort-requires/basic.lua
+++ b/tests/inputs-sort-requires/basic.lua
@@ -1,0 +1,4 @@
+local bee = require("b")
+local ah = require("a")
+
+print("hello world")

--- a/tests/inputs-sort-requires/chained-dependency.lua
+++ b/tests/inputs-sort-requires/chained-dependency.lua
@@ -1,0 +1,6 @@
+local holder = script.Parent
+local modules = holder.Modules
+local cee = require(modules.Script)
+local bee = require(modules.BeeMovie)
+local aa = require(modules.Test)
+print("hello!")

--- a/tests/inputs-sort-requires/dependency.lua
+++ b/tests/inputs-sort-requires/dependency.lua
@@ -1,0 +1,7 @@
+local parent = script.Parent
+local x = foo()
+local bee = require("aaa")
+local cee = require(parent.Cee)
+local aaa = require(parent.Script)
+
+print("hello world")

--- a/tests/inputs-sort-requires/groups-2.lua
+++ b/tests/inputs-sort-requires/groups-2.lua
@@ -1,0 +1,22 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Roact = require(ReplicatedStorage.Packages.Roact)
+local Rodux = require(ReplicatedStorage.Packages.Rodux)
+local RoactRodux = require(ReplicatedStorage.Packages.RoactRodux)
+local Binder = require(ReplicatedStorage.Packages.Binder)
+
+local Remotes = require(ReplicatedStorage.Shared.Remotes)
+
+local Reducers = require(script.Reducers)
+local RobAmount = require(script.Components.RobAmount)
+local CleaningMoney = require(script.Components.CleaningMoney)
+local VaultHacking = require(script.Components.VaultHacking)
+local DisablePower = require(script.Components.DisablePower)
+local BankTellerScreen = require(script.Components.Banking.BankTellerScreen)
+local ATMMachine = require(script.Components.Banking.ATM)
+local Bank = require(script.Bank)
+local MoneyLaunderer = require(script.MoneyLaunderer)
+local BankTeller = require(script.BankTeller)
+local ATM = require(script.ATM)
+local MoneyInfo = require(script.Parent:WaitForChild("MoneyInfo"))
+local LocalPlayer = Players.LocalPlayer

--- a/tests/inputs-sort-requires/groups.lua
+++ b/tests/inputs-sort-requires/groups.lua
@@ -1,0 +1,13 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local mainB = require(ReplicatedStorage.B)
+local mainA = require(ReplicatedStorage.A)
+
+local Packages = ReplicatedStorage.Packages
+local Z = require(Packages.Z)
+local Y = require(Packages.Y)
+local X = require(Packages.X)
+
+local Modules = ReplicatedStorage.Modules
+local C = require(Modules.C)
+local B = require(Modules.B)
+local A = require(Modules.A)

--- a/tests/inputs-sort-requires/ignore-comment.lua
+++ b/tests/inputs-sort-requires/ignore-comment.lua
@@ -1,0 +1,14 @@
+-- stylua: ignore
+local c   = require("c")
+local b = require("b")
+local a = require("a")
+
+local c = require("c")
+-- stylua: ignore
+local b   = require("b")
+local a = require("a")
+
+local c = require("c")
+local b = require("b")
+-- stylua: ignore
+local a   = require("a")

--- a/tests/inputs-sort-requires/ignore-multi-require.lua
+++ b/tests/inputs-sort-requires/ignore-multi-require.lua
@@ -1,0 +1,2 @@
+local c = require("c")
+local b, a = require("b"), require("a")

--- a/tests/inputs-sort-requires/separated-by-comments.lua
+++ b/tests/inputs-sort-requires/separated-by-comments.lua
@@ -1,0 +1,9 @@
+-- Services
+local C = require("C")
+local B = require("B")
+local A = require("A")
+
+-- Packages
+local Z = require("Z")
+local Y = require("Y")
+local X = require("X")

--- a/tests/inputs-sort-requires/sort-services-2.lua
+++ b/tests/inputs-sort-requires/sort-services-2.lua
@@ -1,0 +1,5 @@
+-- Requires should be treated as a separate group to services
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local CollectionService = game:GetService("CollectionService")
+local C = require("C")
+local A = require("A")

--- a/tests/inputs-sort-requires/sort-services.lua
+++ b/tests/inputs-sort-requires/sort-services.lua
@@ -1,0 +1,2 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local CollectionService = game:GetService("CollectionService")

--- a/tests/inputs-sort-requires/variable-case.lua
+++ b/tests/inputs-sort-requires/variable-case.lua
@@ -1,0 +1,5 @@
+local calling = require("../calling")
+local Calling = require("../Calling")
+local D = require("./D")
+local A = require("./A")
+local a = require("./a")

--- a/tests/snapshots/tests__sort_requires@basic.lua.snap
+++ b/tests/snapshots/tests__sort_requires@basic.lua.snap
@@ -1,0 +1,9 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local ah = require("a")
+local bee = require("b")
+
+print("hello world")
+

--- a/tests/snapshots/tests__sort_requires@chained-dependency.lua.snap
+++ b/tests/snapshots/tests__sort_requires@chained-dependency.lua.snap
@@ -1,0 +1,11 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local holder = script.Parent
+local modules = holder.Modules
+local aa = require(modules.Test)
+local bee = require(modules.BeeMovie)
+local cee = require(modules.Script)
+print("hello!")
+

--- a/tests/snapshots/tests__sort_requires@dependency.lua.snap
+++ b/tests/snapshots/tests__sort_requires@dependency.lua.snap
@@ -1,0 +1,12 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local parent = script.Parent
+local x = foo()
+local aaa = require(parent.Script)
+local bee = require("aaa")
+local cee = require(parent.Cee)
+
+print("hello world")
+

--- a/tests/snapshots/tests__sort_requires@empty.lua.snap
+++ b/tests/snapshots/tests__sort_requires@empty.lua.snap
@@ -1,0 +1,5 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+

--- a/tests/snapshots/tests__sort_requires@groups-2.lua.snap
+++ b/tests/snapshots/tests__sort_requires@groups-2.lua.snap
@@ -1,0 +1,27 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Binder = require(ReplicatedStorage.Packages.Binder)
+local Roact = require(ReplicatedStorage.Packages.Roact)
+local RoactRodux = require(ReplicatedStorage.Packages.RoactRodux)
+local Rodux = require(ReplicatedStorage.Packages.Rodux)
+
+local Remotes = require(ReplicatedStorage.Shared.Remotes)
+
+local ATM = require(script.ATM)
+local ATMMachine = require(script.Components.Banking.ATM)
+local Bank = require(script.Bank)
+local BankTeller = require(script.BankTeller)
+local BankTellerScreen = require(script.Components.Banking.BankTellerScreen)
+local CleaningMoney = require(script.Components.CleaningMoney)
+local DisablePower = require(script.Components.DisablePower)
+local MoneyInfo = require(script.Parent:WaitForChild("MoneyInfo"))
+local MoneyLaunderer = require(script.MoneyLaunderer)
+local Reducers = require(script.Reducers)
+local RobAmount = require(script.Components.RobAmount)
+local VaultHacking = require(script.Components.VaultHacking)
+local LocalPlayer = Players.LocalPlayer
+

--- a/tests/snapshots/tests__sort_requires@groups.lua.snap
+++ b/tests/snapshots/tests__sort_requires@groups.lua.snap
@@ -1,0 +1,18 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local mainA = require(ReplicatedStorage.A)
+local mainB = require(ReplicatedStorage.B)
+
+local Packages = ReplicatedStorage.Packages
+local X = require(Packages.X)
+local Y = require(Packages.Y)
+local Z = require(Packages.Z)
+
+local Modules = ReplicatedStorage.Modules
+local A = require(Modules.A)
+local B = require(Modules.B)
+local C = require(Modules.C)
+

--- a/tests/snapshots/tests__sort_requires@ignore-comment.lua.snap
+++ b/tests/snapshots/tests__sort_requires@ignore-comment.lua.snap
@@ -1,0 +1,19 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+-- stylua: ignore
+local c   = require("c")
+local b = require("b")
+local a = require("a")
+
+local c = require("c")
+-- stylua: ignore
+local b   = require("b")
+local a = require("a")
+
+local b = require("b")
+local c = require("c")
+-- stylua: ignore
+local a   = require("a")
+

--- a/tests/snapshots/tests__sort_requires@ignore-multi-require.lua.snap
+++ b/tests/snapshots/tests__sort_requires@ignore-multi-require.lua.snap
@@ -1,0 +1,7 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local c = require("c")
+local b, a = require("b"), require("a")
+

--- a/tests/snapshots/tests__sort_requires@separated-by-comments.lua.snap
+++ b/tests/snapshots/tests__sort_requires@separated-by-comments.lua.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+-- Services
+local A = require("A")
+local B = require("B")
+local C = require("C")
+
+-- Packages
+local X = require("X")
+local Y = require("Y")
+local Z = require("Z")
+

--- a/tests/snapshots/tests__sort_requires@sort-services-2.lua.snap
+++ b/tests/snapshots/tests__sort_requires@sort-services-2.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+-- Requires should be treated as a separate group to services
+local CollectionService = game:GetService("CollectionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local A = require("A")
+local C = require("C")
+

--- a/tests/snapshots/tests__sort_requires@sort-services.lua.snap
+++ b/tests/snapshots/tests__sort_requires@sort-services.lua.snap
@@ -1,0 +1,7 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local CollectionService = game:GetService("CollectionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+

--- a/tests/snapshots/tests__sort_requires@variable-case.lua.snap
+++ b/tests/snapshots/tests__sort_requires@variable-case.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),\n        None, OutputVerification::None).unwrap()"
+---
+local A = require("./A")
+local Calling = require("../Calling")
+local D = require("./D")
+local a = require("./a")
+local calling = require("../calling")
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,5 @@
 use stylua_lib::{
-    format_code, sort_requires::SortRequiresConfig, CollapseSimpleStatement, Config,
-    OutputVerification,
+    format_code, CollapseSimpleStatement, Config, OutputVerification, SortRequiresConfig,
 };
 
 fn format(input: &str) -> String {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,7 @@
-use stylua_lib::{format_code, CollapseSimpleStatement, Config, OutputVerification};
+use stylua_lib::{
+    format_code, sort_requires::SortRequiresConfig, CollapseSimpleStatement, Config,
+    OutputVerification,
+};
 
 fn format(input: &str) -> String {
     format_code(input, Config::default(), None, OutputVerification::None).unwrap()
@@ -110,4 +113,18 @@ fn test_collapse_single_statement_lua_52() {
     if key == "s" then goto continue end
     "###
     );
+}
+
+#[test]
+fn test_sort_requires() {
+    insta::glob!("inputs-sort-requires/*.lua", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_snapshot!(format_code(
+            &contents,
+            Config::default().with_sort_requires(SortRequiresConfig::default().set_enabled(true)),
+            None,
+            OutputVerification::None
+        )
+        .unwrap());
+    })
 }


### PR DESCRIPTION
Take 2 on the sort requires system (supersedes #454)
We take a much simpler approach here.

The following assumptions are made when using this codemod:
- All requires are pure and have no side effects: resorting the requires is not an issue
- Only requires at the top level block are to be sorted
- Requires are of the form `local NAME = require(REQUIRE)`, with only a single require per local assignment

Requires sorting works in the following way:
- We group consecutive requires into a "block". If we hit a line which is a non-require or empty, we close the old block and start a new one.
- Requires are sorted only within their block. This allows us to solve the assumption of depending on local variables (if there is a local variable in between requires, it would split them into two separate blocks, so a require will always be after any local variable it uses)
- Blocks remain in-place in the file.
- If any of the block contains an ignore comment (`-- stylua: ignore`), or falls outside of the specified range, then the whole block will be skipped

We also sort services of the form `local NAME = game:GetService(EXPR)` in the same way (treated as a separate group)

Closes #364 