### PR TITLE
Don't put function definition parentheses on multiple lines when no parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing space when table is inside of Luau interpolated string expression (`{{` is invalid syntax)
 - The CLI tool will now only write files if the contents differ, and not modify if no change (#827)
 - Fixed parentheses around a Luau compound type inside of a type table indexer being removed causing a syntax error (#828)
+- Fixed function body parentheses being placed on multiple lines unnecessarily when there are no parameters (#830)
 
 ## [0.19.1] - 2023-11-15
 

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -572,6 +572,10 @@ fn should_parameters_format_multiline(
     const PARENS_LEN: usize = "()".len();
     const SINGLELINE_END_LEN: usize = " end".len();
 
+    if function_body.parameters().is_empty() {
+        return false;
+    }
+
     // Check the length of the parameters. We need to format them first onto a single line to check if required
     let mut line_length = format_singleline_parameters(ctx, function_body, shape)
         .to_string()

--- a/tests/inputs/function-definition-multiline-2.lua
+++ b/tests/inputs/function-definition-multiline-2.lua
@@ -1,0 +1,4 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/830
+local a_very_long_variable_name_given_that_is_bigger_than_width_upper_limit_but_unfortunately_can_not_be_made_shorter = function()
+	print("Hello")
+end

--- a/tests/snapshots/tests__standard@function-definition-multiline-2.lua.snap
+++ b/tests/snapshots/tests__standard@function-definition-multiline-2.lua.snap
@@ -1,0 +1,10 @@
+---
+source: tests/tests.rs
+expression: format(&contents)
+input_file: tests/inputs/function-definition-multiline-2.lua
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/830
+local a_very_long_variable_name_given_that_is_bigger_than_width_upper_limit_but_unfortunately_can_not_be_made_shorter = function()
+	print("Hello")
+end
+


### PR DESCRIPTION
Fixes #830 