### PR TITLE
Keep parentheses around compound type in table indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed handling of floor division (`//`) syntax when only Luau FFlag is enabled
 - Fixed missing space when table is inside of Luau interpolated string expression (`{{` is invalid syntax)
+- Fixed parentheses around a Luau compound type inside of a type table indexer being removed causing a syntax error (#828)
 
 ## [0.19.1] - 2023-11-15
 

--- a/tests/inputs-luau/types_parentheses_table_indexer.lua
+++ b/tests/inputs-luau/types_parentheses_table_indexer.lua
@@ -1,0 +1,4 @@
+--- https://github.com/JohnnyMorganz/StyLua/issues/828
+type foo = {
+	[("bar" | "baz")]: any,
+}

--- a/tests/snapshots/tests__luau@types_parentheses_table_indexer.lua.snap
+++ b/tests/snapshots/tests__luau@types_parentheses_table_indexer.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+input_file: tests/inputs-luau/types_parentheses_table_indexer.lua
+---
+--- https://github.com/JohnnyMorganz/StyLua/issues/828
+type foo = {
+	[("bar" | "baz")]: any,
+}
+


### PR DESCRIPTION
Fixes #828 