### PR TITLE
Fix collapsible_match clippy lints

### DIFF
--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -996,16 +996,14 @@ fn binop_expression_length(expression: &Expression, top_binop: &BinOp) -> usize 
 
 fn binop_expression_contains_comments(expression: &Expression, top_binop: &BinOp) -> bool {
     match expression {
-        Expression::BinaryOperator { lhs, binop, rhs } => {
-            if binop.precedence() == top_binop.precedence() {
-                contains_comments(binop)
-                    || rhs.has_leading_comments(CommentSearch::All)
-                    || lhs.has_trailing_comments(CommentSearch::All)
-                    || binop_expression_contains_comments(lhs, top_binop)
-                    || binop_expression_contains_comments(rhs, top_binop)
-            } else {
-                false
-            }
+        Expression::BinaryOperator { lhs, binop, rhs }
+            if binop.precedence() == top_binop.precedence() =>
+        {
+            contains_comments(binop)
+                || rhs.has_leading_comments(CommentSearch::All)
+                || lhs.has_trailing_comments(CommentSearch::All)
+                || binop_expression_contains_comments(lhs, top_binop)
+                || binop_expression_contains_comments(rhs, top_binop)
         }
         _ => false,
     }

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -421,31 +421,31 @@ pub fn format_function_args(
                 let trailing_comments = parentheses.tokens().1.trailing_trivia().cloned().collect();
 
                 match argument {
-                    Expression::String(token_reference) => {
-                        if ctx.should_omit_string_parens() {
-                            return format_function_args(
-                                ctx,
-                                &FunctionArgs::String(token_reference.update_trailing_trivia(
-                                    FormatTriviaType::Append(trailing_comments),
-                                )),
-                                shape,
-                                call_next_node,
-                            );
-                        }
+                    Expression::String(token_reference)
+                        if ctx.should_omit_string_parens() =>
+                    {
+                        return format_function_args(
+                            ctx,
+                            &FunctionArgs::String(token_reference.update_trailing_trivia(
+                                FormatTriviaType::Append(trailing_comments),
+                            )),
+                            shape,
+                            call_next_node,
+                        );
                     }
-                    Expression::TableConstructor(table_constructor) => {
-                        if ctx.should_omit_table_parens() {
-                            return format_function_args(
-                                ctx,
-                                &FunctionArgs::TableConstructor(
-                                    table_constructor.update_trailing_trivia(
-                                        FormatTriviaType::Append(trailing_comments),
-                                    ),
+                    Expression::TableConstructor(table_constructor)
+                        if ctx.should_omit_table_parens() =>
+                    {
+                        return format_function_args(
+                            ctx,
+                            &FunctionArgs::TableConstructor(
+                                table_constructor.update_trailing_trivia(
+                                    FormatTriviaType::Append(trailing_comments),
                                 ),
-                                shape,
-                                call_next_node,
-                            );
-                        }
+                            ),
+                            shape,
+                            call_next_node,
+                        );
                     }
                     _ => (),
                 }

--- a/src/formatters/functions.rs
+++ b/src/formatters/functions.rs
@@ -421,9 +421,7 @@ pub fn format_function_args(
                 let trailing_comments = parentheses.tokens().1.trailing_trivia().cloned().collect();
 
                 match argument {
-                    Expression::String(token_reference)
-                        if ctx.should_omit_string_parens() =>
-                    {
+                    Expression::String(token_reference) if ctx.should_omit_string_parens() => {
                         return format_function_args(
                             ctx,
                             &FunctionArgs::String(token_reference.update_trailing_trivia(
@@ -439,9 +437,9 @@ pub fn format_function_args(
                         return format_function_args(
                             ctx,
                             &FunctionArgs::TableConstructor(
-                                table_constructor.update_trailing_trivia(
-                                    FormatTriviaType::Append(trailing_comments),
-                                ),
+                                table_constructor.update_trailing_trivia(FormatTriviaType::Append(
+                                    trailing_comments,
+                                )),
                             ),
                             shape,
                             call_next_node,

--- a/src/formatters/general.rs
+++ b/src/formatters/general.rs
@@ -300,13 +300,11 @@ fn load_token_trivia(
                 // If we are formatting leading trivia, we will allow a single newline to be kept in succession, if we
                 // find one.
                 match format_token_type {
-                    FormatTokenType::LeadingTrivia => {
-                        if characters.contains('\n') {
-                            newline_count_in_succession += 1;
-                            if newline_count_in_succession == 1 {
-                                // We have a case where we will allow a single newline to be kept
-                                token_trivia.push(create_newline_trivia(ctx));
-                            }
+                    FormatTokenType::LeadingTrivia if characters.contains('\n') => {
+                        newline_count_in_succession += 1;
+                        if newline_count_in_succession == 1 {
+                            // We have a case where we will allow a single newline to be kept
+                            token_trivia.push(create_newline_trivia(ctx));
                         }
                     }
                     FormatTokenType::TrailingTrivia => {


### PR DESCRIPTION
Collapse nested if-in-match-arm patterns into match guards, fixing
clippy::collapsible_match errors that fail CI with -D warnings.