### PR TITLE
Add Luau const support and bump full_moon to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Luau: Added support for `const` variable assignments (`const x = 1`) and `const function` declarations ([#1102](https://github.com/JohnnyMorganz/StyLua/issues/1102))
+
 ### Fixed
 
 - Fixed npm publishing by bumping Node.js from 16 to 22 in CI workflows to support npm trusted publishing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "full_moon"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40373a6bf84c41c6124c01cbedf5ab53d0d468adf1c0d7efd4c3273531fbb609"
+checksum = "a083d6f598bbe9d70e694f2a5cf78f0354678a8c13528da2df6467b089586404"
 dependencies = [
  "bytecount",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ console = "0.15.7"
 crossbeam-channel = "0.5.15"
 ec4rs = { version = "1.0.2", optional = true }
 env_logger = { version = "0.10.0", default-features = false }
-full_moon = "2.1.1"
+full_moon = "2.2.0"
 globset = "0.4.13"
 ignore = "0.4.20"
 lazy_static = "1.4.0"

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -587,6 +587,10 @@ pub fn format_const_assignment_no_trivia(
     assignment: &ConstAssignment,
     mut shape: Shape,
 ) -> ConstAssignment {
+    debug_assert!(
+        !assignment.expressions().is_empty(),
+        "const assignment must always have an expression list"
+    );
     let contains_comments = assignment
         .equal_token()
         .is_some_and(trivia_util::token_contains_comments)

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "luau")]
-use full_moon::ast::luau::TypeSpecifier;
+use full_moon::ast::luau::{ConstAssignment, TypeSpecifier};
 #[cfg(feature = "cfxlua")]
 use full_moon::tokenizer::Symbol;
 use full_moon::tokenizer::{Token, TokenReference};
@@ -21,7 +21,7 @@ use crate::{
     formatters::{
         expression::{format_expression, format_var, hang_expression},
         general::{
-            format_punctuated, format_punctuated_multiline, format_token_reference,
+            format_punctuated, format_punctuated_multiline, format_symbol, format_token_reference,
             try_format_punctuated,
         },
         trivia::{
@@ -576,6 +576,158 @@ pub fn format_local_assignment(
     let trailing_trivia = vec![create_newline_trivia(ctx)];
 
     format_local_assignment_no_trivia(ctx, assignment, shape).update_trivia(
+        FormatTriviaType::Append(leading_trivia),
+        FormatTriviaType::Append(trailing_trivia),
+    )
+}
+
+#[cfg(feature = "luau")]
+fn format_const_no_assignment(
+    ctx: &Context,
+    assignment: &ConstAssignment,
+    shape: Shape,
+) -> ConstAssignment {
+    let const_token = format_symbol(
+        ctx,
+        assignment.const_token(),
+        &TokenReference::new(
+            vec![],
+            Token::new(TokenType::Identifier {
+                identifier: "const".into(),
+            }),
+            vec![Token::new(TokenType::spaces(1))],
+        ),
+        shape,
+    );
+    let shape = shape + 6; // 6 = "const "
+    let name_list = try_format_punctuated(
+        ctx,
+        assignment.names(),
+        shape,
+        format_token_reference,
+        Some(1),
+    );
+
+    let type_specifiers: Vec<Option<TypeSpecifier>> = assignment
+        .type_specifiers()
+        .map(|x| x.map(|type_specifier| format_type_specifier(ctx, type_specifier, shape)))
+        .collect();
+
+    ConstAssignment::new(name_list)
+        .with_type_specifiers(type_specifiers)
+        .with_const_token(const_token)
+        .with_equal_token(None)
+        .with_expressions(Punctuated::new())
+}
+
+#[cfg(feature = "luau")]
+pub fn format_const_assignment_no_trivia(
+    ctx: &Context,
+    assignment: &ConstAssignment,
+    mut shape: Shape,
+) -> ConstAssignment {
+    if assignment.expressions().is_empty() {
+        return format_const_no_assignment(ctx, assignment, shape);
+    }
+
+    let contains_comments = assignment
+        .equal_token()
+        .is_some_and(trivia_util::token_contains_comments)
+        || trivia_util::punctuated_inline_comments(assignment.expressions(), true);
+
+    let const_token = format_symbol(
+        ctx,
+        assignment.const_token(),
+        &TokenReference::new(
+            vec![],
+            Token::new(TokenType::Identifier {
+                identifier: "const".into(),
+            }),
+            vec![Token::new(TokenType::spaces(1))],
+        ),
+        shape,
+    );
+
+    let mut name_list = try_format_punctuated(
+        ctx,
+        assignment.names(),
+        shape.with_infinite_width(),
+        format_token_reference,
+        Some(1),
+    );
+    let mut equal_token = fmt_symbol!(ctx, assignment.equal_token().unwrap(), " = ", shape);
+
+    let mut expr_list = format_punctuated(
+        ctx,
+        assignment.expressions(),
+        shape.with_infinite_width(),
+        format_expression,
+    );
+
+    let type_specifiers: Vec<Option<TypeSpecifier>> = assignment
+        .type_specifiers()
+        .map(|x| x.map(|type_specifier| format_type_specifier(ctx, type_specifier, shape)))
+        .collect();
+
+    let type_specifier_len = type_specifiers.iter().fold(0, |acc, x| {
+        acc + x.as_ref().map_or(0, |y| y.to_string().len())
+    });
+
+    let var_list_ends_with_comments = match type_specifiers.last() {
+        Some(Some(specifier)) => specifier.has_trailing_comments(trivia_util::CommentSearch::Single),
+        _ => name_list.has_trailing_comments(trivia_util::CommentSearch::Single),
+    };
+
+    if var_list_ends_with_comments {
+        const EQUAL_TOKEN_LEN: usize = "= ".len();
+        shape = shape
+            .reset()
+            .increment_additional_indent()
+            .add_width(EQUAL_TOKEN_LEN);
+        equal_token = prepend_newline_indent(ctx, &equal_token, shape);
+    }
+
+    let singleline_shape = shape
+        + (strip_leading_trivia(&name_list).to_string().len()
+            + 6 // 6 = "const "
+            + 3 // 3 = " = "
+            + type_specifier_len
+            + strip_trailing_trivia(&expr_list).to_string().len());
+
+    if contains_comments || singleline_shape.over_budget() {
+        name_list = try_format_punctuated(
+            ctx,
+            assignment.names(),
+            shape,
+            format_token_reference,
+            Some(1),
+        );
+        let shape = shape
+            + (strip_leading_trivia(&name_list).to_string().len() + 6 + 3 + type_specifier_len);
+
+        let (new_expr_list, new_equal_token) =
+            attempt_assignment_tactics(ctx, assignment.expressions(), shape, equal_token);
+        expr_list = new_expr_list;
+        equal_token = new_equal_token;
+    }
+
+    ConstAssignment::new(name_list)
+        .with_type_specifiers(type_specifiers)
+        .with_const_token(const_token)
+        .with_equal_token(Some(equal_token))
+        .with_expressions(expr_list)
+}
+
+#[cfg(feature = "luau")]
+pub fn format_const_assignment(
+    ctx: &Context,
+    assignment: &ConstAssignment,
+    shape: Shape,
+) -> ConstAssignment {
+    let leading_trivia = vec![create_indent_trivia(ctx, shape)];
+    let trailing_trivia = vec![create_newline_trivia(ctx)];
+
+    format_const_assignment_no_trivia(ctx, assignment, shape).update_trivia(
         FormatTriviaType::Append(leading_trivia),
         FormatTriviaType::Append(trailing_trivia),
     )

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -582,54 +582,11 @@ pub fn format_local_assignment(
 }
 
 #[cfg(feature = "luau")]
-fn format_const_no_assignment(
-    ctx: &Context,
-    assignment: &ConstAssignment,
-    shape: Shape,
-) -> ConstAssignment {
-    let const_token = format_symbol(
-        ctx,
-        assignment.const_token(),
-        &TokenReference::new(
-            vec![],
-            Token::new(TokenType::Identifier {
-                identifier: "const".into(),
-            }),
-            vec![Token::new(TokenType::spaces(1))],
-        ),
-        shape,
-    );
-    let shape = shape + 6; // 6 = "const "
-    let name_list = try_format_punctuated(
-        ctx,
-        assignment.names(),
-        shape,
-        format_token_reference,
-        Some(1),
-    );
-
-    let type_specifiers: Vec<Option<TypeSpecifier>> = assignment
-        .type_specifiers()
-        .map(|x| x.map(|type_specifier| format_type_specifier(ctx, type_specifier, shape)))
-        .collect();
-
-    ConstAssignment::new(name_list)
-        .with_type_specifiers(type_specifiers)
-        .with_const_token(const_token)
-        .with_equal_token(None)
-        .with_expressions(Punctuated::new())
-}
-
-#[cfg(feature = "luau")]
 pub fn format_const_assignment_no_trivia(
     ctx: &Context,
     assignment: &ConstAssignment,
     mut shape: Shape,
 ) -> ConstAssignment {
-    if assignment.expressions().is_empty() {
-        return format_const_no_assignment(ctx, assignment, shape);
-    }
-
     let contains_comments = assignment
         .equal_token()
         .is_some_and(trivia_util::token_contains_comments)

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -14,7 +14,7 @@ use full_moon::{
 #[cfg(feature = "lua54")]
 use crate::formatters::lua54::format_attribute;
 #[cfg(feature = "luau")]
-use crate::formatters::luau::format_type_specifier;
+use crate::formatters::luau::{const_keyword_token_ref, format_type_specifier};
 use crate::{
     context::{create_indent_trivia, create_newline_trivia, Context},
     fmt_symbol,
@@ -596,18 +596,7 @@ pub fn format_const_assignment_no_trivia(
         .is_some_and(trivia_util::token_contains_comments)
         || trivia_util::punctuated_inline_comments(assignment.expressions(), true);
 
-    let const_token = format_symbol(
-        ctx,
-        assignment.const_token(),
-        &TokenReference::new(
-            vec![],
-            Token::new(TokenType::Identifier {
-                identifier: "const".into(),
-            }),
-            vec![Token::new(TokenType::spaces(1))],
-        ),
-        shape,
-    );
+    let const_token = format_symbol(ctx, assignment.const_token(), &const_keyword_token_ref(), shape);
 
     let mut name_list = try_format_punctuated(
         ctx,

--- a/src/formatters/assignment.rs
+++ b/src/formatters/assignment.rs
@@ -596,7 +596,12 @@ pub fn format_const_assignment_no_trivia(
         .is_some_and(trivia_util::token_contains_comments)
         || trivia_util::punctuated_inline_comments(assignment.expressions(), true);
 
-    let const_token = format_symbol(ctx, assignment.const_token(), &const_keyword_token_ref(), shape);
+    let const_token = format_symbol(
+        ctx,
+        assignment.const_token(),
+        &const_keyword_token_ref(),
+        shape,
+    );
 
     let mut name_list = try_format_punctuated(
         ctx,
@@ -624,7 +629,9 @@ pub fn format_const_assignment_no_trivia(
     });
 
     let var_list_ends_with_comments = match type_specifiers.last() {
-        Some(Some(specifier)) => specifier.has_trailing_comments(trivia_util::CommentSearch::Single),
+        Some(Some(specifier)) => {
+            specifier.has_trailing_comments(trivia_util::CommentSearch::Single)
+        }
         _ => name_list.has_trailing_comments(trivia_util::CommentSearch::Single),
     };
 

--- a/src/formatters/block.rs
+++ b/src/formatters/block.rs
@@ -396,6 +396,20 @@ fn stmt_remove_leading_newlines(stmt: Stmt) -> Stmt {
             let lhs = var_remove_leading_newline(compound_assignment.lhs().to_owned());
             Stmt::CompoundAssignment(compound_assignment.with_lhs(lhs))
         }
+        #[cfg(feature = "luau")]
+        Stmt::ConstAssignment(const_assignment) => update_first_token!(
+            ConstAssignment,
+            const_assignment,
+            const_assignment.const_token(),
+            with_const_token
+        ),
+        #[cfg(feature = "luau")]
+        Stmt::ConstFunction(const_function) => update_first_token!(
+            ConstFunction,
+            const_function,
+            const_function.const_token(),
+            with_const_token
+        ),
 
         #[cfg(feature = "luau")]
         Stmt::ExportedTypeDeclaration(exported_type_declaration) => update_first_token!(

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -11,8 +11,8 @@ use full_moon::tokenizer::{Token, TokenKind, TokenReference, TokenType};
 
 #[cfg(feature = "luau")]
 use crate::formatters::luau::{
-    format_generic_declaration, format_luau_attribute, format_type_instantiation,
-    format_type_specifier,
+    const_keyword_token_ref, format_generic_declaration, format_luau_attribute,
+    format_type_instantiation, format_type_specifier,
 };
 use crate::{
     context::{
@@ -1310,19 +1310,9 @@ pub fn format_const_function(
                 .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.clone()))
         })
         .collect();
-    let const_token = format_symbol(
-        ctx,
-        const_function.const_token(),
-        &TokenReference::new(
-            vec![],
-            Token::new(TokenType::Identifier {
-                identifier: "const".into(),
-            }),
-            vec![Token::new(TokenType::spaces(1))],
-        ),
-        shape,
-    )
-    .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+    let const_token =
+        format_symbol(ctx, const_function.const_token(), &const_keyword_token_ref(), shape)
+            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
     let function_token = fmt_symbol!(ctx, const_function.function_token(), "function ", shape);
     let formatted_name = format_token_reference(ctx, const_function.name(), shape)
         .update_trailing_trivia(FormatTriviaType::Append(function_definition_trivia));

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -1310,9 +1310,13 @@ pub fn format_const_function(
                 .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.clone()))
         })
         .collect();
-    let const_token =
-        format_symbol(ctx, const_function.const_token(), &const_keyword_token_ref(), shape)
-            .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+    let const_token = format_symbol(
+        ctx,
+        const_function.const_token(),
+        &const_keyword_token_ref(),
+        shape,
+    )
+    .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
     let function_token = fmt_symbol!(ctx, const_function.function_token(), "function ", shape);
     let formatted_name = format_token_reference(ctx, const_function.name(), shape)
         .update_trailing_trivia(FormatTriviaType::Append(function_definition_trivia));

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "luau")]
+use full_moon::ast::luau::ConstFunction;
 use full_moon::ast::{
     punctuated::{Pair, Punctuated},
     span::ContainedSpan,
@@ -23,7 +25,7 @@ use crate::{
         expression::{format_expression, format_prefix, format_suffix, hang_expression},
         general::{
             format_contained_punctuated_multiline, format_contained_span, format_end_token,
-            format_punctuated, format_token_reference, EndTokenType,
+            format_punctuated, format_symbol, format_token_reference, EndTokenType,
         },
         stmt::format_stmt_no_trivia,
         table::format_table_constructor,
@@ -1288,6 +1290,52 @@ pub fn format_local_function(
     let local_function = local_function.with_attributes(attributes);
 
     local_function
+}
+
+#[cfg(feature = "luau")]
+pub fn format_const_function(
+    ctx: &Context,
+    const_function: &ConstFunction,
+    shape: Shape,
+) -> ConstFunction {
+    let leading_trivia = vec![create_indent_trivia(ctx, shape)];
+    let trailing_trivia = vec![create_newline_trivia(ctx)];
+    let function_definition_trivia = vec![create_function_definition_trivia(ctx)];
+
+    let attributes = const_function
+        .attributes()
+        .map(|attribute| {
+            format_luau_attribute(ctx, attribute, shape)
+                .update_leading_trivia(FormatTriviaType::Append(leading_trivia.clone()))
+                .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia.clone()))
+        })
+        .collect();
+    let const_token = format_symbol(
+        ctx,
+        const_function.const_token(),
+        &TokenReference::new(
+            vec![],
+            Token::new(TokenType::Identifier {
+                identifier: "const".into(),
+            }),
+            vec![Token::new(TokenType::spaces(1))],
+        ),
+        shape,
+    )
+    .update_leading_trivia(FormatTriviaType::Append(leading_trivia));
+    let function_token = fmt_symbol!(ctx, const_function.function_token(), "function ", shape);
+    let formatted_name = format_token_reference(ctx, const_function.name(), shape)
+        .update_trailing_trivia(FormatTriviaType::Append(function_definition_trivia));
+
+    let shape = shape + (6 + 9 + strip_trivia(&formatted_name).to_string().len()); // 6 = "const ", 9 = "function "
+    let function_body = format_function_body(ctx, const_function.body(), shape)
+        .update_trailing_trivia(FormatTriviaType::Append(trailing_trivia));
+
+    ConstFunction::new(formatted_name)
+        .with_attributes(attributes)
+        .with_const_token(const_token)
+        .with_function_token(function_token)
+        .with_body(function_body)
 }
 
 /// Formats a MethodCall node

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -1590,6 +1590,16 @@ pub fn format_exported_type_function(
         .with_type_function(type_function)
 }
 
+pub fn const_keyword_token_ref() -> TokenReference {
+    TokenReference::new(
+        vec![],
+        Token::new(TokenType::Identifier {
+            identifier: "const".into(),
+        }),
+        vec![Token::new(TokenType::spaces(1))],
+    )
+}
+
 pub fn format_luau_attribute(
     ctx: &Context,
     attribute: &LuauAttribute,

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -3,6 +3,10 @@ use crate::formatters::compound_assignment::format_compound_assignment;
 #[cfg(any(feature = "lua52", feature = "luajit"))]
 use crate::formatters::goto::{format_goto, format_goto_no_trivia, format_label};
 #[cfg(feature = "luau")]
+use crate::formatters::assignment::format_const_assignment;
+#[cfg(feature = "luau")]
+use crate::formatters::functions::format_const_function;
+#[cfg(feature = "luau")]
 use crate::formatters::luau::{
     format_exported_type_declaration, format_exported_type_function, format_type_declaration_stmt,
     format_type_function_stmt, format_type_specifier,
@@ -1073,6 +1077,25 @@ pub(crate) mod stmt_block {
                 Stmt::CompoundAssignment(compound_assignment.to_owned().with_rhs(rhs))
             }
             #[cfg(feature = "luau")]
+            Stmt::ConstAssignment(const_assignment) => {
+                let expressions = const_assignment
+                    .expressions()
+                    .pairs()
+                    .map(|pair| {
+                        pair.to_owned().map(|expression| {
+                            format_expression_block(ctx, &expression, block_shape)
+                        })
+                    })
+                    .collect();
+                Stmt::ConstAssignment(const_assignment.to_owned().with_expressions(expressions))
+            }
+            #[cfg(feature = "luau")]
+            Stmt::ConstFunction(const_function) => {
+                let block = format_block(ctx, const_function.body().block(), block_shape);
+                let body = const_function.body().to_owned().with_block(block);
+                Stmt::ConstFunction(const_function.to_owned().with_body(body))
+            }
+            #[cfg(feature = "luau")]
             Stmt::ExportedTypeDeclaration(node) => Stmt::ExportedTypeDeclaration(node.to_owned()),
             #[cfg(feature = "luau")]
             Stmt::TypeDeclaration(node) => Stmt::TypeDeclaration(node.to_owned()),
@@ -1124,6 +1147,8 @@ pub fn format_stmt(ctx: &Context, stmt: &Stmt, shape: Shape) -> Stmt {
         Repeat = format_repeat_block,
         While = format_while_block,
         #[cfg(any(feature = "luau", feature = "cfxlua"))] CompoundAssignment = format_compound_assignment,
+        #[cfg(feature = "luau")] ConstAssignment = format_const_assignment,
+        #[cfg(feature = "luau")] ConstFunction = format_const_function,
         #[cfg(feature = "luau")] ExportedTypeDeclaration = format_exported_type_declaration,
         #[cfg(feature = "luau")] TypeDeclaration = format_type_declaration_stmt,
         #[cfg(feature = "luau")] ExportedTypeFunction = format_exported_type_function,

--- a/src/formatters/stmt.rs
+++ b/src/formatters/stmt.rs
@@ -1,11 +1,11 @@
-#[cfg(any(feature = "luau", feature = "cfxlua"))]
-use crate::formatters::compound_assignment::format_compound_assignment;
-#[cfg(any(feature = "lua52", feature = "luajit"))]
-use crate::formatters::goto::{format_goto, format_goto_no_trivia, format_label};
 #[cfg(feature = "luau")]
 use crate::formatters::assignment::format_const_assignment;
+#[cfg(any(feature = "luau", feature = "cfxlua"))]
+use crate::formatters::compound_assignment::format_compound_assignment;
 #[cfg(feature = "luau")]
 use crate::formatters::functions::format_const_function;
+#[cfg(any(feature = "lua52", feature = "luajit"))]
+use crate::formatters::goto::{format_goto, format_goto_no_trivia, format_label};
 #[cfg(feature = "luau")]
 use crate::formatters::luau::{
     format_exported_type_declaration, format_exported_type_function, format_type_declaration_stmt,

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -550,12 +550,16 @@ define_update_trivia!(Attribute, |this, leading, trailing| {
 #[cfg(feature = "luau")]
 define_update_trivia!(ConstAssignment, |this, leading, trailing| {
     if this.expressions().is_empty() {
-        let mut type_specifiers = this.type_specifiers().map(|x| x.cloned()).collect::<Vec<_>>();
+        let mut type_specifiers = this
+            .type_specifiers()
+            .map(|x| x.cloned())
+            .collect::<Vec<_>>();
 
         if let Some(Some(type_specifier)) = type_specifiers.pop() {
             type_specifiers.push(Some(type_specifier.update_trailing_trivia(trailing)));
 
-            return this.clone()
+            return this
+                .clone()
                 .with_const_token(this.const_token().update_leading_trivia(leading))
                 .with_type_specifiers(type_specifiers);
         }

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -2,10 +2,11 @@
 use full_moon::ast::lua54::Attribute;
 #[cfg(feature = "luau")]
 use full_moon::ast::luau::{
-    ElseIfExpression, GenericDeclaration, GenericDeclarationParameter, GenericParameterInfo,
-    IfExpression, IndexedTypeInfo, InterpolatedString, InterpolatedStringSegment, LuauAttribute,
-    TypeArgument, TypeAssertion, TypeDeclaration, TypeField, TypeFieldKey, TypeFunction, TypeInfo,
-    TypeInstantiation, TypeIntersection, TypeSpecifier, TypeUnion,
+    ConstAssignment, ElseIfExpression, GenericDeclaration, GenericDeclarationParameter,
+    GenericParameterInfo, IfExpression, IndexedTypeInfo, InterpolatedString,
+    InterpolatedStringSegment, LuauAttribute, TypeArgument, TypeAssertion, TypeDeclaration,
+    TypeField, TypeFieldKey, TypeFunction, TypeInfo, TypeInstantiation, TypeIntersection,
+    TypeSpecifier, TypeUnion,
 };
 use full_moon::ast::{
     punctuated::Punctuated, span::ContainedSpan, AnonymousFunction, BinOp, Call, Expression,
@@ -546,6 +547,29 @@ define_update_trivia!(Attribute, |this, leading, trailing| {
         .with_brackets(this.brackets().update_trivia(leading, trailing))
 });
 
+#[cfg(feature = "luau")]
+define_update_trivia!(ConstAssignment, |this, leading, trailing| {
+    if this.expressions().is_empty() {
+        let mut type_specifiers = this.type_specifiers().map(|x| x.cloned()).collect::<Vec<_>>();
+
+        if let Some(Some(type_specifier)) = type_specifiers.pop() {
+            type_specifiers.push(Some(type_specifier.update_trailing_trivia(trailing)));
+
+            return this.clone()
+                .with_const_token(this.const_token().update_leading_trivia(leading))
+                .with_type_specifiers(type_specifiers);
+        }
+
+        this.clone()
+            .with_const_token(this.const_token().update_leading_trivia(leading))
+            .with_names(this.names().update_trailing_trivia(trailing))
+    } else {
+        this.clone()
+            .with_const_token(this.const_token().update_leading_trivia(leading))
+            .with_expressions(this.expressions().update_trailing_trivia(trailing))
+    }
+});
+
 define_update_trivia!(LocalAssignment, |this, leading, trailing| {
     if this.expressions().is_empty() {
         // Handle if the last item had a type specifier set
@@ -671,6 +695,19 @@ define_update_trivia!(Stmt, |this, leading, trailing| {
             let lhs = stmt.lhs().update_leading_trivia(leading);
             let rhs = stmt.rhs().update_trailing_trivia(trailing);
             Stmt::CompoundAssignment(stmt.to_owned().with_lhs(lhs).with_rhs(rhs))
+        }
+        #[cfg(feature = "luau")]
+        Stmt::ConstAssignment(stmt) => Stmt::ConstAssignment(stmt.update_trivia(leading, trailing)),
+        #[cfg(feature = "luau")]
+        Stmt::ConstFunction(stmt) => {
+            let const_token = stmt.const_token().update_leading_trivia(leading);
+            let end_token = stmt.body().end_token().update_trailing_trivia(trailing);
+            let body = stmt.body().to_owned().with_end_token(end_token);
+            Stmt::ConstFunction(
+                stmt.to_owned()
+                    .with_const_token(const_token)
+                    .with_body(body),
+            )
         }
         #[cfg(feature = "luau")]
         Stmt::ExportedTypeDeclaration(stmt) => {

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -939,58 +939,24 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
         #[cfg(feature = "luau")]
         Stmt::ConstAssignment(const_assignment) => {
             let mut trailing_trivia = Vec::new();
-            let new_assignment = if const_assignment.expressions().is_empty() {
-                let mut type_specifiers = const_assignment
-                    .type_specifiers()
-                    .map(|x| x.cloned())
-                    .collect::<Vec<_>>();
-
-                if let Some(Some(type_specifier)) = type_specifiers.pop() {
-                    trailing_trivia = type_specifier.trailing_trivia();
-                    type_specifiers.push(Some(
-                        type_specifier.update_trailing_trivia(FormatTriviaType::Replace(vec![])),
-                    ));
-                    ConstAssignment::new(const_assignment.names().to_owned())
-                        .with_type_specifiers(type_specifiers)
-                        .with_const_token(const_assignment.const_token().to_owned())
-                        .with_equal_token(None)
-                        .with_expressions(Punctuated::new())
-                } else {
-                    let mut formatted_name_list = const_assignment.names().to_owned();
-                    if let Some(last_pair) = formatted_name_list.pop() {
-                        let pair = last_pair.map(|value| {
-                            trailing_trivia =
-                                value.trailing_trivia().map(|x| x.to_owned()).collect();
-                            value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
-                        });
-                        formatted_name_list.push(pair);
-                    }
-                    ConstAssignment::new(formatted_name_list)
-                        .with_type_specifiers(type_specifiers)
-                        .with_const_token(const_assignment.const_token().to_owned())
-                        .with_equal_token(None)
-                        .with_expressions(Punctuated::new())
-                }
-            } else {
-                let mut formatted_expression_list = const_assignment.expressions().to_owned();
-                if let Some(last_pair) = formatted_expression_list.pop() {
-                    let pair = last_pair.map(|value| {
-                        trailing_trivia = value.trailing_trivia();
-                        value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
-                    });
-                    formatted_expression_list.push(pair);
-                }
-                ConstAssignment::new(const_assignment.names().to_owned())
-                    .with_type_specifiers(
-                        const_assignment
-                            .type_specifiers()
-                            .map(|x| x.cloned())
-                            .collect(),
-                    )
-                    .with_const_token(const_assignment.const_token().to_owned())
-                    .with_equal_token(const_assignment.equal_token().cloned())
-                    .with_expressions(formatted_expression_list)
-            };
+            let mut formatted_expression_list = const_assignment.expressions().to_owned();
+            if let Some(last_pair) = formatted_expression_list.pop() {
+                let pair = last_pair.map(|value| {
+                    trailing_trivia = value.trailing_trivia();
+                    value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
+                });
+                formatted_expression_list.push(pair);
+            }
+            let new_assignment = ConstAssignment::new(const_assignment.names().to_owned())
+                .with_type_specifiers(
+                    const_assignment
+                        .type_specifiers()
+                        .map(|x| x.cloned())
+                        .collect(),
+                )
+                .with_const_token(const_assignment.const_token().to_owned())
+                .with_equal_token(const_assignment.equal_token().cloned())
+                .with_expressions(formatted_expression_list);
             (Stmt::ConstAssignment(new_assignment), trailing_trivia)
         }
         #[cfg(feature = "luau")]

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -5,9 +5,8 @@ use crate::{
 };
 #[cfg(feature = "luau")]
 use full_moon::ast::luau::{
-    ConstAssignment, GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo,
-    TypeArgument, TypeDeclaration, TypeFunction, TypeInfo, TypeIntersection, TypeSpecifier,
-    TypeUnion,
+    GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo, TypeArgument,
+    TypeDeclaration, TypeFunction, TypeInfo, TypeIntersection, TypeSpecifier, TypeUnion,
 };
 use full_moon::{
     ast::{
@@ -947,17 +946,10 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                 });
                 formatted_expression_list.push(pair);
             }
-            let new_assignment = ConstAssignment::new(const_assignment.names().to_owned())
-                .with_type_specifiers(
-                    const_assignment
-                        .type_specifiers()
-                        .map(|x| x.cloned())
-                        .collect(),
-                )
-                .with_const_token(const_assignment.const_token().to_owned())
-                .with_equal_token(const_assignment.equal_token().cloned())
-                .with_expressions(formatted_expression_list);
-            (Stmt::ConstAssignment(new_assignment), trailing_trivia)
+            (
+                Stmt::ConstAssignment(const_assignment.with_expressions(formatted_expression_list)),
+                trailing_trivia,
+            )
         }
         #[cfg(feature = "luau")]
         Stmt::ConstFunction(stmt) => {

--- a/src/formatters/trivia_util.rs
+++ b/src/formatters/trivia_util.rs
@@ -5,8 +5,9 @@ use crate::{
 };
 #[cfg(feature = "luau")]
 use full_moon::ast::luau::{
-    GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo, TypeArgument,
-    TypeDeclaration, TypeFunction, TypeInfo, TypeIntersection, TypeSpecifier, TypeUnion,
+    ConstAssignment, GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo,
+    TypeArgument, TypeDeclaration, TypeFunction, TypeInfo, TypeIntersection, TypeSpecifier,
+    TypeUnion,
 };
 use full_moon::{
     ast::{
@@ -934,6 +935,68 @@ pub fn get_stmt_trailing_trivia(stmt: Stmt) -> (Stmt, Vec<Token>) {
                 Stmt::CompoundAssignment(stmt.with_rhs(expr)),
                 trailing_trivia,
             )
+        }
+        #[cfg(feature = "luau")]
+        Stmt::ConstAssignment(const_assignment) => {
+            let mut trailing_trivia = Vec::new();
+            let new_assignment = if const_assignment.expressions().is_empty() {
+                let mut type_specifiers = const_assignment
+                    .type_specifiers()
+                    .map(|x| x.cloned())
+                    .collect::<Vec<_>>();
+
+                if let Some(Some(type_specifier)) = type_specifiers.pop() {
+                    trailing_trivia = type_specifier.trailing_trivia();
+                    type_specifiers.push(Some(
+                        type_specifier.update_trailing_trivia(FormatTriviaType::Replace(vec![])),
+                    ));
+                    ConstAssignment::new(const_assignment.names().to_owned())
+                        .with_type_specifiers(type_specifiers)
+                        .with_const_token(const_assignment.const_token().to_owned())
+                        .with_equal_token(None)
+                        .with_expressions(Punctuated::new())
+                } else {
+                    let mut formatted_name_list = const_assignment.names().to_owned();
+                    if let Some(last_pair) = formatted_name_list.pop() {
+                        let pair = last_pair.map(|value| {
+                            trailing_trivia =
+                                value.trailing_trivia().map(|x| x.to_owned()).collect();
+                            value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
+                        });
+                        formatted_name_list.push(pair);
+                    }
+                    ConstAssignment::new(formatted_name_list)
+                        .with_type_specifiers(type_specifiers)
+                        .with_const_token(const_assignment.const_token().to_owned())
+                        .with_equal_token(None)
+                        .with_expressions(Punctuated::new())
+                }
+            } else {
+                let mut formatted_expression_list = const_assignment.expressions().to_owned();
+                if let Some(last_pair) = formatted_expression_list.pop() {
+                    let pair = last_pair.map(|value| {
+                        trailing_trivia = value.trailing_trivia();
+                        value.update_trailing_trivia(FormatTriviaType::Replace(vec![]))
+                    });
+                    formatted_expression_list.push(pair);
+                }
+                ConstAssignment::new(const_assignment.names().to_owned())
+                    .with_type_specifiers(
+                        const_assignment
+                            .type_specifiers()
+                            .map(|x| x.cloned())
+                            .collect(),
+                    )
+                    .with_const_token(const_assignment.const_token().to_owned())
+                    .with_equal_token(const_assignment.equal_token().cloned())
+                    .with_expressions(formatted_expression_list)
+            };
+            (Stmt::ConstAssignment(new_assignment), trailing_trivia)
+        }
+        #[cfg(feature = "luau")]
+        Stmt::ConstFunction(stmt) => {
+            let (body, trailing_trivia) = take_trailing_trivia(stmt.body());
+            (Stmt::ConstFunction(stmt.with_body(body)), trailing_trivia)
         }
         #[cfg(feature = "luau")]
         Stmt::ExportedTypeDeclaration(stmt) => {

--- a/tests/inputs-luau/const.lua
+++ b/tests/inputs-luau/const.lua
@@ -1,0 +1,14 @@
+const x = 1
+const y: number = 2
+const a, b = 1, 2
+const foo: string, bar: number = "hello", 42
+const longVariableName: string = "this is a very long string that might cause the line to exceed the column width limit"
+
+const function greet()
+    print("hello")
+end
+
+@native
+const function optimized()
+    return 42
+end

--- a/tests/snapshots/tests__luau@const.lua.snap
+++ b/tests/snapshots/tests__luau@const.lua.snap
@@ -1,0 +1,20 @@
+---
+source: tests/tests.rs
+expression: "format(&contents, LuaVersion::Luau)"
+input_file: tests/inputs-luau/const.lua
+---
+const x = 1
+const y: number = 2
+const a, b = 1, 2
+const foo: string, bar: number = "hello", 42
+const longVariableName: string = "this is a very long string that might cause the line to exceed the column width limit"
+
+const function greet()
+	print("hello")
+end
+
+@native
+const function optimized()
+	return 42
+end
+


### PR DESCRIPTION
Bumps full_moon from 2.1.1 to 2.2.0, which adds two new Luau AST nodes:
- ConstAssignment: for `const x = 1` style declarations
- ConstFunction: for `const function foo() end` declarations

Implements formatting for both new node types, following the same
patterns as LocalAssignment and LocalFunction respectively.

Closes https://github.com/JohnnyMorganz/StyLua/issues/1102