### PR TITLE
extension: add `stylua.configPath`

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,10 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Added
+
+- Added configuration option `stylua.configPath` to provide a direct path to a `stylua.toml` file. Note: this will override any workspace config lookup
+
 ### Changed
 
 - Removed excessive error notifications on formatting failure and replaced with VSCode language status bar item

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -94,6 +94,11 @@
           "default": false,
           "description": "Disable checking the version of stylua for newer versions. Useful if you do not want network requests."
         },
+        "stylua.configPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to a `stylua.toml` configuration file. NOTE: this will override workspace configuration lookup"
+        },
         "stylua.searchParentDirectories": {
           "type": "boolean",
           "default": false,

--- a/stylua-vscode/src/stylua.ts
+++ b/stylua-vscode/src/stylua.ts
@@ -45,6 +45,15 @@ export function formatCode(
       args.push("--range-end");
       args.push(endPos.toString());
     }
+
+    const configPath = vscode.workspace
+      .getConfiguration("stylua")
+      .get<string>("configPath");
+    if (configPath && configPath.trim() !== "") {
+      args.push("--config-path");
+      args.push(configPath);
+    }
+
     if (
       vscode.workspace.getConfiguration("stylua").get("searchParentDirectories")
     ) {


### PR DESCRIPTION
Allow passing a custom path to a `stylua.toml` file, overriding any workspace config lookup

Closes #782 