### PR TITLE
vscode-stylua: search configuration file for Lua files not in workspace

### DIFF
--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { formatCode, checkIgnored } from "./stylua";
 import { GitHub } from "./github";
 import { StyluaDownloader } from "./download";
@@ -84,7 +85,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const currentWorkspace = vscode.workspace.getWorkspaceFolder(
           document.uri
         );
-        const cwd = currentWorkspace?.uri?.fsPath;
+        // const cwd = currentWorkspace?.uri?.fsPath;
+        const cwd = path.dirname(document.uri.fsPath);
 
         if (await checkIgnored(document.uri, currentWorkspace?.uri)) {
           return [];


### PR DESCRIPTION
Hi,

The current VSCode StyLua extension is unable to search for configuration files in parent directories of a Lua file not in the current workspace.

I fixed that issue by setting the `cwd` parameter to the parent directory of the currently opened file.

Can you consider merging this PR?

Thanks!