### PR TITLE
fix: use "summary" for the missing `--check` error message

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -266,7 +266,7 @@ fn format(opt: opt::Opt) -> Result<i32> {
             opt::OutputFormat::Unified | opt::OutputFormat::Summary
         )
     {
-        bail!("--output-format=unified and --output-format=standard can only be used when --check is enabled");
+        bail!("--output-format=unified and --output-format=summary can only be used when --check is enabled");
     }
 
     // Load the configuration


### PR DESCRIPTION
As discussed in #943 , the error message when invoking StyLua with either `unified` or `summary` without the `--check` flag was giving an error stating `standard` required the flag instead of `summary`.

This is basically just a typo PR 😅 so I'm happy for you to ignore it or whatever if it's easier for you to do it yourself.