### PR TITLE
Overhaul extension bundling

### DIFF
--- a/stylua-vscode/package-lock.json
+++ b/stylua-vscode/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ignore": "^5.1.8",
         "node-fetch": "^2.6.1",
+        "node-which": "^1.0.0",
         "semver": "^7.5.4",
         "unzipper": "^0.10.14"
       },
@@ -21,6 +22,7 @@
         "@types/node-fetch": "^2.5.8",
         "@types/unzipper": "^0.10.8",
         "@types/vscode": "^1.82.0",
+        "@types/which": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",
         "@vscode/test-cli": "^0.0.4",
@@ -346,6 +348,12 @@
       "version": "1.82.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
       "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+      "dev": true
+    },
+    "node_modules/@types/which": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2128,6 +2136,12 @@
         }
       }
     },
+    "node_modules/node-which": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-which/-/node-which-1.0.0.tgz",
+      "integrity": "sha512-PVVbv6DyDc3VkTizcd/7Xchn3NDh+OUnQkrHxgumQ+2lwoWE36KuQClfAVjTwEh3T0jzb1WHrbgCol5HbBZqdQ==",
+      "deprecated": "please use 'which'"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3147,6 +3161,12 @@
       "version": "1.82.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
       "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+      "dev": true
+    },
+    "@types/which": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -4451,6 +4471,11 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-which": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-which/-/node-which-1.0.0.tgz",
+      "integrity": "sha512-PVVbv6DyDc3VkTizcd/7Xchn3NDh+OUnQkrHxgumQ+2lwoWE36KuQClfAVjTwEh3T0jzb1WHrbgCol5HbBZqdQ=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -143,6 +143,7 @@
     "@types/node-fetch": "^2.5.8",
     "@types/unzipper": "^0.10.8",
     "@types/vscode": "^1.82.0",
+    "@types/which": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vscode/test-cli": "^0.0.4",
@@ -156,6 +157,7 @@
   "dependencies": {
     "ignore": "^5.1.8",
     "node-fetch": "^2.6.1",
+    "node-which": "^1.0.0",
     "semver": "^7.5.4",
     "unzipper": "^0.10.14"
   }


### PR DESCRIPTION
Supersedes #767 

Instead of bundling extension, we still rely on downloading, but with a better interface.

Supports stylua binary on PATH (Closes #527)

TODO:
- foreman/aftman handling: if not configured, fall back to bundled version
- Display "bundled" status in status bar
- Check bundled version matches requested version if targetReleaseVersion set (currently this is linked with getting latest version, and has a bad message)
- Latest version notifier