### PR TITLE
format luau @[...] attribute params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support formatting Luau attributes with bracketed parameters (`@[name]`, `@[name(args...)]`, `@[name literal]`, and grouped `@[a, b(x), c]`), following full_moon's parser support for the same
+
 ## [2.5.2] - 2026-05-16
 
 ### Fixed

--- a/src/formatters/luau.rs
+++ b/src/formatters/luau.rs
@@ -11,7 +11,10 @@ use crate::{
             format_contained_punctuated_multiline, format_contained_span, format_punctuated,
             format_symbol, format_token_reference,
         },
-        table::{create_table_braces, format_multiline_table, format_singleline_table, TableType},
+        table::{
+            create_table_braces, format_multiline_table, format_singleline_table,
+            format_table_constructor, TableType,
+        },
         trivia::{
             strip_leading_trivia, strip_trailing_trivia, strip_trivia, FormatTriviaType,
             UpdateLeadingTrivia, UpdateTrailingTrivia, UpdateTrivia,
@@ -28,6 +31,7 @@ use full_moon::ast::{
     luau::{
         ExportedTypeDeclaration, ExportedTypeFunction, GenericDeclaration,
         GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo, LuauAttribute,
+        LuauAttributeArgument, LuauAttributeItem, LuauAttributeKind, LuauAttributeParams,
         TypeArgument, TypeAssertion, TypeDeclaration, TypeField, TypeFieldKey, TypeFunction,
         TypeInfo, TypeInstantiation, TypeIntersection, TypeSpecifier, TypeUnion,
     },
@@ -1607,7 +1611,101 @@ pub fn format_luau_attribute(
     shape: Shape,
 ) -> LuauAttribute {
     let at_sign = fmt_symbol!(ctx, attribute.at_sign(), "@", shape);
-    let name = format_token_reference(ctx, attribute.name(), shape);
+    let kind = format_luau_attribute_kind(ctx, attribute.kind(), shape);
 
-    attribute.clone().with_at_sign(at_sign).with_name(name)
+    attribute.clone().with_at_sign(at_sign).with_kind(kind)
+}
+
+fn format_luau_attribute_kind(
+    ctx: &Context,
+    kind: &LuauAttributeKind,
+    shape: Shape,
+) -> LuauAttributeKind {
+    match kind {
+        LuauAttributeKind::Name(name) => {
+            LuauAttributeKind::Name(format_token_reference(ctx, name, shape))
+        }
+        LuauAttributeKind::Bracketed {
+            brackets,
+            attributes,
+        } => {
+            let brackets = format_contained_span(ctx, brackets, shape);
+            let attributes =
+                format_punctuated(ctx, attributes, shape, format_luau_attribute_item);
+
+            LuauAttributeKind::Bracketed {
+                brackets,
+                attributes,
+            }
+        }
+    }
+}
+
+fn format_luau_attribute_item(
+    ctx: &Context,
+    item: &LuauAttributeItem,
+    shape: Shape,
+) -> LuauAttributeItem {
+    let name = format_token_reference(ctx, item.name(), shape);
+    let params = item.params().map(|params| {
+        let params = format_luau_attribute_params(ctx, params, shape);
+        // A bare literal (no parens) needs a space to separate it from the name,
+        // e.g. `deprecated "reason"`, not `deprecated"reason"`
+        match params {
+            LuauAttributeParams::Literal(argument) => {
+                LuauAttributeParams::Literal(argument.update_leading_trivia(
+                    FormatTriviaType::Append(vec![Token::new(TokenType::spaces(1))]),
+                ))
+            }
+            parens => parens,
+        }
+    });
+
+    item.clone().with_name(name).with_params(params)
+}
+
+fn format_luau_attribute_params(
+    ctx: &Context,
+    params: &LuauAttributeParams,
+    shape: Shape,
+) -> LuauAttributeParams {
+    match params {
+        LuauAttributeParams::Parens { parens, arguments } => {
+            let parens = format_contained_span(ctx, parens, shape);
+            let arguments =
+                format_punctuated(ctx, arguments, shape, format_luau_attribute_argument);
+
+            LuauAttributeParams::Parens { parens, arguments }
+        }
+        LuauAttributeParams::Literal(argument) => {
+            LuauAttributeParams::Literal(format_luau_attribute_argument(ctx, argument, shape))
+        }
+    }
+}
+
+fn format_luau_attribute_argument(
+    ctx: &Context,
+    argument: &LuauAttributeArgument,
+    shape: Shape,
+) -> LuauAttributeArgument {
+    match argument {
+        LuauAttributeArgument::Nil(token) => {
+            LuauAttributeArgument::Nil(fmt_symbol!(ctx, token, "nil", shape))
+        }
+        LuauAttributeArgument::True(token) => {
+            LuauAttributeArgument::True(fmt_symbol!(ctx, token, "true", shape))
+        }
+        LuauAttributeArgument::False(token) => {
+            LuauAttributeArgument::False(fmt_symbol!(ctx, token, "false", shape))
+        }
+        LuauAttributeArgument::Number(token) => {
+            LuauAttributeArgument::Number(format_token_reference(ctx, token, shape))
+        }
+        LuauAttributeArgument::Str(token) => {
+            LuauAttributeArgument::Str(format_token_reference(ctx, token, shape))
+        }
+        LuauAttributeArgument::Table(table) => {
+            LuauAttributeArgument::Table(format_table_constructor(ctx, table, shape))
+        }
+    }
 }

--- a/src/formatters/trivia.rs
+++ b/src/formatters/trivia.rs
@@ -4,9 +4,9 @@ use full_moon::ast::lua54::Attribute;
 use full_moon::ast::luau::{
     ConstAssignment, ElseIfExpression, GenericDeclaration, GenericDeclarationParameter,
     GenericParameterInfo, IfExpression, IndexedTypeInfo, InterpolatedString,
-    InterpolatedStringSegment, LuauAttribute, TypeArgument, TypeAssertion, TypeDeclaration,
-    TypeField, TypeFieldKey, TypeFunction, TypeInfo, TypeInstantiation, TypeIntersection,
-    TypeSpecifier, TypeUnion,
+    InterpolatedStringSegment, LuauAttribute, LuauAttributeArgument, LuauAttributeKind,
+    TypeArgument, TypeAssertion, TypeDeclaration, TypeField, TypeFieldKey, TypeFunction, TypeInfo,
+    TypeInstantiation, TypeIntersection, TypeSpecifier, TypeUnion,
 };
 use full_moon::ast::{
     punctuated::Punctuated, span::ContainedSpan, AnonymousFunction, BinOp, Call, Expression,
@@ -770,6 +770,30 @@ define_update_trivia!(TableConstructor, |this, leading, trailing| {
         .with_braces(this.braces().update_trivia(leading, trailing))
 });
 
+#[cfg(feature = "luau")]
+define_update_trivia!(LuauAttributeArgument, |this, leading, trailing| {
+    match this {
+        LuauAttributeArgument::Nil(token) => {
+            LuauAttributeArgument::Nil(token.update_trivia(leading, trailing))
+        }
+        LuauAttributeArgument::True(token) => {
+            LuauAttributeArgument::True(token.update_trivia(leading, trailing))
+        }
+        LuauAttributeArgument::False(token) => {
+            LuauAttributeArgument::False(token.update_trivia(leading, trailing))
+        }
+        LuauAttributeArgument::Number(token) => {
+            LuauAttributeArgument::Number(token.update_trivia(leading, trailing))
+        }
+        LuauAttributeArgument::Str(token) => {
+            LuauAttributeArgument::Str(token.update_trivia(leading, trailing))
+        }
+        LuauAttributeArgument::Table(table) => {
+            LuauAttributeArgument::Table(table.update_trivia(leading, trailing))
+        }
+    }
+});
+
 define_update_leading_trivia!(UnOp, |this, leading| {
     match this {
         UnOp::Hash(token_reference) => UnOp::Hash(token_reference.update_leading_trivia(leading)),
@@ -1168,7 +1192,20 @@ define_update_leading_trivia!(InterpolatedStringSegment, |this, leading| {
 
 #[cfg(feature = "luau")]
 define_update_trivia!(LuauAttribute, |this, leading, trailing| {
+    let kind = match this.kind().to_owned() {
+        LuauAttributeKind::Name(name) => {
+            LuauAttributeKind::Name(name.update_trailing_trivia(trailing))
+        }
+        LuauAttributeKind::Bracketed {
+            brackets,
+            attributes,
+        } => LuauAttributeKind::Bracketed {
+            brackets: brackets.update_trailing_trivia(trailing),
+            attributes,
+        },
+    };
+
     this.clone()
         .with_at_sign(this.at_sign().update_leading_trivia(leading))
-        .with_name(this.name().update_trailing_trivia(trailing))
+        .with_kind(kind)
 });


### PR DESCRIPTION
Depends on Kampfkarren/full-moon#362 - won't build against crates.io until that's merged and published, since it uses LuauAttributeKind/Item/Params/Argument which don't exist upstream yet.

Formats the new bracketed attribute shape (`@[name(args)]`, grouped `@[a, b(x)]`, etc). Also fixes bare literal params missing a space - `deprecated"reason"` was printing with no gap before the string, now `deprecated "reason"`.