### PR TITLE
Remove legacy release artifacts from GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,9 @@ jobs:
         include:
           - os: windows-latest
             artifact-name: stylua-windows-x86_64
-            artifact-alias: stylua-win64
             cargo-target: x86_64-pc-windows-msvc
           - os: ubuntu-20.04
             artifact-name: stylua-linux-x86_64
-            artifact-alias: stylua-linux
             cargo-target: x86_64-unknown-linux-gnu
           - os: ubuntu-20.04
             artifact-name: stylua-linux-x86_64-musl
@@ -44,7 +42,6 @@ jobs:
             linker: gcc-aarch64-linux-gnu
           - os: macos-latest
             artifact-name: stylua-macos-x86_64
-            artifact-alias: stylua-macos
             cargo-target: x86_64-apple-darwin
           - os: macos-latest
             artifact-name: stylua-macos-aarch64
@@ -100,18 +97,6 @@ jobs:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: release.zip
           asset_name: ${{ matrix.artifact-name }}.zip
-          asset_content_type: application/zip
-
-      # TODO: Remove this after deprecation notice
-      - name: Upload Binary to Release aliases
-        if: ${{ matrix.artifact-alias != '' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: release.zip
-          asset_name: ${{ matrix.artifact-alias }}.zip
           asset_content_type: application/zip
 
   release_cargo:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- For automated downloaders: the legacy release artifacts `stylua-win64.zip`, `stylua-linux.zip` and `stylua-macos.zip` are no longer produced in GitHub releases, in favour of more specific names (e.g., `stylua-windows-x86_64`, `stylua-linux-x86_64` and `stylua-macos-x86_64`).
+
 ### Added
 
 - Added runtime syntax configuration option `syntax` to help handle ambiguous syntax. By default, StyLua builds and runs with a parser to handle all Lua versions. However, the syntax of some Lua versions conflict with eachother: most notably, Lua 5.2+ goto label syntax `::label::` and Luau type assertion operator `::`. This option allows choosing what syntax to parse, to handle these conflicts. ([#407](https://github.com/JohnnyMorganz/StyLua/issues/407))


### PR DESCRIPTION
Back in #559, we created more specific release artifacts matching platforms.

As we approach v2, there has been sufficient time for users to move away from these legacy artifacts. It is time to retire them.