### PR TITLE
Update dependabot npm ecosystem configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,12 @@ updates:
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/stylua-npm-bin"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/stylua-vscode"
     schedule:
       interval: "weekly"
       


### PR DESCRIPTION
Hi, I've notice your dependabot have npm ecosystem configurations.

but as [the document say for `directory` field](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-dependabotyml-file): Look for `package.json` and `lock` files in the `directory` directory, current configuration for npm ecosystem is invalid