### PR TITLE
Fix union/intersection types not hanging when " = " pushes line over column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed npm publishing by bumping Node.js from 16 to 22 in CI workflows to support npm trusted publishing
+- Luau: Fixed union/intersection type definitions not being hung when the type alone fits within the column width but the full line (including ` = `) exceeds it ([#1104](https://github.com/JohnnyMorganz/StyLua/issues/1104))
 
 ## [2.4.1] - 2026-04-06
 

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -1152,14 +1152,15 @@ fn attempt_assigned_type_tactics(
         // If we can hang the type definition, and its over width, then lets try doing so
         if can_hang_type(type_info)
             && (must_hang
-                || shape.test_over_budget(&strip_trailing_trivia(&singleline_type_definition))
+                || (shape + EQUAL_TOKEN_LENGTH)
+                    .test_over_budget(&strip_trailing_trivia(&singleline_type_definition))
                 || spans_multiple_lines(&singleline_type_definition))
         {
             // If we should hug the type, then lets check out the proper definition and see if it fits
             if !must_hang
                 && should_hug_type(type_info)
                 && !is_union_of_tables(type_info)
-                && !shape.test_over_budget(&proper_type_definition)
+                && !(shape + EQUAL_TOKEN_LENGTH).test_over_budget(&proper_type_definition)
             {
                 type_definition = proper_type_definition;
             } else {
@@ -1173,7 +1174,7 @@ fn attempt_assigned_type_tactics(
         } else {
             // Test whether the proper formatting goes over the column width
             // If so, hang at the equals token and reformat
-            if shape.test_over_budget(&proper_type_definition) {
+            if (shape + EQUAL_TOKEN_LENGTH).test_over_budget(&proper_type_definition) {
                 // Hang at the equal token
                 equal_token = hang_equal_token(ctx, &equal_token, shape, true);
 

--- a/tests/inputs-luau/type-hanging-issue-1104.lua
+++ b/tests/inputs-luau/type-hanging-issue-1104.lua
@@ -1,0 +1,5 @@
+type MonsterMembers = { string }
+type MonsterClass = { string }
+export type MonsterObject = typeof(setmetatable({} :: MonsterMembers, {} :: MonsterClass)) & HeroObject & AnotherComponent
+
+export type CameraState = "Basic" | "OctulusBeam" | "OctulusFlight" | "LockCFrame" | "Aim" | "Default" | "Flying" | "Run"

--- a/tests/snapshots/tests__luau@type-hanging-issue-1104.lua.snap
+++ b/tests/snapshots/tests__luau@type-hanging-issue-1104.lua.snap
@@ -1,0 +1,12 @@
+---
+source: tests/tests.rs
+assertion_line: 36
+expression: "format(&contents, LuaVersion::Luau)"
+input_file: tests/inputs-luau/type-hanging-issue-1104.lua
+---
+type MonsterMembers = { string }
+type MonsterClass = { string }
+export type MonsterObject = typeof(setmetatable({} :: MonsterMembers, {} :: MonsterClass)) & HeroObject & AnotherComponent
+
+export type CameraState = "Basic" | "OctulusBeam" | "OctulusFlight" | "LockCFrame" | "Aim" | "Default" | "Flying" | "Run"
+

--- a/tests/snapshots/tests__luau@type-hanging-issue-1104.lua.snap
+++ b/tests/snapshots/tests__luau@type-hanging-issue-1104.lua.snap
@@ -6,7 +6,18 @@ input_file: tests/inputs-luau/type-hanging-issue-1104.lua
 ---
 type MonsterMembers = { string }
 type MonsterClass = { string }
-export type MonsterObject = typeof(setmetatable({} :: MonsterMembers, {} :: MonsterClass)) & HeroObject & AnotherComponent
+export type MonsterObject =
+	typeof(setmetatable({} :: MonsterMembers, {} :: MonsterClass))
+	& HeroObject
+	& AnotherComponent
 
-export type CameraState = "Basic" | "OctulusBeam" | "OctulusFlight" | "LockCFrame" | "Aim" | "Default" | "Flying" | "Run"
+export type CameraState =
+	"Basic"
+	| "OctulusBeam"
+	| "OctulusFlight"
+	| "LockCFrame"
+	| "Aim"
+	| "Default"
+	| "Flying"
+	| "Run"
 


### PR DESCRIPTION
Fixes #1104.

## Problem

`attempt_assigned_type_tactics` called `test_over_budget` with `shape` — the column offset *before* the ` = ` token — instead of `shape + 3` (after ` = `). This made every over-budget check 3 characters too lenient, so a union or intersection type that fit without the equal sign but overflowed with it was left on a single line.

**Example** (`column_width = 100`):

```luau
-- before (102 chars, over the limit)
export type CameraState = "Basic" | "OctulusBeam" | "OctulusFlight" | "LockCFrame" | "Aim" | "Default"

-- after
export type CameraState =
    "Basic"
    | "OctulusBeam"
    | "OctulusFlight"
    | "LockCFrame"
    | "Aim"
    | "Default"
```

## Fix

Three `shape.test_over_budget(…)` calls in `attempt_assigned_type_tactics` are changed to `(shape + EQUAL_TOKEN_LENGTH).test_over_budget(…)`:

1. The main over-budget check that decides whether to hang a union/intersection type.
2. The hug-fit check that decides if the type can stay inline after hanging was triggered.
3. The fallback over-budget check for non-hangable types.
