### PR TITLE
Add loongarch support

### DIFF
--- a/stylua-vscode/src/util.ts
+++ b/stylua-vscode/src/util.ts
@@ -39,6 +39,9 @@ export const getAssetFilenamePatternForPlatform = (
     case "arm64":
       archPattern = "aarch64";
       break;
+    case "loongarch64":
+      archPattern = "loongarch64";
+      break;
     case "x64":
       archPattern = "x86_64";
       break;


### PR DESCRIPTION
test result on LoongArchLinux:

```
running 57 tests
test editorconfig::tests::test_call_parentheses_no_single_table ... ok
test editorconfig::tests::test_call_parentheses_always ... ok
test editorconfig::tests::test_call_parentheses_no_single_string ... ok
test editorconfig::tests::test_call_parentheses_none ... ok
test editorconfig::tests::test_collapse_simple_statement_always ... ok
test editorconfig::tests::test_collapse_simple_statement_conditional_only ... ok
test editorconfig::tests::test_collapse_simple_statement_function_only ... ok
test editorconfig::tests::test_end_of_line_cr ... ok
test editorconfig::tests::test_collapse_simple_statement_never ... ok
test editorconfig::tests::test_end_of_line_crlf ... ok
test editorconfig::tests::test_end_of_line_lf ... ok
test editorconfig::tests::test_indent_size ... ok
test editorconfig::tests::test_indent_size_use_tab_width ... ok
test editorconfig::tests::test_indent_style_space ... ok
test editorconfig::tests::test_indent_style_tab ... ok
test editorconfig::tests::test_invalid_properties ... ok
test editorconfig::tests::test_max_line_length ... ok
test editorconfig::tests::test_max_line_length_off ... ok
test editorconfig::tests::test_quote_type_auto ... ok
test editorconfig::tests::test_quote_type_double ... ok
test editorconfig::tests::test_quote_type_single ... ok
test editorconfig::tests::test_sort_requires_disabled ... ok
test editorconfig::tests::test_sort_requires_enabled ... ok
test formatters::trivia_util::tests::test_token_contains_no_singleline_comments ... ok
test formatters::trivia_util::tests::test_token_contains_no_singleline_comments_2 ... ok
test formatters::trivia_util::tests::test_token_contains_singleline_comments ... ok
test sort_requires::tests::fail_extracting_non_identifier_token ... ok
test sort_requires::tests::get_expression_kind_other_4 ... ok
test sort_requires::tests::get_expression_kind_other_1 ... ok
test sort_requires::tests::get_expression_kind_other_2 ... ok
test sort_requires::tests::get_expression_kind_other_6 ... ok
test sort_requires::tests::get_expression_kind_get_service ... ok
test sort_requires::tests::get_expression_kind_other_3 ... ok
test sort_requires::tests::get_expression_kind_other_5 ... ok
test sort_requires::tests::get_expression_kind_require_stmt ... ok
test tests::test_config_call_parentheses ... ok
test tests::test_config_column_width ... ok
test tests::test_config_indent_type ... ok
test tests::test_config_indent_width ... ok
test tests::test_config_line_endings ... ok
test tests::test_config_quote_style ... ok
test tests::test_invalid_input ... ok
test verify_ast::tests::test_different_hex_numbers ... ok
test verify_ast::tests::test_equivalent_asts ... ok
test tests::test_entry_point ... ok
test verify_ast::tests::test_equivalent_numbers ... ok
test verify_ast::tests::test_equivalent_function_calls ... ok
test verify_ast::tests::test_different_asts ... ok
test verify_ast::tests::test_equivalent_conditions ... ok
test tests::test_with_ast_verification ... ok
test verify_ast::tests::test_equivalent_hex_numbers ... ok
test verify_ast::tests::test_equivalent_function_calls_2 ... ok
test verify_ast::tests::test_equivalent_numbers_2 ... ok
test verify_ast::tests::test_equivalent_stmt_semicolons ... ok
test verify_ast::tests::test_equivalent_string_escapes ... ok
test verify_ast::tests::test_equivalent_string_quote_types ... ok
test verify_ast::tests::test_equivalent_table_separators ... ok

test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running unittests src/cli/main.rs (target/debug/deps/stylua-c3f35a587622bed9)

running 18 tests
test output_diff::tests::test_addition_diff ... ok
test output_diff::tests::test_change_diff ... ok
test output_diff::tests::test_deletion_diff ... ok
test output_diff::tests::test_no_diff ... ok
test opt::tests::verify_opt ... ok
test config::tests::test_override_indent_width ... ok
test config::tests::test_override_indent_type ... ok
test config::tests::test_override_call_parentheses ... ok
test config::tests::test_override_column_width ... ok
test config::tests::test_override_quote_style ... ok
test config::tests::test_override_line_endings ... ok
test tests::test_no_files_provided ... ok
test tests::test_format_stdin ... ok
test tests::test_format_file ... ok
test tests::explicitly_provided_files_dont_check_ignores ... ok
test tests::test_stylua_ignore ... ok
test tests::test_respect_ignores_directory_no_glob ... ok
test tests::test_respect_ignores ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/test_call_parentheses.rs (target/debug/deps/test_call_parentheses-2674d63e30a8977e)

running 12 tests
test test_call_parens_no_single_table_handles_string_correctly ... ok
test test_call_parens_no_single_string_handles_string_correctly ... ok
test test_call_parens_comments ... ok
test test_call_parens_input ... ok
test test_call_parens_always_handles_table_correctly ... ok
test test_call_parens_no_single_string_handles_table_correctly ... ok
test test_call_parens_always_handles_string_correctly ... ok
test test_call_parens_none_handles_string_correctly ... ok
test test_call_parens_semicolons ... ok
test test_call_parens_no_single_table_handles_table_correctly ... ok
test test_call_parens_has_no_affect_on_multi_arg_fn_calls_ ... ok
test test_call_parens_none_handles_table_correctly ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/test_editorconfig.rs (target/debug/deps/test_editorconfig-c7ec7c9ba805ac03)

running 5 tests
test test_root ... ok
test test_empty_root ... ok
test test_local ... ok
test test_global ... ok
test test_stylua_toml ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

     Running tests/test_no_call_parens.rs (target/debug/deps/test_no_call_parens-16bc16497127709e)

running 10 tests
test test_no_parens_method_chain_1 ... ok
test test_no_parens_multiline_table ... ok
test test_keep_parens_binop_string ... ok
test test_no_parens_brackets_string ... ok
test test_no_parens_string ... ok
test test_no_parens_large_example ... ok
test test_no_parens_singleline_table ... ok
test test_no_parens_method_chain_2 ... ok
test test_omit_parens_brackets_string ... ok
test test_omit_parens_string ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/test_quote_style.rs (target/debug/deps/test_quote_style-010ced2b11c14aac)

running 4 tests
test test_force_single_quotes ... ok
test test_auto_prefer_double_quotes ... ok
test test_force_double_quotes ... ok
test test_auto_prefer_single_quotes ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/test_ranges.rs (target/debug/deps/test_ranges-f329a11f090e2866)

running 19 tests
test test_incomplete_range ... ok
test test_nested_range_do ... ok
test test_dont_modify_eof ... ok
test test_nested_range_binop ... ok
test test_default ... ok
test test_nested_range ... ok
test test_ignore_last_stmt ... ok
test test_large_example ... ok
test test_nested_range_repeat ... ok
test test_nested_range_generic_for ... ok
test test_nested_range_function_call ... ok
test test_nested_range_else_if ... ok
test test_nested_range_function_call_table ... ok
test test_nested_range_table_1 ... ok
test test_nested_range_while ... ok
test test_nested_range_table_2 ... ok
test test_no_range_start ... ok
test test_no_range_end ... ok
test test_nested_range_local_function ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/tests.rs (target/debug/deps/tests-4b08a79754201d84)

running 7 tests
test test_crlf_in_multiline_strings ... ok
test test_crlf_in_multiline_comments ... ok
test test_ignores ... ok
test test_sort_requires ... ok
test test_full_moon_test_suite ... ok
test test_collapse_single_statement ... ok
test test_standard ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.58s

   Doc-tests stylua_lib
'+frecipe' is not a recognized feature for this target (ignoring feature)
'+frecipe' is not a recognized feature for this target (ignoring feature)
'+relax' is not a recognized feature for this target (ignoring feature)
'+relax' is not a recognized feature for this target (ignoring feature)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```