### PR TITLE
collapse_simple_stmt: check if return expressions are "simple"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.stylua.toml` config resolution now supports looking up config files next to files being formatted, recursively going
   upwards until reaching the current working directory, then stopping (unless `--search-parent-directories` was specified).
   For example, for a file `./src/test.lua`, executing `stylua src/` will look for `./src/stylua.toml` and then `./stylua.toml`.
-- When `collapse_simple_statement` is enabled, if the enclosing block is a return, we will check if the return expression is "simple" (currently, not containing a function definition)
+- When `collapse_simple_statement` is enabled, if the enclosing block is a return, we will check if the return expression is "simple" (currently, not containing a function definition) ([#898](https://github.com/JohnnyMorganz/StyLua/issues/898))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.stylua.toml` config resolution now supports looking up config files next to files being formatted, recursively going
   upwards until reaching the current working directory, then stopping (unless `--search-parent-directories` was specified).
   For example, for a file `./src/test.lua`, executing `stylua src/` will look for `./src/stylua.toml` and then `./stylua.toml`.
+- When `collapse_simple_statement` is enabled, if the enclosing block is a return, we will check if the return expression is "simple" (currently, not containing a function definition)
 
 ### Fixed
 

--- a/tests/inputs-collapse-single-statement/conditional-with-function-1.lua
+++ b/tests/inputs-collapse-single-statement/conditional-with-function-1.lua
@@ -1,0 +1,13 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/898
+
+if bar then
+	return function()
+		foo()
+	end
+end
+
+if bar then
+	return Array.filter({}, function()
+		return true
+	end)
+end

--- a/tests/snapshots/tests__collapse_single_statement@conditional-with-function-1.lua.snap
+++ b/tests/snapshots/tests__collapse_single_statement@conditional-with-function-1.lua.snap
@@ -1,0 +1,15 @@
+---
+source: tests/tests.rs
+expression: "format_code(&contents,\n        Config {\n            collapse_simple_statement: CollapseSimpleStatement::Always,\n            ..Config::default()\n        }, None, OutputVerification::None).unwrap()"
+input_file: tests/inputs-collapse-single-statement/conditional-with-function-1.lua
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/898
+
+if bar then
+	return function() foo() end
+end
+
+if bar then
+	return Array.filter({}, function() return true end)
+end
+


### PR DESCRIPTION
Right now, check if the return expression doesn't contain another function definition

Closes #898 