### PR TITLE
Mention conform.nvim as a Neovim formatter plugin that supports stylua

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ aftman add johnnymorganz/stylua@2.5.2
 Note that these integrations require the StyLua binary to already be installed and available on your system.
 
 - Sublime: [Sublime Text Package](https://github.com/aerobounce/Sublime-Pretty-Lua)
-- Neovim: [stylua-nvim](https://github.com/ckipp01/stylua-nvim) / [stylua.nvim](https://github.com/wesleimp/stylua.nvim)
+- Neovim: [stylua-nvim](https://github.com/ckipp01/stylua-nvim) / [stylua.nvim](https://github.com/wesleimp/stylua.nvim) / [conform.nvim](https://github.com/stevearc/conform.nvim)
 - Zed: [Zed Lua StyLua formatter settings](https://zed.dev/docs/languages/lua#stylua)
 
 ## Usage


### PR DESCRIPTION
I've been using [conform.nvim](https://github.com/stevearc/conform.nvim) with stylua for a while and it works nicely. I think it's worth mentioning in addition to thte dedicated wrappers.
