### PR TITLE
Update VSCode extension to use stdin-filepath and respect-ignores

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,11 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Changed
+
+- The VSCode extension will now defer to using `stylua` itself to determine ignores and other configuration, rather than rolling its own ignore system
+- The VSCode extension now passes `--stdin-filepath` and `--respect-ignores` to the command line
+
 ## [1.6.3] - 2024-01-06
 
 ### Fixed

--- a/stylua-vscode/package-lock.json
+++ b/stylua-vscode/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.6.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "ignore": "^5.1.8",
         "node-fetch": "^2.6.1",
         "semver": "^7.5.4",
         "unzipper": "^0.10.14",
@@ -2165,6 +2164,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5599,7 +5599,8 @@
     "ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "dev": true
     },
     "immediate": {
       "version": "3.0.6",

--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -166,7 +166,6 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "ignore": "^5.1.8",
     "node-fetch": "^2.6.1",
     "semver": "^7.5.4",
     "unzipper": "^0.10.14",

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as semver from "semver";
-import { formatCode, checkIgnored } from "./stylua";
+import { formatCode } from "./stylua";
 import { GitHub, GitHubRelease } from "./github";
 import { ResolveMode, StyluaDownloader, StyluaInfo } from "./download";
 import { getDesiredVersion } from "./util";
@@ -241,16 +241,14 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         const cwd = currentWorkspace?.uri?.fsPath;
 
-        if (await checkIgnored(document.uri, currentWorkspace?.uri)) {
-          return [];
-        }
-
         const text = document.getText();
 
         try {
           const formattedText = await formatCode(
+            outputChannel,
             styluaBinaryPath.path,
             text,
+            document.uri.fsPath,
             cwd,
             byteOffset(document, range.start),
             byteOffset(document, range.end)


### PR DESCRIPTION
Use the actual stylua binary to handle ignores, rather than reimplementing ignoring in the extension.

Enabling --stdin-filepath allows stylua's config resolution logic and ignore handling to take effect, including editorconfig support.

Closes #913