### PR TITLE
Don't ignore by default with `--stdin-filepath`, use `--respect-ignores`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - For automated downloaders: the legacy release artifacts `stylua-win64.zip`, `stylua-linux.zip` and `stylua-macos.zip` are no longer produced in GitHub releases, in favour of more specific names (e.g., `stylua-windows-x86_64`, `stylua-linux-x86_64` and `stylua-macos-x86_64`).
+- `--stdin-filepath` no longer respects ignore files by default, in line with passing files directly to the command line. Now, `stylua --stdin-filepath foo.lua -` will still format the stdin even if `foo.lua` was in a `.styluaignore` file. Use `--respect-ignores` to preserve the original behaviour.
 
 ### Added
 


### PR DESCRIPTION
Back in #765, we introduced `--respect-ignores` behaviour that would force look ups in `.styluaignore` even if a file was explicitly provided on the command line.

This behaviour was not switched over for `--stdin-filepath` due to backwards compatibility reasons, since stdin ignoring was originally added in #495

Now, as we approach v2, we make the breaking change to make `--stdin-filepath` not respect ignores by default. Pass `--respect-ignores` to preserve original behaviour.