### PR TITLE
fix(stylua-npm-bin): adjust axios config to work with proxy env variables

### DIFF
--- a/stylua-npm-bin/binary.js
+++ b/stylua-npm-bin/binary.js
@@ -4,6 +4,7 @@ const os = require("os");
 const axios = require("axios");
 const unzip = require("unzipper");
 const rimraf = require("rimraf");
+const { ProxyAgent } = require('proxy-agent');
 const { join } = require("path");
 const { existsSync, mkdirSync, createWriteStream } = require("fs");
 const { spawnSync } = require("child_process");
@@ -44,8 +45,12 @@ const error = (msg) => {
 };
 
 const downloadArtifact = (url, location) => {
+  const agent = new ProxyAgent();
   return new Promise((resolve, reject) => {
     axios
+      // proxy: false is needed, otherwise axios is trying to overwrite the agent
+      // See https://github.com/axios/axios/issues/4531
+      .create({ proxy: false, httpAgent: agent, httpsAgent: agent })
       .get(url, { responseType: "stream" })
       .then((res) => res.data.pipe(unzip.Parse()))
       .then((stream) => {

--- a/stylua-npm-bin/package.json
+++ b/stylua-npm-bin/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "node-fetch": "^3.2.10",
+    "proxy-agent": "^6.4.0",
     "rimraf": "^3.0.2",
     "unzipper": "^0.10.11"
   }


### PR DESCRIPTION
Hello,

First of all, thanks for providing this code formatter on so many distribution channels 🙏🏻 

We wanted to pull the wrapper from [npm](https://github.com/JohnnyMorganz/StyLua?tab=readme-ov-file#npm) so we added it to our `yarn` dependencies. 

However, since we are behind a corporate proxy, the install just failed. More precisely, `axios` was not correctly resolving the GitHub redirects in addition to our proxy environment variables:

<details>
  <summary>Some output from our GitLab CI job</summary>

```sh
$ https_proxy=$PROXY no_proxy=$NO_PROXY yarn --frozen-lockfile
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
warning smol-toml@1.2.0: The engine "pnpm" appears to be invalid.
[3/4] Linking dependencies...
warning "@commitlint/cli > @commitlint/load > cosmiconfig-typescript-loader@5.0.0" has unmet peer dependency "@types/node@*".
warning "@commitlint/cli > @commitlint/load > cosmiconfig-typescript-loader@5.0.0" has unmet peer dependency "typescript@>=4".
[4/4] Building fresh packages...
error /builds/<REDACTED>/node_modules/@johnnymorganz/stylua-bin: Command failed.
Exit code: 1
Command: node ./install.js
Arguments: 
Directory: /builds/<REDACTED>/node_modules/@johnnymorganz/stylua-bin
Output:
Downloading release from https://github.com/johnnymorganz/stylua/releases/download/v0.20.0/stylua-linux-x86_64.zip
Error fetching release: Maximum number of redirects exceeded
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
</details>

This is kind of a known issue, see https://github.com/axios/axios/issues/2072 for instance.

This MR implements the fix proposed in https://github.com/axios/axios/issues/4531#issuecomment-1608140085.

---

If you are open to it, another option would be to get rid of `axios`. I see it is [only used once](https://github.com/JohnnyMorganz/StyLua/blob/main/stylua-npm-bin/binary.js#L48) so I could refactor the code and just switch to a native `node` fetch. I could use the [undici - fetch](https://undici.nodejs.org/#/) for instance: we [recently contributed upstream to editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker.javascript/commit/b6f19742da5d22e47ca09884b13c0bed03b551f1) to also bring back support for http proxies 😉 

/cc @nejch @fgreinacher @bufferoverflow

🛠️ with ❤️ by [Siemens](https://opensource.siemens.com/)