### PR TITLE
Skip files in .gitignore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The CLI tool will now only write files if the contents differ, and not modify if no change (#827)
 - Fixed parentheses around a Luau compound type inside of a type table indexer being removed causing a syntax error (#828)
 - Fixed function body parentheses being placed on multiple lines unnecessarily when there are no parameters (#830)
+- Ignore files in .gitignore by default.
 
 ## [0.19.1] - 2023-11-15
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -315,7 +315,7 @@ fn format(opt: opt::Opt) -> Result<i32> {
     }
 
     walker_builder
-        .standard_filters(false)
+        .standard_filters(true)
         .hidden(!opt.allow_hidden)
         .parents(true)
         .add_custom_ignore_filename(".styluaignore");


### PR DESCRIPTION
This is a common behavior of formatters (e.g Ruff and Black) as it's arguably a more useful default behavior.

Closes https://github.com/JohnnyMorganz/StyLua/issues/833.