### PR TITLE
Don't remove parentheses in `(expr :: assertion) < expr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Luau: fixed parentheses incorrectly removed in `(expr :: assertion) < foo` when multilining the expression, leading to a syntax error ([#940](https://github.com/JohnnyMorganz/StyLua/issues/940))
+
 ## [2.0.2] - 2024-12-07
 
 ### Fixed

--- a/tests/inputs-luau/excess-parentheses-type-assertion.lua
+++ b/tests/inputs-luau/excess-parentheses-type-assertion.lua
@@ -1,0 +1,3 @@
+local x = if (foo :: number) < bar
+	then very + very + very + long + line + right + here + hopefully
+	else lets + ensure + stylua + writes + this + out + using + multiple + lines

--- a/tests/snapshots/tests__luau@excess-parentheses-type-assertion.lua.snap
+++ b/tests/snapshots/tests__luau@excess-parentheses-type-assertion.lua.snap
@@ -1,0 +1,9 @@
+---
+source: tests/tests.rs
+expression: "format(&contents, LuaVersion::Luau)"
+input_file: tests/inputs-luau/excess-parentheses-type-assertion.lua
+snapshot_kind: text
+---
+local x = if (foo :: number) < bar
+	then very + very + very + long + line + right + here + hopefully
+	else lets + ensure + stylua + writes + this + out + using + multiple + lines


### PR DESCRIPTION
Causing a syntax error.

Related to #441 and #443

Fixes #940 