### PR TITLE
Fix syntax error when comment appears between index and table call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added flag `--no-ignore-vcs` to continue formatting files listed in a `.gitignore` file, instead of skipping over them ([#895](https://github.com/JohnnyMorganz/StyLua/issues/895))
 
+### Fixed
+
+- Fixed syntax error in output when a single-line comment appears between an index suffix and a table call argument, e.g. `foo.bar -- comment { }` ([#873](https://github.com/JohnnyMorganz/StyLua/issues/873))
+
 ## [2.3.1] - 2025-11-01
 
 ### Fixed

--- a/tests/inputs/hang-call-chain-comments-4.lua
+++ b/tests/inputs/hang-call-chain-comments-4.lua
@@ -1,0 +1,15 @@
+-- https://github.com/JohnnyMorganz/StyLua/issues/873
+
+x = a.b -- comment
+{
+  y
+}
+
+console.dialog = iup.dialog
+{
+  iup.hbox -- use it to inherit margins
+  {
+    console.prompt,
+  },
+  title = "Command:",
+}

--- a/tests/snapshots/tests__standard@hang-call-chain-comments-4.lua.snap
+++ b/tests/snapshots/tests__standard@hang-call-chain-comments-4.lua.snap
@@ -1,0 +1,21 @@
+---
+source: tests/tests.rs
+expression: "format(&contents, LuaVersion::Lua51)"
+input_file: tests/inputs/hang-call-chain-comments-4.lua
+---
+-- https://github.com/JohnnyMorganz/StyLua/issues/873
+
+x = a
+	.b -- comment
+	({
+		y,
+	})
+
+console.dialog = iup.dialog({
+	iup
+		.hbox -- use it to inherit margins
+		({
+			console.prompt,
+		}),
+	title = "Command:",
+})


### PR DESCRIPTION
When a single-line comment appeared between an index suffix (like `.foo`) and a table call argument (`{}`), the formatter would place the opening parenthesis/brace on the same line as the comment, causing it to be commented out and producing invalid Lua syntax.

For example, `foo.bar -- comment { x }` was being formatted as:
```lua
foo
    .bar -- comment({
        x,
    })
```

Now the anonymous call is correctly placed on a new line when the previous suffix has trailing single-line comments:
```lua
foo
    .bar -- comment
    ({
        x,
    })
```

Fixes #873