### PR TITLE
Keep necessary parentheses on the LHS of a hung binary operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed necessary parentheses being removed from the LHS of a binary operation when the expression is hung over multiple lines. This affected `(-X) ^ Y` (changing the meaning of the expression) and, in Luau, `(expr :: assertion) < Y` (causing a syntax error)
+
 ## [2.5.2] - 2026-05-16
 
 ### Fixed

--- a/src/formatters/expression.rs
+++ b/src/formatters/expression.rs
@@ -124,6 +124,15 @@ pub fn format_binop(ctx: &Context, binop: &BinOp, shape: Shape) -> BinOp {
     })
 }
 
+/// The context to use when formatting the expression on the LHS of the given binop
+fn binary_lhs_context(binop: &BinOp) -> ExpressionContext {
+    if let BinOp::Caret(_) = binop {
+        ExpressionContext::BinaryLHSExponent
+    } else {
+        ExpressionContext::BinaryLHS
+    }
+}
+
 /// Check to determine whether expression parentheses are required, depending on the provided
 /// internal expression contained within the parentheses
 fn check_excess_parentheses(internal_expression: &Expression, context: ExpressionContext) -> bool {
@@ -285,12 +294,7 @@ fn format_expression_internal(
             }
         }
         Expression::BinaryOperator { lhs, binop, rhs } => {
-            let context = if let BinOp::Caret(_) = binop {
-                ExpressionContext::BinaryLHSExponent
-            } else {
-                ExpressionContext::BinaryLHS
-            };
-            let lhs = format_expression_internal(ctx, lhs, context, shape);
+            let lhs = format_expression_internal(ctx, lhs, binary_lhs_context(binop), shape);
             let binop = format_binop(ctx, binop, shape);
             let shape = shape.take_last_line(&lhs) + binop.to_string().len();
             Expression::BinaryOperator {
@@ -1184,6 +1188,10 @@ fn hang_binop_expression(
                 new_binop = hang_binop(ctx, binop.to_owned(), shape, &rhs);
             }
 
+            // The context of the lhs is determined by the binop it is attached to, not by the
+            // context that this expression was hung in
+            let lhs_context = binary_lhs_context(&binop);
+
             let (lhs, rhs) = match should_hang {
                 true => {
                     let lhs_shape = shape;
@@ -1202,7 +1210,7 @@ fn hang_binop_expression(
                                 },
                                 lhs_shape,
                                 lhs_range,
-                                expression_context,
+                                lhs_context,
                             ),
                             if contains_comments(&*rhs) {
                                 hang_binop_expression(
@@ -1230,15 +1238,10 @@ fn hang_binop_expression(
                                     binop.clone(),
                                     shape,
                                     lhs_range,
-                                    expression_context,
+                                    lhs_context,
                                 )
                             } else {
-                                let context = if let BinOp::Caret(_) = binop {
-                                    ExpressionContext::BinaryLHSExponent
-                                } else {
-                                    ExpressionContext::BinaryLHS
-                                };
-                                format_expression_internal(ctx, &lhs, context, lhs_shape)
+                                format_expression_internal(ctx, &lhs, lhs_context, lhs_shape)
                             },
                             hang_binop_expression(
                                 ctx,
@@ -1265,15 +1268,10 @@ fn hang_binop_expression(
                             binop.to_owned(),
                             shape,
                             lhs_range,
-                            expression_context,
+                            lhs_context,
                         )
                     } else {
-                        let context = if let BinOp::Caret(_) = binop {
-                            ExpressionContext::BinaryLHSExponent
-                        } else {
-                            ExpressionContext::BinaryLHS
-                        };
-                        format_expression_internal(ctx, &lhs, context, shape)
+                        format_expression_internal(ctx, &lhs, lhs_context, shape)
                     };
 
                     let rhs = if contains_comments(&*rhs) {
@@ -1457,7 +1455,7 @@ fn format_hanging_expression_(
                 binop.to_owned(),
                 shape,
                 lhs_range,
-                ExpressionContext::UnaryOrBinary,
+                binary_lhs_context(binop),
             );
 
             let current_shape = shape.take_last_line(&lhs) + 1; // 1 = space before binop

--- a/tests/inputs-luau/excess-parentheses-type-assertion.lua
+++ b/tests/inputs-luau/excess-parentheses-type-assertion.lua
@@ -1,3 +1,9 @@
 local x = if (foo :: number) < bar
 	then very + very + very + long + line + right + here + hopefully
 	else lets + ensure + stylua + writes + this + out + using + multiple + lines
+
+local isNegative = someExtremelyLongVariableNameHere ~= nil and (someExtremelyLongVariableNameHereAsWellOkayThenFine :: number) < someExtremelyLongThresholdVariableNameHereTooRight
+
+if someExtremelyLongVariableNameHere ~= nil and (someExtremelyLongVariableNameHereAsWellOkayThenFine :: number) < someExtremelyLongThresholdVariableNameHereTooRight then
+	print(someExtremelyLongVariableNameHere)
+end

--- a/tests/inputs/excess-parentheses-dont-remove.lua
+++ b/tests/inputs/excess-parentheses-dont-remove.lua
@@ -6,3 +6,7 @@ local _ = (not true) and false
 -- https://github.com/JohnnyMorganz/StyLua/issues/623
 -- Changes meaning
 local y = (-X) ^ Y
+
+-- The same holds when the expression is hung over multiple lines
+local someVeryLongVariableNameHere = (-someExtremelyLongOperandNameOnTheLeft) ^ someOtherExtremelyLongOperandNameOnTheRight
+local anotherVeryLongVariableNameHere = (not someExtremelyLongConditionNameOnTheLeft) and someOtherExtremelyLongConditionNameOnTheRight

--- a/tests/snapshots/tests__luau@excess-parentheses-type-assertion.lua.snap
+++ b/tests/snapshots/tests__luau@excess-parentheses-type-assertion.lua.snap
@@ -7,3 +7,15 @@ snapshot_kind: text
 local x = if (foo :: number) < bar
 	then very + very + very + long + line + right + here + hopefully
 	else lets + ensure + stylua + writes + this + out + using + multiple + lines
+
+local isNegative = someExtremelyLongVariableNameHere ~= nil
+	and (someExtremelyLongVariableNameHereAsWellOkayThenFine :: number)
+		< someExtremelyLongThresholdVariableNameHereTooRight
+
+if
+	someExtremelyLongVariableNameHere ~= nil
+	and (someExtremelyLongVariableNameHereAsWellOkayThenFine :: number)
+		< someExtremelyLongThresholdVariableNameHereTooRight
+then
+	print(someExtremelyLongVariableNameHere)
+end

--- a/tests/snapshots/tests__standard@excess-parentheses-dont-remove.lua.snap
+++ b/tests/snapshots/tests__standard@excess-parentheses-dont-remove.lua.snap
@@ -11,3 +11,9 @@ local _ = (not true) and false
 -- Changes meaning
 local y = (-X) ^ Y
 
+-- The same holds when the expression is hung over multiple lines
+local someVeryLongVariableNameHere = (-someExtremelyLongOperandNameOnTheLeft)
+	^ someOtherExtremelyLongOperandNameOnTheRight
+local anotherVeryLongVariableNameHere = (not someExtremelyLongConditionNameOnTheLeft)
+	and someOtherExtremelyLongConditionNameOnTheRight
+

--- a/tests/snapshots/tests__standard@multiline-expression-comments-1.lua.snap
+++ b/tests/snapshots/tests__standard@multiline-expression-comments-1.lua.snap
@@ -17,7 +17,7 @@ end
 if
 	name
 		and (
-			not strictFiltering
+			(not strictFiltering)
 			and (
 				tokenTable[subgroup]
 				or tokenTable[className]


### PR DESCRIPTION
Two parentheses bugs that were fixed once already come back as soon as the expression is long enough to be hung over multiple lines:

```lua
-- input
local someVeryLongVariableNameHere = (-someExtremelyLongOperandNameOnTheLeft) ^ someOtherExtremelyLongOperandNameOnTheRight

-- 2.5.2 output: this is now -(a ^ b)
local someVeryLongVariableNameHere = -someExtremelyLongOperandNameOnTheLeft
	^ someOtherExtremelyLongOperandNameOnTheRight
```

and, with `syntax = "Luau"`:

```lua
-- input
local isNegative = someExtremelyLongVariableNameHere ~= nil and (someExtremelyLongVariableNameHereAsWellOkayThenFine :: number) < someExtremelyLongThresholdVariableNameHereTooRight

-- 2.5.2 output: does not parse, `number < ...` is read as a generic type instantiation
local isNegative = someExtremelyLongVariableNameHere ~= nil
	and someExtremelyLongVariableNameHereAsWellOkayThenFine :: number
		< someExtremelyLongThresholdVariableNameHereTooRight
```

These are the same cases as #623 and #940. `check_excess_parentheses` handles both correctly, but only if it is told the expression is the LHS of a binop — and the hanging paths never do. `hang_binop_expression` forwards whatever context the expression as a whole was hung in, and `format_hanging_expression_` passes `UnaryOrBinary`, so the `BinaryLHS`/`BinaryLHSExponent` guards never fire once hanging kicks in.

I pulled the context choice into a small helper and used it at each LHS call site. The direction is one-way — these contexts only ever keep more parentheses, never remove them — so the blast radius is small: across the whole test corpus one existing snapshot changed, `multiline-expression-comments-1`, where `(not strictFiltering)` now keeps its parentheses like the non-hung `(not true) and false` case above it already does.

Found this while checking that formatting is a fixed point (`format(format(x)) == format(x)`) over the test inputs with various configs; the Luau one showed up as StyLua failing to re-read its own output.

Tested with `cargo test` on each feature in the CI matrix, plus clippy and rustfmt.