### PR TITLE
test: stop using deprecated assert_cmd cargo_bin helper

### DIFF
--- a/tests/test_editorconfig.rs
+++ b/tests/test_editorconfig.rs
@@ -64,7 +64,7 @@ fn test_stylua_toml() {
         // Save file contents
         let original = std::fs::read_to_string(path).unwrap();
         let result = std::panic::catch_unwind(|| {
-            let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+            let mut cmd = assert_cmd::Command::new(assert_cmd::cargo::cargo_bin!(env!("CARGO_PKG_NAME")));
             cmd.arg("--config-path")
                 .arg("tests/inputs-editorconfig/stylua-toml/stylua.toml")
                 .arg(path)


### PR DESCRIPTION
## Summary
- replace deprecated `assert_cmd::Command::cargo_bin(...)` usage in `tests/test_editorconfig.rs`
- use `assert_cmd::cargo::cargo_bin!` with `Command::new(...)` to follow the recommended API and avoid future Cargo breakage

## Testing
- Could not run tests in this runner because Rust/Cargo is not installed (`cargo: command not found`).
- Validation done via focused code update scoped to issue #1056 and matching the upstream recommendation.

## Related
Fixes #1056