### PR TITLE
Add new release artifact x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
             artifact-alias: stylua-linux
             cargo-target: x86_64-unknown-linux-gnu
           - os: ubuntu-20.04
+            artifact-name: stylua-linux-x86_64-musl
+            cargo-target: x86_64-unknown-linux-musl
+          - os: ubuntu-20.04
             artifact-name: stylua-linux-aarch64
             cargo-target: aarch64-unknown-linux-gnu
             linker: gcc-aarch64-linux-gnu


### PR DESCRIPTION
Hi, thanks for `stylua` formatter! I use it a lot within neovim.

The aim of this PR is to support distro like Alpine Linux (on amd64 arch),
building and attaching a new artifact for the target `x86_64-unknown-linux-musl` 
when releasing with `release.yml` workflow

From local tests, the build process for this new target finished without errors ... only one warning
```log
 warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-linux-musl`
```
related to the `[lib]` part of `Cargo.toml`

Let me know if I need to do something ... maybe trigger some CI to test `stylua` works also for this new target