### PR TITLE
Use configuration from cwd when formatting from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed regression where configuration present in current working directory not used when formatting from stdin and no `--stdin-filepath` is provided ([#928](https://github.com/JohnnyMorganz/StyLua/issues/928))
+
 ## [2.0.1] - 2024-11-18
 
 ### Added

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -811,6 +811,24 @@ mod tests {
     }
 
     #[test]
+    fn test_cwd_configuration_respected_when_formatting_from_stdin() {
+        let cwd = construct_tree!({
+            "stylua.toml": "quote_style = 'AutoPreferSingle'",
+            "foo.lua": "local x = \"hello\"",
+        });
+
+        let mut cmd = create_stylua();
+        cmd.current_dir(cwd.path())
+            .arg("-")
+            .write_stdin("local x = \"hello\"")
+            .assert()
+            .success()
+            .stdout("local x = 'hello'\n");
+
+        cwd.close().unwrap();
+    }
+
+    #[test]
     fn test_cwd_configuration_respected_for_file_in_cwd() {
         let cwd = construct_tree!({
             "stylua.toml": "quote_style = 'AutoPreferSingle'",


### PR DESCRIPTION
When no `--stdin-filepath` is provided

Fixes #928 