### PR TITLE
Add rust version for StyLua pre-commit hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "smol_str",
  "strum",
  "thiserror",
  "threadpool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ regex = "1.10.2"
 serde = "1.0.188"
 serde_json = "1.0.108"
 similar = { version = "2.3.0", features = ["text", "inline", "serde", "bytes"] }
+smol_str = "<0.3.4"
 strum = { version = "0.25.0", features = ["derive"], optional = true }
 thiserror = "1.0.49"
 threadpool = "1.8.1"


### PR DESCRIPTION
```
error: failed to compile `stylua v2.3.1 (/pc/clone/_XddIJeZTI-thzuRq77iQw)`, intermediate artifacts can be found at `/pc/clone/_XddIJeZTI-thzuRq77iQw/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
    rustc 1.85.0 is not supported by the following package:
    smol_str@0.3.4 requires rustc 1.89
    Either upgrade rustc or select compatible dependency versions with
    `cargo update <name>@<current-ver> --precise <compatible-ver>`
    where `<compatible-ver>` is the latest version supporting rustc 1.85.0
```