### PR TITLE
Write files only if modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed handling of floor division (`//`) syntax when only Luau FFlag is enabled
 - Fixed missing space when table is inside of Luau interpolated string expression (`{{` is invalid syntax)
+- The CLI tool will now only write files if the contents differ, and not modify if no change (#827)
 
 ## [0.19.1] - 2023-11-15
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -180,8 +180,10 @@ fn format_file(
             None => Ok(FormatResult::Complete),
         }
     } else {
-        fs::write(path, formatted_contents)
-            .with_context(|| format!("could not write to {}", path.display()))?;
+        if formatted_contents != contents {
+            fs::write(path, formatted_contents)
+                .with_context(|| format!("could not write to {}", path.display()))?;
+        }
         Ok(FormatResult::Complete)
     }
 }


### PR DESCRIPTION
Only write a file if the contents before and after are different.

`O(n)` check, but I don't think it matters (formatting is still the most expensive part!)

Fixes #827 