### PR TITLE
Add glua support

### DIFF
--- a/stylua-vscode/package.json
+++ b/stylua-vscode/package.json
@@ -28,7 +28,8 @@
   ],
   "activationEvents": [
     "onLanguage:lua",
-    "onLanguage:luau"
+    "onLanguage:luau",
+    "onLanguage:glua"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/stylua-vscode/src/extension.ts
+++ b/stylua-vscode/src/extension.ts
@@ -5,7 +5,7 @@ import { GitHub, GitHubRelease } from "./github";
 import { ResolveMode, StyluaDownloader, StyluaInfo } from "./download";
 import { getDesiredVersion } from "./util";
 
-const documentSelector = ["lua", "luau"];
+const documentSelector = ["lua", "luau", "glua"];
 
 /**
  * Convert a Position within a Document to a byte offset.


### PR DESCRIPTION
Adds `gmod` dialect support to improve compatibility with Garry's Mod extensions and setups.

Most Garry's Mod VS Code extensions requires associate `.lua` files with the `glua` language mode. Because of this, StyLua doesn't format these files out of the box unless you manually override the file association back to `lua`. Adding `gmod` as a recognized dialect fixes this workflow friction completely.

> **Note on syntax:** This patch only adds compatibility for the standard Lua syntax used in GMod. Non-standard C-style operators (`//`, `&&`, `||`, `!`) are intentionally excluded, as standard syntax is the widely accepted best practice in the GLua community anyway.