### PR TITLE
Smaller text edits in lsp formatting handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The language server has an initialization option called `respect_editor_formatting_options`.
+  If it's true, the formatting handler will override the configurations `indent-width` and `indent-type` with values from [FormattingOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions)
+
 ### Changed
 
 - In language server mode, compute the difference between the unformatted and formatted document and only respond with the changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- In language server mode, compute the difference between the unformatted and formatted document and only respond with the changes.
+- Include `serverInfo` in the language server's [`InitializeResponse`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult)
+
 ### Fixed
 
 - Fixed comments lost from expression after parentheses are removed when we are attempting to "hang" the expression. ([#1033](https://github.com/JohnnyMorganz/StyLua/issues/1033))
+- `document_range_formatting_provider` field missing from `ServerCapabilities`
 
 ## [2.2.0] - 2025-09-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
 dependencies = [
  "anstyle",
- "bstr",
+ "bstr 1.9.0",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "cfg_aliases",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -418,7 +427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 1.9.0",
  "log",
  "regex-automata",
  "regex-syntax",
@@ -914,6 +923,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 dependencies = [
+ "bstr 0.2.17",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ num_cpus = "1.16.0"
 regex = "1.10.2"
 serde = "1.0.188"
 serde_json = "1.0.108"
-similar = { version = "2.3.0", features = ["text", "inline", "serde"] }
+similar = { version = "2.3.0", features = ["text", "inline", "serde", "bytes"] }
 strum = { version = "0.25.0", features = ["derive"], optional = true }
 thiserror = "1.0.49"
 threadpool = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ StyLua can run as a language server, connecting with language clients that follo
 It will then respond to `textDocument/formatting` and `textDocument/rangeFormatting` requests.
 Formatting is only performed on files with a `lua` or `luau` language ID.
 
+If the initialization option `respect_editor_formatting_options` is set to `true`, the formatting handler will override the configurations `indent-width` and `indent-type` with values from [FormattingOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions).
+
 You can start the language server by running:
 
 ```sh

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -174,6 +174,7 @@ fn handle_request(
 fn main_loop(connection: Connection, config_resolver: &mut ConfigResolver) -> anyhow::Result<()> {
     let initialize_result = InitializeResult {
         capabilities: ServerCapabilities {
+            document_range_formatting_provider: Some(OneOf::Left(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
             text_document_sync: Some(TextDocumentSyncCapability::Kind(
                 TextDocumentSyncKind::INCREMENTAL,
@@ -289,6 +290,7 @@ mod tests {
                 && result
                     == serde_json::json!({
                     "capabilities": ServerCapabilities {
+                        document_range_formatting_provider: Some(OneOf::Left(true)),
                         document_formatting_provider: Some(OneOf::Left(true)),
                         text_document_sync: Some(TextDocumentSyncCapability::Kind(
                             TextDocumentSyncKind::INCREMENTAL,

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -348,7 +348,7 @@ mod tests {
         assert!(client.receiver.is_empty());
     }
 
-    fn with_edits(text: &str, mut edits: Vec<TextEdit>) -> String {
+    fn apply_text_edits_to(text: &str, mut edits: Vec<TextEdit>) -> String {
         edits.sort_by(|a, b| match a.range.start.line.cmp(&b.range.start.line) {
             Ordering::Equal => a
                 .range
@@ -424,7 +424,28 @@ mod tests {
         expect_server_initialized(&client.receiver, 1);
 
         let edits: Vec<TextEdit> = expect_response(&client.receiver, 2);
-        let formatted = with_edits(contents, edits);
+        assert_eq!(
+            edits,
+            [
+                TextEdit {
+                    range: Range::new(Position::new(0, 6), Position::new(0, 7)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(0, 8), Position::new(0, 9)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(0, 12), Position::new(0, 13)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(0, 14), Position::new(0, 14)),
+                    new_text: "\n".to_string()
+                },
+            ]
+        );
+        let formatted = apply_text_edits_to(contents, edits);
         assert_eq!(formatted, "local x = 1\n");
 
         expect_server_shutdown(&client.receiver, 3);
@@ -479,7 +500,36 @@ mod tests {
         expect_server_initialized(&client.receiver, 1);
 
         let edits: Vec<TextEdit> = expect_response(&client.receiver, 2);
-        let formatted = with_edits(contents, edits);
+        assert_eq!(
+            edits,
+            [
+                TextEdit {
+                    range: Range::new(Position::new(1, 6), Position::new(1, 9)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(1, 10), Position::new(1, 11)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(1, 12), Position::new(1, 13)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(1, 14), Position::new(1, 15)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(1, 16), Position::new(1, 17)),
+                    new_text: "".to_string()
+                },
+                TextEdit {
+                    range: Range::new(Position::new(1, 18), Position::new(1, 18)),
+                    new_text: "\n".to_string()
+                },
+            ]
+        );
+        let formatted = apply_text_edits_to(contents, edits);
         assert_eq!(formatted, "local  x  =  1\nlocal y = 2\n");
 
         expect_server_shutdown(&client.receiver, 3);

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -182,7 +182,7 @@ fn main_loop(connection: Connection, config_resolver: &mut ConfigResolver) -> an
             ..Default::default()
         },
         server_info: Some(ServerInfo {
-            name: "stylua".to_string(),
+            name: env!("CARGO_PKG_NAME").to_string(),
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }),
     };
@@ -298,7 +298,7 @@ mod tests {
                         ..Default::default()
                     },
                     "serverInfo": Some(ServerInfo {
-                        name: "stylua".to_string(),
+                        name: env!("CARGO_PKG_NAME").to_string(),
                         version: Some(env!("CARGO_PKG_VERSION").to_string()),
                     }),
                     }) => {}


### PR DESCRIPTION
Hi, I saw the `TODO` in the new LSP implementation and thought I'd try it.

Now, the formatting handler does a byte by byte diff of the unformatted and formatted contents, and only responds with the changes between the two.
An alternative would be a line by line diff, but I found that doing it byte-wise has two advantages:
1. `document.position_at()` can be used to compute positions
2. The formatted string can just be sliced to get the new text, no need to search for line endings

<br>

Additionally, I took the liberty of implementing two other nitpicks that I had with the LSP. Let me know if you'd prefer separate PRs or don't want these at all.
1. The servers initialize response includes a [serverInfo](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult) field
3. [FormattingOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions) are respected

Couldn't find a CONTRIBUTING.md, so I hope I didn't miss any PR guidelines 😅.