### PR TITLE
VSCode: Fix ENOENT causing file to be emptied when StyLua binary is missing

### DIFF
--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -13,8 +13,8 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ### Fixed
 
-- Fixed file being emptied when StyLua binary is missing (ENOENT). The child process error event was registered under the wrong name, causing spawn failures to be silently swallowed and the document to be replaced with empty content (#1001)
 - Fixed spurious "No release version matches v." error when GitHub API returns a non-OK response (e.g. rate limiting). The extension no longer shows a bogus update prompt in this case
+- Fixed file being emptied when StyLua binary is missing (ENOENT). The child process error event was registered under the wrong name, causing spawn failures to be silently swallowed and the document to be replaced with empty content (#1001)
 
 ## [1.7.1] - 2024-11-17
 

--- a/stylua-vscode/CHANGELOG.md
+++ b/stylua-vscode/CHANGELOG.md
@@ -11,6 +11,10 @@ To view the changelog of the StyLua binary, see [here](https://github.com/Johnny
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed file being emptied when StyLua binary is missing (ENOENT). The child process error event was registered under the wrong name, causing spawn failures to be silently swallowed and the document to be replaced with empty content (#1001)
+
 ## [1.7.1] - 2024-11-17
 
 ### Fixed

--- a/stylua-vscode/src/stylua.ts
+++ b/stylua-vscode/src/stylua.ts
@@ -59,7 +59,9 @@ export function formatCode(
       resolve(output);
     });
     child.stderr.on("data", (data) => reject(data.toString()));
-    child.on("error", (err) => reject(`Failed to start StyLua: ${err.message}`));
+    child.on("error", (err) =>
+      reject(`Failed to start StyLua: ${err.message}`)
+    );
     child.stdin.on("error", () => {
       // Suppress EPIPE when the process failed to spawn and stdin is already closed
     });

--- a/stylua-vscode/src/stylua.ts
+++ b/stylua-vscode/src/stylua.ts
@@ -59,7 +59,7 @@ export function formatCode(
       resolve(output);
     });
     child.stderr.on("data", (data) => reject(data.toString()));
-    child.on("err", (err) => reject("Failed to start StyLua"));
+    child.on("error", (err) => reject(`Failed to start StyLua: ${err.message}`));
 
     // Write our code to stdin
     child.stdin.write(code);

--- a/stylua-vscode/src/test/suite/stylua.test.ts
+++ b/stylua-vscode/src/test/suite/stylua.test.ts
@@ -1,0 +1,42 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { formatCode } from "../../stylua";
+
+suite("formatCode", () => {
+  let outputChannel: vscode.LogOutputChannel;
+
+  setup(() => {
+    outputChannel = vscode.window.createOutputChannel("StyLua Test", {
+      log: true,
+    });
+  });
+
+  teardown(() => {
+    outputChannel.dispose();
+  });
+
+  // Regression test for https://github.com/JohnnyMorganz/StyLua/issues/1001
+  // When the binary is missing (ENOENT), the promise must reject rather than
+  // resolve with an empty string, which would otherwise cause the document to
+  // be replaced with empty content.
+  test("rejects when the binary path does not exist", async () => {
+    let didResolve = false;
+
+    try {
+      await formatCode(
+        outputChannel,
+        "/nonexistent/path/to/stylua",
+        "local x = 1\n"
+      );
+      didResolve = true;
+    } catch (_err) {
+      // Expected: promise should reject, not resolve
+    }
+
+    assert.strictEqual(
+      didResolve,
+      false,
+      "formatCode resolved with empty string instead of rejecting on ENOENT"
+    );
+  });
+});


### PR DESCRIPTION
The child process error event was registered as "err" instead of the
correct "error", so spawn failures (e.g. ENOENT when the binary does
not exist) were never caught. The stdout close handler would then
resolve the Promise with an empty string, causing the extension to
replace the entire document with empty content.

Fixes #1001