### PR TITLE
Don't add semicolons unnecessarily for non-ambiguous statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Luau: fixed parentheses incorrectly removed in `(expr :: assertion) < foo` when multilining the expression, leading to a syntax error ([#940](https://github.com/JohnnyMorganz/StyLua/issues/940))
 - Fixed panic when attempting to format a file outside of the current working directory when `--respect-ignores` is enabled ([#969](https://github.com/JohnnyMorganz/StyLua/pull/969))
+- Fixed unnecessary semicolons being introduced at the end of statements when incorrectly determined as ambiguous ([#963](https://github.com/JohnnyMorganz/StyLua/issues/963))
 
 ## [2.0.2] - 2024-12-07
 

--- a/tests/inputs/ambiguous-syntax-2.lua
+++ b/tests/inputs/ambiguous-syntax-2.lua
@@ -1,0 +1,20 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/963
+local value = nil
+
+(Foo):Call()
+
+local tbl = {}
+
+(Foo):Call()
+
+local x = 1
+
+(Foo):Call()
+
+local x = "value"
+
+(Foo):Call()
+
+local x = function() end
+
+(Foo):Call()

--- a/tests/inputs/ambiguous-syntax-3.lua
+++ b/tests/inputs/ambiguous-syntax-3.lua
@@ -1,0 +1,17 @@
+local x = call "";
+(foo or bar and baz)(bar)
+
+local x = call {};
+(foo or bar and baz)(bar)
+
+local x = identifier;
+(foo or bar and baz)(bar)
+
+local x = (identifier);
+(foo or bar and baz)(bar)
+
+local x = x.y;
+(foo or bar and baz)(bar)
+
+local x = x["y"];
+(foo or bar and baz)(bar)

--- a/tests/snapshots/tests__standard@ambiguous-syntax-2.lua.snap
+++ b/tests/snapshots/tests__standard@ambiguous-syntax-2.lua.snap
@@ -1,0 +1,26 @@
+---
+source: tests/tests.rs
+expression: "format(&contents, LuaVersion::Lua51)"
+input_file: tests/inputs/ambiguous-syntax-2.lua
+snapshot_kind: text
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/963
+local value = nil
+
+(Foo):Call()
+
+local tbl = {}
+
+(Foo):Call()
+
+local x = 1
+
+(Foo):Call()
+
+local x = "value"
+
+(Foo):Call()
+
+local x = function() end
+
+(Foo):Call()

--- a/tests/snapshots/tests__standard@ambiguous-syntax-3.lua.snap
+++ b/tests/snapshots/tests__standard@ambiguous-syntax-3.lua.snap
@@ -1,0 +1,23 @@
+---
+source: tests/tests.rs
+expression: "format(&contents, LuaVersion::Lua51)"
+input_file: tests/inputs/ambiguous-syntax-3.lua
+snapshot_kind: text
+---
+local x = call("");
+(foo or bar and baz)(bar)
+
+local x = call({});
+(foo or bar and baz)(bar)
+
+local x = identifier;
+(foo or bar and baz)(bar)
+
+local x = identifier;
+(foo or bar and baz)(bar)
+
+local x = x.y;
+(foo or bar and baz)(bar)
+
+local x = x["y"];
+(foo or bar and baz)(bar)

--- a/tests/snapshots/tests__standard@excess-parentheses.lua.snap
+++ b/tests/snapshots/tests__standard@excess-parentheses.lua.snap
@@ -1,6 +1,8 @@
 ---
 source: tests/tests.rs
-expression: format(&contents)
+expression: "format(&contents, LuaVersion::Lua51)"
+input_file: tests/inputs/excess-parentheses.lua
+snapshot_kind: text
 ---
 local x
 something(x)
@@ -11,7 +13,7 @@ local z = (...) == nil and foo or bar
 local foo = not (bar and baz)
 local bar = #bar and baz
 local cond = condition and (not object or object.Value == y)
-local baz = (-4 + 3) * 2;
+local baz = (-4 + 3) * 2
 
 ({}):foo();
 ("hello"):format()
@@ -34,4 +36,3 @@ local y = "hello"
 local z = function()
 	return true
 end
-


### PR DESCRIPTION
Fixes #963 