### PR TITLE
VSCode: prevent bogus update prompt when GitHub API returns non-OK response

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,10 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spurious "No release version matches v." error when GitHub API returns a non-OK response (e.g. rate limiting). The extension no longer shows a bogus update prompt in this case
+
 ## [1.7.1] - 2024-11-17
 
 ### Fixed

--- a/stylua-vscode/src/github.ts
+++ b/stylua-vscode/src/github.ts
@@ -30,6 +30,11 @@ async function fetchJson(
     headers.set("Authorization", `token ${token}`);
   }
   const response = await fetch(url, { headers: headers });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed: ${response.status} ${response.statusText}`
+    );
+  }
   return response.json();
 }
 
@@ -140,7 +145,17 @@ export class GitHub implements Disposable {
   public async getRelease(version: string): Promise<GitHubRelease> {
     if (version === "latest") {
       const json = await fetchJson(RELEASES_URL_LATEST, this.credential.token);
-      return releaseFromJson(json);
+      const release = releaseFromJson(json);
+      if (!release.tagName) {
+        throw new Error(
+          "Failed to retrieve latest release information from GitHub"
+        );
+      }
+      return release;
+    }
+
+    if (!version) {
+      throw new Error("No release version specified");
     }
 
     version = version.startsWith("v") ? version : "v" + version;


### PR DESCRIPTION
When the GitHub API rate-limits or otherwise returns a non-2xx response,
fetchJson was silently parsing the error body JSON. releaseFromJson would
then produce a release with an empty tagName, causing ensureStyluaExists
to always show the "update available" status bar item (since any installed
version != ""). When the user clicked Update, downloadStyLuaVisual("") was
called, which produced the confusing error "No release version matches v."

Fix by throwing in fetchJson on non-OK HTTP responses so the existing
try/catch in ensureStyluaExists handles it gracefully. Also add a tagName
guard in getRelease for defense in depth against other malformed payloads.

Fixes #859